### PR TITLE
fix: resolve 6 pre-existing test failures

### DIFF
--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizScope.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizScope.kt
@@ -110,9 +110,14 @@ class VizScope(
             CoroutineScope(currentCoroutineContext())
         } ?: this
 
+        // Merge VizScope's own context (which may contain a specific dispatcher)
+        // so that e.g. ioScope.vizLaunch() uses the IO dispatcher even when nested
+        val scopeDispatcher = this.coroutineContext[ContinuationInterceptor]
 
         // Launch with the viz element in context
-        val job = targetScope.launch(context + vizElement) {
+        // scopeDispatcher is applied first, then overridden by explicit context if provided
+        val mergedContext = (scopeDispatcher ?: EmptyCoroutineContext) + context + vizElement
+        val job = targetScope.launch(mergedContext) {
             val currentJob = coroutineContext[Job] ?: throw IllegalArgumentException("Missing job")
             // ✨ NEW: Register job for tracking
             session.snapshot.registerJob(currentJob, coroutineId)
@@ -243,22 +248,24 @@ class VizScope(
             label = label
         )
 
-        // ✨ NEW: Register job
-        val currentJob = coroutineContext[Job]!!
-        session.snapshot.registerJob(currentJob, coroutineId)
-        session.jobMonitor.track(currentJob, jobId, coroutineId)
-
-
         // Check if we're in a nested context (inside another vizLaunch/vizAsync)
         // If so, use current scope; otherwise use VizScope
         val targetScope = currentCoroutineContext()[VizCoroutineElement]?.let {
             CoroutineScope(currentCoroutineContext())
         } ?: this
 
+        // Merge VizScope's own context (which may contain a specific dispatcher)
+        val scopeDispatcher = this.coroutineContext[ContinuationInterceptor]
+        val mergedContext = (scopeDispatcher ?: EmptyCoroutineContext) + context + vizElement
+
         // Use async{} instead of launch{}
-        val deferred = targetScope.async(context + vizElement) {
+        val deferred = targetScope.async(mergedContext) {
 
             val currentJob = coroutineContext[Job] ?: throw IllegalArgumentException("Missing job")
+
+            // ✨ Register job for tracking (must happen inside async where Job exists)
+            session.snapshot.registerJob(currentJob, coroutineId)
+            session.jobMonitor.track(currentJob, jobId, coroutineId)
 
             // Emit lifecycle events (similar to vizLaunch)
             session.send(ctx.coroutineCreated())

--- a/backend/src/test/kotlin/VizLaunchTest.kt
+++ b/backend/src/test/kotlin/VizLaunchTest.kt
@@ -67,8 +67,8 @@ class VizLaunchTest {
         assertEquals(completedState, childOne?.state)
         assertEquals(completedState, childTwo?.state)
         assertEquals(completedState, childThree?.state)
-        val eventLogExpected = listOf(parentLabel,childTwoLabel,childOneLabel,childThreeLabel)
-        assertEquals(eventLog, eventLogExpected)
+        val eventLogExpected = listOf(childTwoLabel,childOneLabel,childThreeLabel,parentLabel)
+        assertEquals(eventLogExpected, eventLog)
 
     }
 

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/sync/SyncPrimitivesTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/sync/SyncPrimitivesTest.kt
@@ -109,7 +109,7 @@ class SyncPrimitivesTest {
 
     @Test
     @DisplayName("VizMutex - Queue position tracked correctly")
-    fun `mutex queue tracking`() = runTest {
+    fun `mutex queue tracking`() = runBlocking {
         val mutex = VizMutex(session, "queue-mutex")
         val scope = VizScope(session)
 
@@ -129,7 +129,7 @@ class SyncPrimitivesTest {
             }
         }
 
-        delay(10)
+        delay(50) // Give waiter-1 time to reach lock() and emit MutexLockRequested
 
         // Verify queue position in request event
         val requests = session.store.all().filterIsInstance<MutexLockRequested>()
@@ -171,23 +171,29 @@ class SyncPrimitivesTest {
 
     @Test
     @DisplayName("VizSemaphore - Never exceeds permit limit")
-    fun `semaphore permit bounds`() = runTest {
+    fun `semaphore permit bounds`() = runBlocking {
         val semaphore = VizSemaphore(session, permits = 2, label = "bounded-semaphore")
         val scope = VizScope(session)
+        val concurrentCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val maxConcurrent = java.util.concurrent.atomic.AtomicInteger(0)
 
         // Launch multiple coroutines
         val jobs = (1..5).map { i ->
             scope.vizLaunch("worker-$i") {
                 semaphore.withPermit {
-                    // At most 2 should be active simultaneously
-                    assertTrue(semaphore.getActiveHolderCount() <= 2)
+                    // Track actual concurrency using an atomic counter
+                    val current = concurrentCount.incrementAndGet()
+                    maxConcurrent.updateAndGet { max -> maxOf(max, current) }
                     vizDelay(50)
+                    concurrentCount.decrementAndGet()
                 }
             }
         }
 
         jobs.forEach { it.join() }
 
+        // Verify at most 2 were active simultaneously (delegate semaphore enforces this)
+        assertTrue(maxConcurrent.get() <= 2, "Max concurrent was ${maxConcurrent.get()}, expected <= 2")
         // Verify all permits returned
         assertEquals(2, semaphore.availablePermits)
     }

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/VizDispatchersIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/VizDispatchersIntegrationTest.kt
@@ -4,7 +4,7 @@ import com.jh.proj.coroutineviz.events.dispatcher.DispatcherSelected
 import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
 import com.jh.proj.coroutineviz.session.VizSession
 import kotlinx.coroutines.*
-import kotlinx.coroutines.test.runTest
+
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
@@ -15,7 +15,7 @@ class VizDispatchersIntegrationTest {
 
     @Test
     @DisplayName("Integration: Complete scenario with mixed dispatchers")
-    fun testCompleteScenarioWithMixedDispatchers() = runTest {
+    fun testCompleteScenarioWithMixedDispatchers() = runBlocking {
         // Simulate a real-world scenario
         val session = VizSession("integration-mixed-dispatchers")
         val dispatchers = VizDispatchers(session, scopeId = "api-handlers")
@@ -241,8 +241,9 @@ class VizDispatchersIntegrationTest {
         val session = VizSession("integration-exception-handling")
         val dispatchers = VizDispatchers(session, scopeId = "exception")
         
-        // Use SupervisorJob to allow observation without test failing
-        val scope = VizScope(session, context = dispatchers.default + SupervisorJob())
+        // Use SupervisorJob + CoroutineExceptionHandler to allow observation without leaking exceptions
+        val exceptionHandler = CoroutineExceptionHandler { _, _ -> /* expected simulated failure */ }
+        val scope = VizScope(session, context = dispatchers.default + SupervisorJob() + exceptionHandler)
         
         val job = scope.vizLaunch(label = "parent") {
             // Child 1: Succeeds on Default


### PR DESCRIPTION
## Summary
- Fix 6 pre-existing test failures across coroutine visualization tests
- Fix event order assertion in VizLaunchTest (children complete before parent)
- Switch timing-sensitive tests from `runTest` to `runBlocking` for proper real-dispatcher behavior
- Fix NPE in `vizAsync` by moving job registration inside the async block
- Add `CoroutineExceptionHandler` to exception-handling integration test to prevent leaking uncaught exceptions
- Fix VizScope to properly merge its dispatcher context in nested `vizLaunch`/`vizAsync` calls

## Test plan
- [x] `./gradlew test` passes all 68 tests with 0 failures