### PR TITLE
feat: add channel visualization wrapper

### DIFF
--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelBufferStateChanged.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelBufferStateChanged.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when the buffer state of a Channel changes (after send or receive).
+ *
+ * @property channelId ID of the Channel
+ * @property currentSize Current number of elements in the buffer
+ * @property capacity Maximum capacity of the channel buffer
+ */
+@Serializable
+@SerialName("ChannelBufferStateChanged")
+data class ChannelBufferStateChanged(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val currentSize: Int,
+    val capacity: Int
+) : VizEvent {
+    override val kind: String get() = "ChannelBufferStateChanged"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelClosed.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelClosed.kt
@@ -1,0 +1,23 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a Channel is closed.
+ *
+ * @property channelId ID of the closed Channel
+ * @property cause Description of the close cause, if any
+ */
+@Serializable
+@SerialName("ChannelClosed")
+data class ChannelClosed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val cause: String? = null
+) : VizEvent {
+    override val kind: String get() = "ChannelClosed"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelCreated.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelCreated.kt
@@ -1,0 +1,27 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when an instrumented Channel is created.
+ *
+ * @property channelId Unique identifier for this Channel instance
+ * @property name Optional human-readable name for the channel
+ * @property capacity The buffer capacity of the channel
+ * @property channelType Type of channel: RENDEZVOUS, BUFFERED, CONFLATED, UNLIMITED
+ */
+@Serializable
+@SerialName("ChannelCreated")
+data class ChannelCreated(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val name: String? = null,
+    val capacity: Int,
+    val channelType: String  // RENDEZVOUS, BUFFERED, CONFLATED, UNLIMITED
+) : VizEvent {
+    override val kind: String get() = "ChannelCreated"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveCompleted.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveCompleted.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a receive operation from a Channel completes with a value.
+ *
+ * @property channelId ID of the Channel
+ * @property coroutineId ID of the receiving coroutine
+ * @property valueDescription Preview of the received value
+ */
+@Serializable
+@SerialName("ChannelReceiveCompleted")
+data class ChannelReceiveCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+    val valueDescription: String
+) : VizEvent {
+    override val kind: String get() = "ChannelReceiveCompleted"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveStarted.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveStarted.kt
@@ -1,0 +1,23 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine begins receiving from a Channel.
+ *
+ * @property channelId ID of the Channel being received from
+ * @property coroutineId ID of the receiving coroutine
+ */
+@Serializable
+@SerialName("ChannelReceiveStarted")
+data class ChannelReceiveStarted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String
+) : VizEvent {
+    override val kind: String get() = "ChannelReceiveStarted"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveSuspended.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveSuspended.kt
@@ -1,0 +1,23 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a receive operation suspends because the channel is empty.
+ *
+ * @property channelId ID of the Channel
+ * @property coroutineId ID of the suspended receiving coroutine
+ */
+@Serializable
+@SerialName("ChannelReceiveSuspended")
+data class ChannelReceiveSuspended(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String
+) : VizEvent {
+    override val kind: String get() = "ChannelReceiveSuspended"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendCompleted.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendCompleted.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a send operation to a Channel completes successfully.
+ *
+ * @property channelId ID of the Channel
+ * @property coroutineId ID of the sending coroutine
+ * @property valueDescription Preview of the value that was sent
+ */
+@Serializable
+@SerialName("ChannelSendCompleted")
+data class ChannelSendCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+    val valueDescription: String
+) : VizEvent {
+    override val kind: String get() = "ChannelSendCompleted"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendStarted.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendStarted.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine begins sending a value to a Channel.
+ *
+ * @property channelId ID of the Channel being sent to
+ * @property coroutineId ID of the sending coroutine
+ * @property valueDescription Preview of the value being sent
+ */
+@Serializable
+@SerialName("ChannelSendStarted")
+data class ChannelSendStarted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+    val valueDescription: String
+) : VizEvent {
+    override val kind: String get() = "ChannelSendStarted"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendSuspended.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendSuspended.kt
@@ -1,0 +1,27 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a send operation suspends because the channel buffer is full.
+ *
+ * @property channelId ID of the Channel
+ * @property coroutineId ID of the suspended sending coroutine
+ * @property bufferSize Current number of elements in the buffer
+ * @property capacity Maximum capacity of the channel buffer
+ */
+@Serializable
+@SerialName("ChannelSendSuspended")
+data class ChannelSendSuspended(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+    val bufferSize: Int,
+    val capacity: Int
+) : VizEvent {
+    override val kind: String get() = "ChannelSendSuspended"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/routes/ScenarioRunnerRoutes.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/routes/ScenarioRunnerRoutes.kt
@@ -127,6 +127,64 @@ fun Route.registerScenarioRunnerRoutes() {
     }
 
     // ============================================================================
+    // CHANNEL SCENARIOS - Channel communication patterns
+    // ============================================================================
+
+    post("/api/scenarios/channel-rendezvous") {
+        val sessionId = call.request.queryParameters["sessionId"]
+        val session = getOrCreateSession(sessionId)
+
+        logger.info("Running channel rendezvous scenario in session: ${session.sessionId}")
+
+        call.runScenarioWithResponse(session) {
+            ScenarioRunner.runChannelRendezvous(session)
+            ScenarioCompletionResponse(
+                success = true,
+                sessionId = session.sessionId,
+                message = "Channel rendezvous scenario completed",
+                coroutineCount = session.snapshot.coroutines.size,
+                eventCount = session.store.all().size
+            )
+        }
+    }
+
+    post("/api/scenarios/channel-buffered") {
+        val sessionId = call.request.queryParameters["sessionId"]
+        val session = getOrCreateSession(sessionId)
+
+        logger.info("Running channel buffered scenario in session: ${session.sessionId}")
+
+        call.runScenarioWithResponse(session) {
+            ScenarioRunner.runChannelBuffered(session)
+            ScenarioCompletionResponse(
+                success = true,
+                sessionId = session.sessionId,
+                message = "Channel buffered scenario completed",
+                coroutineCount = session.snapshot.coroutines.size,
+                eventCount = session.store.all().size
+            )
+        }
+    }
+
+    post("/api/scenarios/channel-fan-out") {
+        val sessionId = call.request.queryParameters["sessionId"]
+        val session = getOrCreateSession(sessionId)
+
+        logger.info("Running channel fan-out scenario in session: ${session.sessionId}")
+
+        call.runScenarioWithResponse(session) {
+            ScenarioRunner.runChannelFanOut(session)
+            ScenarioCompletionResponse(
+                success = true,
+                sessionId = session.sessionId,
+                message = "Channel fan-out scenario completed",
+                coroutineCount = session.snapshot.coroutines.size,
+                eventCount = session.store.all().size
+            )
+        }
+    }
+
+    // ============================================================================
     // REALISTIC SCENARIOS - Real-world service simulations
     // ============================================================================
 
@@ -272,6 +330,31 @@ fun Route.registerScenarioRunnerRoutes() {
                         "endpoint" to "/api/scenarios/report-generation",
                         "category" to "realistic",
                         "duration" to "~25-35 seconds"
+                    ),
+                    // ========== CHANNEL SCENARIOS ==========
+                    mapOf(
+                        "id" to "channel-rendezvous",
+                        "name" to "Channel Rendezvous",
+                        "description" to "Zero-buffer channel where sender and receiver must meet for each transfer. Demonstrates suspension on both sides.",
+                        "endpoint" to "/api/scenarios/channel-rendezvous",
+                        "category" to "channel",
+                        "duration" to "~2-3 seconds"
+                    ),
+                    mapOf(
+                        "id" to "channel-buffered",
+                        "name" to "Channel Buffered",
+                        "description" to "Buffered channel (capacity 3) showing buffer fill/drain. Producer sends 5 items, consumer starts after delay.",
+                        "endpoint" to "/api/scenarios/channel-buffered",
+                        "category" to "channel",
+                        "duration" to "~2-3 seconds"
+                    ),
+                    mapOf(
+                        "id" to "channel-fan-out",
+                        "name" to "Channel Fan-Out",
+                        "description" to "Fan-out pattern: one producer dispatches 10 tasks, 3 workers compete to receive and process them.",
+                        "endpoint" to "/api/scenarios/channel-fan-out",
+                        "category" to "channel",
+                        "duration" to "~3-5 seconds"
                     ),
                     // ========== BASIC SCENARIOS ==========
                     mapOf(

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/scenarios/ScenarioRunner.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/scenarios/ScenarioRunner.kt
@@ -3,6 +3,7 @@ package com.jh.proj.coroutineviz.scenarios
 import com.jh.proj.coroutineviz.session.VizSession
 import com.jh.proj.coroutineviz.wrappers.VizScope
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import org.slf4j.LoggerFactory
 
 /**
@@ -230,6 +231,155 @@ object ScenarioRunner {
         val job = viz.executeCoroutineConfig(config.root)
 
         logger.info("Custom scenario '${config.name}' launched, waiting for completion...")
+        job
+    }
+
+    // ============================================================================
+    // CHANNEL SCENARIOS - Demonstrating Channel communication patterns
+    // ============================================================================
+
+    /**
+     * Rendezvous Channel Scenario
+     *
+     * Demonstrates a zero-buffer channel where sender and receiver must
+     * meet (rendezvous) for each element transfer. The sender suspends
+     * until a receiver is ready, and vice versa.
+     */
+    suspend fun runChannelRendezvous(session: VizSession): Job = coroutineScope {
+        logger.info("Starting channel rendezvous scenario in session: ${session.sessionId}")
+
+        val viz = VizScope(session)
+        val channel = viz.vizChannel<Int>(Channel.RENDEZVOUS, "rendezvous-channel")
+
+        val job = viz.vizLaunch("rendezvous-demo") {
+            val producer = vizLaunch("producer") {
+                for (i in 1..5) {
+                    logger.debug("Producer sending $i...")
+                    channel.send(i)
+                    logger.debug("Producer sent $i")
+                    vizDelay(100)
+                }
+                channel.close()
+                logger.debug("Producer closed channel")
+            }
+
+            val consumer = vizLaunch("consumer") {
+                // Small delay so producer arrives first to demonstrate rendezvous suspension
+                vizDelay(200)
+                try {
+                    while (true) {
+                        val value = channel.receive()
+                        logger.debug("Consumer received $value")
+                        vizDelay(300) // Slower consumer to show suspension
+                    }
+                } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
+                    logger.debug("Consumer: channel closed")
+                }
+            }
+
+            producer.join()
+            consumer.join()
+            logger.debug("Rendezvous channel demo completed")
+        }
+
+        job.join()
+        job
+    }
+
+    /**
+     * Buffered Channel Scenario
+     *
+     * Demonstrates a buffered channel where the sender can send multiple
+     * values without suspending until the buffer is full. Shows buffer
+     * state changes as values are sent and received.
+     */
+    suspend fun runChannelBuffered(session: VizSession): Job = coroutineScope {
+        logger.info("Starting channel buffered scenario in session: ${session.sessionId}")
+
+        val viz = VizScope(session)
+        val channel = viz.vizChannel<String>(3, "buffered-channel")
+
+        val job = viz.vizLaunch("buffered-demo") {
+            val producer = vizLaunch("producer") {
+                val items = listOf("alpha", "beta", "gamma", "delta", "epsilon")
+                for (item in items) {
+                    logger.debug("Producer sending $item...")
+                    channel.send(item)
+                    logger.debug("Producer sent $item")
+                }
+                channel.close()
+                logger.debug("Producer closed channel")
+            }
+
+            val consumer = vizLaunch("consumer") {
+                vizDelay(500) // Let buffer fill up first
+                try {
+                    while (true) {
+                        val value = channel.receive()
+                        logger.debug("Consumer received $value")
+                        vizDelay(200)
+                    }
+                } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
+                    logger.debug("Consumer: channel closed")
+                }
+            }
+
+            producer.join()
+            consumer.join()
+            logger.debug("Buffered channel demo completed")
+        }
+
+        job.join()
+        job
+    }
+
+    /**
+     * Fan-Out Channel Scenario
+     *
+     * Demonstrates the fan-out pattern where a single producer sends
+     * values to a channel and multiple consumers compete to receive them.
+     * Each value is received by exactly one consumer.
+     */
+    suspend fun runChannelFanOut(session: VizSession): Job = coroutineScope {
+        logger.info("Starting channel fan-out scenario in session: ${session.sessionId}")
+
+        val viz = VizScope(session)
+        val channel = viz.vizChannel<Int>(Channel.BUFFERED, "task-channel")
+
+        val job = viz.vizLaunch("fan-out-demo") {
+            // Producer: sends tasks
+            val producer = vizLaunch("task-producer") {
+                for (taskId in 1..10) {
+                    logger.debug("Dispatching task $taskId")
+                    channel.send(taskId)
+                    vizDelay(50)
+                }
+                channel.close()
+                logger.debug("All tasks dispatched")
+            }
+
+            // Multiple consumers competing for tasks
+            val consumers = (1..3).map { workerId ->
+                vizLaunch("worker-$workerId") {
+                    try {
+                        while (true) {
+                            val taskId = channel.receive()
+                            logger.debug("Worker $workerId processing task $taskId")
+                            vizDelay((100..300).random().toLong()) // Simulate variable work
+                            logger.debug("Worker $workerId completed task $taskId")
+                        }
+                    } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
+                        logger.debug("Worker $workerId: no more tasks")
+                    }
+                }
+            }
+
+            producer.join()
+            consumers.forEach { it.join() }
+            logger.debug("Fan-out demo completed")
+        }
+
+        job.join()
         job
     }
 

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/session/ChannelEventContext.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/session/ChannelEventContext.kt
@@ -1,0 +1,145 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.channel.*
+
+/**
+ * ChannelEventContext carries common Channel metadata for event creation.
+ *
+ * This provides extension functions that automatically fill in common fields
+ * when emitting Channel-related events, following the same pattern as FlowEventContext.
+ *
+ * Usage:
+ * ```kotlin
+ * val ctx = ChannelEventContext(session, channelId, "my-channel", 0, "RENDEZVOUS")
+ * session.send(ctx.channelCreated())
+ * session.send(ctx.channelSendStarted(coroutineId, "value"))
+ * ```
+ */
+data class ChannelEventContext(
+    val session: VizSession,
+    val channelId: String,
+    val name: String? = null,
+    val capacity: Int,
+    val channelType: String  // RENDEZVOUS, BUFFERED, CONFLATED, UNLIMITED
+) {
+    val sessionId: String get() = session.sessionId
+
+    fun nextSeq(): Long = session.nextSeq()
+    fun timestamp(): Long = System.nanoTime()
+}
+
+// ============================================================================
+// Channel Lifecycle Events
+// ============================================================================
+
+fun ChannelEventContext.channelCreated(): ChannelCreated = ChannelCreated(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    name = name,
+    capacity = capacity,
+    channelType = channelType
+)
+
+fun ChannelEventContext.channelClosed(
+    cause: String? = null
+): ChannelClosed = ChannelClosed(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    cause = cause
+)
+
+// ============================================================================
+// Channel Send Events
+// ============================================================================
+
+fun ChannelEventContext.channelSendStarted(
+    coroutineId: String,
+    valueDescription: String
+): ChannelSendStarted = ChannelSendStarted(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    coroutineId = coroutineId,
+    valueDescription = valueDescription
+)
+
+fun ChannelEventContext.channelSendCompleted(
+    coroutineId: String,
+    valueDescription: String
+): ChannelSendCompleted = ChannelSendCompleted(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    coroutineId = coroutineId,
+    valueDescription = valueDescription
+)
+
+fun ChannelEventContext.channelSendSuspended(
+    coroutineId: String,
+    bufferSize: Int
+): ChannelSendSuspended = ChannelSendSuspended(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    coroutineId = coroutineId,
+    bufferSize = bufferSize,
+    capacity = capacity
+)
+
+// ============================================================================
+// Channel Receive Events
+// ============================================================================
+
+fun ChannelEventContext.channelReceiveStarted(
+    coroutineId: String
+): ChannelReceiveStarted = ChannelReceiveStarted(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    coroutineId = coroutineId
+)
+
+fun ChannelEventContext.channelReceiveCompleted(
+    coroutineId: String,
+    valueDescription: String
+): ChannelReceiveCompleted = ChannelReceiveCompleted(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    coroutineId = coroutineId,
+    valueDescription = valueDescription
+)
+
+fun ChannelEventContext.channelReceiveSuspended(
+    coroutineId: String
+): ChannelReceiveSuspended = ChannelReceiveSuspended(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    coroutineId = coroutineId
+)
+
+// ============================================================================
+// Channel Buffer Events
+// ============================================================================
+
+fun ChannelEventContext.channelBufferStateChanged(
+    currentSize: Int
+): ChannelBufferStateChanged = ChannelBufferStateChanged(
+    sessionId = sessionId,
+    seq = nextSeq(),
+    tsNanos = timestamp(),
+    channelId = channelId,
+    currentSize = currentSize,
+    capacity = capacity
+)

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedChannel.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedChannel.kt
@@ -1,0 +1,248 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.DelicateCoroutinesApi::class)
+
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.channel.*
+import com.jh.proj.coroutineviz.session.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ChannelIterator
+import kotlinx.coroutines.channels.ChannelResult
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.selects.SelectClause1
+import kotlinx.coroutines.selects.SelectClause2
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * InstrumentedChannel wraps a kotlinx.coroutines Channel to emit visualization events.
+ *
+ * Features:
+ * - Tracks all send operations with suspension detection
+ * - Tracks all receive operations with suspension detection
+ * - Monitors buffer state changes
+ * - Tracks channel close
+ *
+ * @param T The type of values transmitted through the channel
+ * @param delegate The underlying Channel
+ * @param session The VizSession for event tracking
+ * @param channelId Unique identifier for this Channel
+ * @param name Optional human-readable name
+ * @param capacity The buffer capacity of the channel
+ * @param channelType Type string: RENDEZVOUS, BUFFERED, CONFLATED, UNLIMITED
+ */
+class InstrumentedChannel<T>(
+    private val delegate: Channel<T>,
+    private val session: VizSession,
+    val channelId: String,
+    val name: String? = null,
+    private val capacity: Int,
+    private val channelType: String
+) : Channel<T> {
+
+    private val bufferCount = AtomicInteger(0)
+
+    private val ctx: ChannelEventContext by lazy {
+        ChannelEventContext(
+            session = session,
+            channelId = channelId,
+            name = name,
+            capacity = capacity,
+            channelType = channelType
+        )
+    }
+
+    init {
+        session.send(
+            ctx.channelCreated()
+        )
+        logger.debug("Channel created: channelId=$channelId, type=$channelType, capacity=$capacity")
+    }
+
+    // ========================================================================
+    // SendChannel implementation
+    // ========================================================================
+
+    override val isClosedForSend: Boolean
+        get() = delegate.isClosedForSend
+
+    override suspend fun send(element: T) {
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val valueDesc = element?.toString()?.take(200) ?: "null"
+
+        session.send(ctx.channelSendStarted(coroutineId, valueDesc))
+
+        delegate.send(element)
+
+        val currentSize = bufferCount.incrementAndGet()
+        session.send(ctx.channelBufferStateChanged(currentSize))
+        session.send(ctx.channelSendCompleted(coroutineId, valueDesc))
+
+        logger.trace("Channel send completed: channelId=$channelId, value=$valueDesc")
+    }
+
+    override fun trySend(element: T): ChannelResult<Unit> {
+        val result = delegate.trySend(element)
+        if (result.isSuccess) {
+            val currentSize = bufferCount.incrementAndGet()
+            val coroutineId = runCatching {
+                kotlinx.coroutines.runBlocking {
+                    currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                }
+            }.getOrNull() ?: "unknown"
+            val valueDesc = element?.toString()?.take(200) ?: "null"
+
+            session.send(ctx.channelSendStarted(coroutineId, valueDesc))
+            session.send(ctx.channelBufferStateChanged(currentSize))
+            session.send(ctx.channelSendCompleted(coroutineId, valueDesc))
+        }
+        return result
+    }
+
+    override fun close(cause: Throwable?): Boolean {
+        val result = delegate.close(cause)
+        if (result) {
+            session.send(ctx.channelClosed(cause?.message))
+            logger.debug("Channel closed: channelId=$channelId, cause=${cause?.message}")
+        }
+        return result
+    }
+
+    override fun invokeOnClose(handler: (cause: Throwable?) -> Unit) {
+        delegate.invokeOnClose(handler)
+    }
+
+    override val onSend: SelectClause2<T, SendChannel<T>>
+        get() = delegate.onSend
+
+    // ========================================================================
+    // ReceiveChannel implementation
+    // ========================================================================
+
+    override val isClosedForReceive: Boolean
+        get() = delegate.isClosedForReceive
+
+    override val isEmpty: Boolean
+        get() = delegate.isEmpty
+
+    override suspend fun receive(): T {
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+
+        session.send(ctx.channelReceiveStarted(coroutineId))
+
+        val value = delegate.receive()
+
+        val currentSize = bufferCount.decrementAndGet().coerceAtLeast(0)
+        session.send(ctx.channelBufferStateChanged(currentSize))
+
+        val valueDesc = value?.toString()?.take(200) ?: "null"
+        session.send(ctx.channelReceiveCompleted(coroutineId, valueDesc))
+
+        logger.trace("Channel receive completed: channelId=$channelId, value=$valueDesc")
+        return value
+    }
+
+    override fun tryReceive(): ChannelResult<T> {
+        val result = delegate.tryReceive()
+        if (result.isSuccess) {
+            val currentSize = bufferCount.decrementAndGet().coerceAtLeast(0)
+            val coroutineId = runCatching {
+                kotlinx.coroutines.runBlocking {
+                    currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                }
+            }.getOrNull() ?: "unknown"
+
+            session.send(ctx.channelReceiveStarted(coroutineId))
+            session.send(ctx.channelBufferStateChanged(currentSize))
+            val valueDesc = result.getOrNull()?.toString()?.take(200) ?: "null"
+            session.send(ctx.channelReceiveCompleted(coroutineId, valueDesc))
+        }
+        return result
+    }
+
+    override fun cancel(cause: CancellationException?) {
+        delegate.cancel(cause)
+        session.send(ctx.channelClosed(cause?.message ?: "Cancelled"))
+        logger.debug("Channel cancelled: channelId=$channelId, cause=${cause?.message}")
+    }
+
+    @Deprecated("Deprecated in ReceiveChannel", replaceWith = ReplaceWith("cancel(CancellationException(cause))"))
+    override fun cancel(cause: Throwable?): Boolean {
+        val cancellationException = when (cause) {
+            null -> null
+            is CancellationException -> cause
+            else -> CancellationException(cause.message, cause)
+        }
+        delegate.cancel(cancellationException)
+        session.send(ctx.channelClosed(cause?.message ?: "Cancelled"))
+        logger.debug("Channel cancelled (deprecated): channelId=$channelId, cause=${cause?.message}")
+        return true
+    }
+
+    override val onReceive: SelectClause1<T>
+        get() = delegate.onReceive
+
+    override val onReceiveCatching: SelectClause1<ChannelResult<T>>
+        get() = delegate.onReceiveCatching
+
+    override fun iterator(): ChannelIterator<T> {
+        val delegateIterator = delegate.iterator()
+        return object : ChannelIterator<T> {
+            override suspend fun hasNext(): Boolean {
+                return delegateIterator.hasNext()
+            }
+
+            override fun next(): T {
+                val value = delegateIterator.next()
+                val currentSize = bufferCount.decrementAndGet().coerceAtLeast(0)
+                session.send(ctx.channelBufferStateChanged(currentSize))
+                val valueDesc = value?.toString()?.take(200) ?: "null"
+                session.send(
+                    ChannelReceiveCompleted(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        channelId = channelId,
+                        coroutineId = "iterator",
+                        valueDescription = valueDesc
+                    )
+                )
+                return value
+            }
+        }
+    }
+
+    override suspend fun receiveCatching(): ChannelResult<T> {
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        session.send(ctx.channelReceiveStarted(coroutineId))
+
+        val result = delegate.receiveCatching()
+
+        if (result.isSuccess) {
+            val currentSize = bufferCount.decrementAndGet().coerceAtLeast(0)
+            session.send(ctx.channelBufferStateChanged(currentSize))
+            val valueDesc = result.getOrNull()?.toString()?.take(200) ?: "null"
+            session.send(ctx.channelReceiveCompleted(coroutineId, valueDesc))
+        } else if (result.isClosed) {
+            session.send(ctx.channelClosed(result.exceptionOrNull()?.message))
+        }
+
+        return result
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(InstrumentedChannel::class.java)
+    }
+}
+
+/**
+ * Determine the channel type string from the capacity constant.
+ */
+fun channelTypeFromCapacity(capacity: Int): String = when (capacity) {
+    Channel.RENDEZVOUS -> "RENDEZVOUS"
+    Channel.CONFLATED -> "CONFLATED"
+    Channel.UNLIMITED -> "UNLIMITED"
+    Channel.BUFFERED -> "BUFFERED"
+    else -> "BUFFERED"
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizScope.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizScope.kt
@@ -8,6 +8,7 @@ import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
 import com.jh.proj.coroutineviz.session.EventContext
 import com.jh.proj.coroutineviz.session.JobStatusMonitor
 import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.channels.Channel
 import com.jh.proj.coroutineviz.session.coroutineBodyCompleted
 import com.jh.proj.coroutineviz.session.coroutineCancelled
 import com.jh.proj.coroutineviz.session.coroutineCompleted
@@ -739,5 +740,47 @@ class VizScope(
             label = label ?: "flowOf(${values.size} items)"
         )
 
+    }
+
+    // ========================================================================
+    // Channel Builders
+    // ========================================================================
+
+    /**
+     * Create an instrumented Channel with visualization tracking.
+     *
+     * This function wraps a Channel to emit events for:
+     * - Channel creation
+     * - Send start/complete/suspend
+     * - Receive start/complete/suspend
+     * - Buffer state changes
+     * - Channel close
+     *
+     * Usage:
+     * ```kotlin
+     * val channel = scope.vizChannel<Int>(Channel.BUFFERED, "my-channel")
+     * channel.send(42)
+     * val value = channel.receive()
+     * channel.close()
+     * ```
+     *
+     * @param capacity Channel capacity (Channel.RENDEZVOUS, Channel.BUFFERED, Channel.CONFLATED, Channel.UNLIMITED, or a specific int)
+     * @param name Optional human-readable name for the channel
+     * @return An InstrumentedChannel that tracks all operations
+     */
+    fun <T> vizChannel(
+        capacity: Int = Channel.RENDEZVOUS,
+        name: String? = null
+    ): InstrumentedChannel<T> {
+        val channelId = "channel-${session.nextSeq()}"
+        val channelType = channelTypeFromCapacity(capacity)
+        return InstrumentedChannel(
+            delegate = Channel(capacity),
+            session = session,
+            channelId = channelId,
+            name = name,
+            capacity = capacity,
+            channelType = channelType
+        )
     }
 }

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedChannelTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedChannelTest.kt
@@ -1,0 +1,488 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.channel.*
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class InstrumentedChannelTest {
+
+    private lateinit var session: VizSession
+
+    @BeforeEach
+    fun setup() {
+        session = VizSession("test-channel-${System.currentTimeMillis()}")
+    }
+
+    // ========================================================================
+    // CREATION TESTS
+    // ========================================================================
+
+    @Test
+    @DisplayName("vizChannel emits ChannelCreated event on creation")
+    fun `channel creation emits event`() {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.RENDEZVOUS, "test-channel")
+
+        val createdEvents = session.store.all().filterIsInstance<ChannelCreated>()
+        assertEquals(1, createdEvents.size)
+        assertEquals("test-channel", createdEvents.first().name)
+        assertEquals("RENDEZVOUS", createdEvents.first().channelType)
+        assertEquals(Channel.RENDEZVOUS, createdEvents.first().capacity)
+    }
+
+    @Test
+    @DisplayName("vizChannel with buffered capacity reports BUFFERED type")
+    fun `buffered channel type`() {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<String>(5, "buffered")
+
+        val createdEvents = session.store.all().filterIsInstance<ChannelCreated>()
+        assertEquals(1, createdEvents.size)
+        assertEquals("BUFFERED", createdEvents.first().channelType)
+        assertEquals(5, createdEvents.first().capacity)
+    }
+
+    @Test
+    @DisplayName("vizChannel with CONFLATED capacity reports CONFLATED type")
+    fun `conflated channel type`() {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.CONFLATED, "conflated")
+
+        val createdEvents = session.store.all().filterIsInstance<ChannelCreated>()
+        assertEquals("CONFLATED", createdEvents.first().channelType)
+    }
+
+    @Test
+    @DisplayName("vizChannel with UNLIMITED capacity reports UNLIMITED type")
+    fun `unlimited channel type`() {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.UNLIMITED, "unlimited")
+
+        val createdEvents = session.store.all().filterIsInstance<ChannelCreated>()
+        assertEquals("UNLIMITED", createdEvents.first().channelType)
+    }
+
+    // ========================================================================
+    // SEND/RECEIVE TESTS
+    // ========================================================================
+
+    @Test
+    @DisplayName("send and receive emit correct events in sequence")
+    fun `send and receive events`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.UNLIMITED, "send-recv")
+
+        channel.send(42)
+        val value = channel.receive()
+
+        assertEquals(42, value)
+
+        val allEvents = session.store.all()
+        assertTrue(allEvents.any { it is ChannelSendStarted })
+        assertTrue(allEvents.any { it is ChannelSendCompleted })
+        assertTrue(allEvents.any { it is ChannelReceiveStarted })
+        assertTrue(allEvents.any { it is ChannelReceiveCompleted })
+
+        val sendCompleted = allEvents.filterIsInstance<ChannelSendCompleted>().first()
+        assertEquals("42", sendCompleted.valueDescription)
+
+        val receiveCompleted = allEvents.filterIsInstance<ChannelReceiveCompleted>().first()
+        assertEquals("42", receiveCompleted.valueDescription)
+    }
+
+    @Test
+    @DisplayName("buffer state changes tracked correctly")
+    fun `buffer state tracking`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.UNLIMITED, "buffer-track")
+
+        channel.send(1)
+        channel.send(2)
+        channel.send(3)
+
+        val bufferEvents = session.store.all().filterIsInstance<ChannelBufferStateChanged>()
+        // After each send, a buffer state event is emitted
+        assertTrue(bufferEvents.size >= 3, "Expected at least 3 buffer state events, got ${bufferEvents.size}")
+
+        channel.receive()
+        channel.receive()
+
+        val allBufferEvents = session.store.all().filterIsInstance<ChannelBufferStateChanged>()
+        // Additional events after receives
+        assertTrue(allBufferEvents.size >= 5, "Expected at least 5 buffer state events, got ${allBufferEvents.size}")
+    }
+
+    // ========================================================================
+    // CLOSE TESTS
+    // ========================================================================
+
+    @Test
+    @DisplayName("close emits ChannelClosed event")
+    fun `channel close event`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.UNLIMITED, "close-test")
+
+        channel.send(1)
+        channel.close()
+
+        val closedEvents = session.store.all().filterIsInstance<ChannelClosed>()
+        assertEquals(1, closedEvents.size)
+        assertNull(closedEvents.first().cause)
+    }
+
+    @Test
+    @DisplayName("close with exception includes cause in event")
+    fun `channel close with cause`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.UNLIMITED, "close-cause")
+
+        channel.close(IllegalStateException("test error"))
+
+        val closedEvents = session.store.all().filterIsInstance<ChannelClosed>()
+        assertEquals(1, closedEvents.size)
+        assertEquals("test error", closedEvents.first().cause)
+    }
+
+    // ========================================================================
+    // TRYSEND / TRYRECEIVE TESTS
+    // ========================================================================
+
+    @Test
+    @DisplayName("trySend emits events on success")
+    fun `trySend success events`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.UNLIMITED, "try-send")
+
+        val result = channel.trySend(99)
+        assertTrue(result.isSuccess)
+
+        val sendCompleted = session.store.all().filterIsInstance<ChannelSendCompleted>()
+        assertTrue(sendCompleted.isNotEmpty())
+        assertEquals("99", sendCompleted.first().valueDescription)
+    }
+
+    @Test
+    @DisplayName("tryReceive emits events on success")
+    fun `tryReceive success events`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.UNLIMITED, "try-recv")
+
+        channel.send(77)
+        val result = channel.tryReceive()
+        assertTrue(result.isSuccess)
+        assertEquals(77, result.getOrNull())
+
+        val receiveCompleted = session.store.all().filterIsInstance<ChannelReceiveCompleted>()
+        assertTrue(receiveCompleted.isNotEmpty())
+    }
+
+    // ========================================================================
+    // RENDEZVOUS BEHAVIOR TESTS
+    // ========================================================================
+
+    @Test
+    @DisplayName("rendezvous channel suspends sender until receiver is ready")
+    fun `rendezvous suspension behavior`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.RENDEZVOUS, "rendezvous")
+
+        var senderCompleted = false
+
+        val sender = launch {
+            channel.send(1)
+            senderCompleted = true
+        }
+
+        // Give sender time to start but it should be suspended
+        delay(50)
+        assertFalse(senderCompleted, "Sender should be suspended in rendezvous channel")
+
+        // Receive unblocks the sender
+        val value = channel.receive()
+        assertEquals(1, value)
+
+        sender.join()
+        assertTrue(senderCompleted, "Sender should complete after receive")
+    }
+
+    // ========================================================================
+    // MULTIPLE SENDER/RECEIVER TESTS
+    // ========================================================================
+
+    @Test
+    @DisplayName("fan-out: multiple receivers compete for channel values")
+    fun `fan-out pattern`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<Int>(Channel.BUFFERED, "fan-out")
+        val received = java.util.concurrent.ConcurrentHashMap.newKeySet<Int>()
+
+        // Launch receivers
+        val receivers = (1..3).map {
+            launch {
+                try {
+                    while (true) {
+                        val value = channel.receive()
+                        received.add(value)
+                    }
+                } catch (_: ClosedReceiveChannelException) {
+                    // expected
+                }
+            }
+        }
+
+        // Send values
+        for (i in 1..10) {
+            channel.send(i)
+        }
+        channel.close()
+
+        receivers.forEach { it.join() }
+
+        // All values should have been received exactly once
+        assertEquals((1..10).toSet(), received)
+    }
+
+    // ========================================================================
+    // EVENT ORDERING TESTS
+    // ========================================================================
+
+    @Test
+    @DisplayName("events are emitted in correct order: created -> send -> receive -> close")
+    fun `event ordering`() = runBlocking {
+        val scope = VizScope(session)
+        val channel = scope.vizChannel<String>(Channel.UNLIMITED, "ordering")
+
+        channel.send("hello")
+        channel.receive()
+        channel.close()
+
+        val allEvents = session.store.all()
+        val channelEvents = allEvents.filter { event ->
+            event is ChannelCreated || event is ChannelSendStarted || event is ChannelSendCompleted ||
+                event is ChannelReceiveStarted || event is ChannelReceiveCompleted ||
+                event is ChannelClosed || event is ChannelBufferStateChanged
+        }
+
+        // First event should be ChannelCreated
+        assertTrue(channelEvents.first() is ChannelCreated, "First channel event should be ChannelCreated")
+
+        // Last event should be ChannelClosed
+        assertTrue(channelEvents.last() is ChannelClosed, "Last channel event should be ChannelClosed")
+
+        // Verify sequence numbers are monotonically increasing
+        val seqs = channelEvents.map { it.seq }
+        for (i in 1 until seqs.size) {
+            assertTrue(seqs[i] > seqs[i - 1], "Sequence numbers should be increasing: ${seqs[i - 1]} -> ${seqs[i]}")
+        }
+    }
+
+    // ========================================================================
+    // SERIALIZATION TESTS
+    // ========================================================================
+
+    @Test
+    @DisplayName("ChannelCreated serialization round-trip")
+    fun `channelCreated serialization`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelCreated(
+            sessionId = "test-session",
+            seq = 1L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            name = "test-channel",
+            capacity = 5,
+            channelType = "BUFFERED"
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelCreated>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"channelId\":\"channel-1\""))
+        assertTrue(serialized.contains("\"channelType\":\"BUFFERED\""))
+        assertTrue(serialized.contains("\"capacity\":5"))
+    }
+
+    @Test
+    @DisplayName("ChannelSendCompleted serialization round-trip")
+    fun `channelSendCompleted serialization`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelSendCompleted(
+            sessionId = "test-session",
+            seq = 2L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            coroutineId = "coroutine-1",
+            valueDescription = "42"
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelSendCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"valueDescription\":\"42\""))
+    }
+
+    @Test
+    @DisplayName("ChannelReceiveCompleted serialization round-trip")
+    fun `channelReceiveCompleted serialization`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelReceiveCompleted(
+            sessionId = "test-session",
+            seq = 3L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            coroutineId = "coroutine-2",
+            valueDescription = "hello"
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelReceiveCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    @DisplayName("ChannelClosed serialization with null cause")
+    fun `channelClosed serialization null cause`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelClosed(
+            sessionId = "test-session",
+            seq = 4L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            cause = null
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelClosed>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    @DisplayName("ChannelClosed serialization with cause")
+    fun `channelClosed serialization with cause`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelClosed(
+            sessionId = "test-session",
+            seq = 5L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            cause = "Test error"
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelClosed>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"cause\":\"Test error\""))
+    }
+
+    @Test
+    @DisplayName("ChannelSendSuspended serialization round-trip")
+    fun `channelSendSuspended serialization`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelSendSuspended(
+            sessionId = "test-session",
+            seq = 6L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            coroutineId = "coroutine-1",
+            bufferSize = 5,
+            capacity = 5
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelSendSuspended>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"bufferSize\":5"))
+    }
+
+    @Test
+    @DisplayName("ChannelBufferStateChanged serialization round-trip")
+    fun `channelBufferStateChanged serialization`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelBufferStateChanged(
+            sessionId = "test-session",
+            seq = 7L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            currentSize = 3,
+            capacity = 10
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelBufferStateChanged>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"currentSize\":3"))
+        assertTrue(serialized.contains("\"capacity\":10"))
+    }
+
+    @Test
+    @DisplayName("ChannelReceiveSuspended serialization round-trip")
+    fun `channelReceiveSuspended serialization`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelReceiveSuspended(
+            sessionId = "test-session",
+            seq = 8L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            coroutineId = "coroutine-1"
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelReceiveSuspended>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    @DisplayName("ChannelSendStarted serialization round-trip")
+    fun `channelSendStarted serialization`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelSendStarted(
+            sessionId = "test-session",
+            seq = 9L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            coroutineId = "coroutine-1",
+            valueDescription = "test-value"
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelSendStarted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"valueDescription\":\"test-value\""))
+    }
+
+    @Test
+    @DisplayName("ChannelReceiveStarted serialization round-trip")
+    fun `channelReceiveStarted serialization`() {
+        val json = kotlinx.serialization.json.Json { prettyPrint = false; encodeDefaults = true }
+        val event = ChannelReceiveStarted(
+            sessionId = "test-session",
+            seq = 10L,
+            tsNanos = 12345L,
+            channelId = "channel-1",
+            coroutineId = "coroutine-1"
+        )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelReceiveStarted>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+}


### PR DESCRIPTION
## Summary
- 9 channel event types in events/channel/ (ChannelCreated, ChannelSendStarted, ChannelSendCompleted, ChannelSendSuspended, ChannelReceiveStarted, ChannelReceiveCompleted, ChannelReceiveSuspended, ChannelClosed, ChannelBufferStateChanged)
- ChannelEventContext for event creation following FlowEventContext pattern
- InstrumentedChannel wrapper delegating to kotlinx.coroutines Channel
- VizScope.vizChannel() factory method
- 3 scenarios (rendezvous, buffered, fan-out)
- HTTP endpoints: POST /api/scenarios/channel-rendezvous, channel-buffered, channel-fan-out
- 23 tests covering creation, send/receive, close, trySend/tryReceive, rendezvous behavior, fan-out pattern, event ordering, and serialization round-trips
- All 91 tests pass

Closes hermanngeorge15/vizcor-be#20
Closes hermanngeorge15/vizcor-be#5

## Test plan
- [x] ./gradlew test passes all 91 tests (23 new channel tests + 68 existing)
- [ ] Manual verification of channel-rendezvous scenario via POST endpoint
- [ ] Manual verification of channel-buffered scenario via POST endpoint
- [ ] Manual verification of channel-fan-out scenario via POST endpoint