### PR TITLE
fix: restore tabs and add animations to all visualization panels

### DIFF
--- a/frontend/src/components/SessionDetails.tsx
+++ b/frontend/src/components/SessionDetails.tsx
@@ -306,8 +306,8 @@ export function SessionDetails({ sessionId, scenarioId, scenarioName }: SessionD
 
       {/* Main Tabs */}
       <Tabs aria-label="Session tabs" variant="bordered" fullWidth>
-        {/* Overview tab - contains existing content */}
-        <Tab key="overview" title="Overview">
+        {/* Coroutines tab - Graph/List view toggle */}
+        <Tab key="coroutines" title="Coroutines">
           <div className="space-y-4 pt-2">
             <Card>
               <CardBody className="overflow-auto">
@@ -318,13 +318,23 @@ export function SessionDetails({ sessionId, scenarioId, scenarioName }: SessionD
                 )}
               </CardBody>
             </Card>
+          </div>
+        </Tab>
 
+        {/* Events tab - restored as its own focused tab */}
+        <Tab key="events" title="Events">
+          <div className="pt-2">
             <Card>
               <CardBody>
                 <EventsList events={allEvents} />
               </CardBody>
             </Card>
+          </div>
+        </Tab>
 
+        {/* Threads tab - thread activity and dispatcher overview */}
+        <Tab key="threads" title="Threads">
+          <div className="space-y-4 pt-2">
             {threadActivity ? (
               <ThreadTimeline threadActivity={threadActivity} />
             ) : (

--- a/frontend/src/components/channels/ChannelBufferGauge.tsx
+++ b/frontend/src/components/channels/ChannelBufferGauge.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 
 interface ChannelBufferGaugeProps {
   currentSize: number
@@ -57,7 +58,13 @@ export function ChannelBufferGauge({
   const barColorName = getBarColorName(fillPercent)
 
   return (
-    <div className="space-y-2" data-testid="channel-buffer-gauge">
+    <motion.div
+      className="space-y-2"
+      data-testid="channel-buffer-gauge"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4, delay: 0.1 }}
+    >
       {/* Header: type badge + closed indicator */}
       <div className="flex items-center justify-between">
         <Chip
@@ -83,9 +90,11 @@ export function ChannelBufferGauge({
       ) : (
         <>
           <div className="flex h-4 rounded-full overflow-hidden bg-default-100" data-testid="buffer-bar">
-            <div
-              className={`${barColor} transition-all duration-300`}
-              style={{ width: `${fillPercent}%` }}
+            <motion.div
+              className={`${barColor} rounded-full`}
+              initial={{ width: 0 }}
+              animate={{ width: `${fillPercent}%` }}
+              transition={{ duration: 0.8, ease: 'easeOut' }}
               data-testid="buffer-fill"
             />
           </div>
@@ -99,6 +108,6 @@ export function ChannelBufferGauge({
           </div>
         </>
       )}
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/channels/ChannelPanel.test.tsx
+++ b/frontend/src/components/channels/ChannelPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { ChannelPanel } from './ChannelPanel'
@@ -148,8 +148,10 @@ describe('ChannelPanel', () => {
     const betaSelector = screen.getByTestId('channel-selector-ch-2')
     fireEvent.click(betaSelector)
 
-    // After clicking, the buffer state header should show Beta
-    expect(screen.getByText(/Buffer State:.*Beta/)).toBeInTheDocument()
+    // After clicking, the buffer state header should show Beta (wait for animation)
+    await waitFor(() => {
+      expect(screen.getByText(/Buffer State:.*Beta/)).toBeInTheDocument()
+    })
   })
 })
 

--- a/frontend/src/components/channels/ChannelPanel.tsx
+++ b/frontend/src/components/channels/ChannelPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Card, CardBody, CardHeader, Chip, Divider } from '@heroui/react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { FiRadio, FiHash } from 'react-icons/fi'
 import { useChannelEvents } from '@/hooks/use-channel-events'
 import { ChannelBufferGauge } from './ChannelBufferGauge'
@@ -24,17 +25,23 @@ export function ChannelPanel({ sessionId }: ChannelPanelProps) {
 
   if (channels.length === 0) {
     return (
-      <Card className="mt-2" data-testid="channel-panel-empty">
-        <CardBody>
-          <div className="text-center text-default-400 py-8">
-            <FiRadio className="w-8 h-8 mx-auto mb-3 opacity-50" />
-            <p className="text-lg font-semibold mb-2">No Channel Activity</p>
-            <p className="text-sm">
-              Channel events will appear here once send/receive operations occur.
-            </p>
-          </div>
-        </CardBody>
-      </Card>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+      >
+        <Card className="mt-2" data-testid="channel-panel-empty">
+          <CardBody>
+            <div className="text-center text-default-400 py-8">
+              <FiRadio className="w-8 h-8 mx-auto mb-3 opacity-50" />
+              <p className="text-lg font-semibold mb-2">No Channel Activity</p>
+              <p className="text-sm">
+                Channel events will appear here once send/receive operations occur.
+              </p>
+            </div>
+          </CardBody>
+        </Card>
+      </motion.div>
     )
   }
 
@@ -47,7 +54,13 @@ export function ChannelPanel({ sessionId }: ChannelPanelProps) {
     : null
 
   return (
-    <div className="space-y-4 mt-2" data-testid="channel-panel">
+    <motion.div
+      className="space-y-4 mt-2"
+      data-testid="channel-panel"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
       {/* Channel list */}
       <Card>
         <CardHeader>
@@ -58,11 +71,11 @@ export function ChannelPanel({ sessionId }: ChannelPanelProps) {
         </CardHeader>
         <CardBody>
           <div className="flex flex-wrap gap-2" data-testid="channel-list">
-            {channels.map((ch) => {
+            {channels.map((ch, index) => {
               const isSelected = ch.channelId === effectiveSelectedId
               const evtCount = eventsByChannel.get(ch.channelId)?.length ?? 0
               return (
-                <button
+                <motion.button
                   key={ch.channelId}
                   onClick={() => setSelectedChannelId(ch.channelId)}
                   className={`flex items-center gap-2 px-3 py-2 rounded-lg border transition-colors ${
@@ -71,6 +84,11 @@ export function ChannelPanel({ sessionId }: ChannelPanelProps) {
                       : 'border-default-200 hover:bg-default-100'
                   }`}
                   data-testid={`channel-selector-${ch.channelId}`}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.3, delay: index * 0.05 }}
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
                 >
                   <div
                     className={`w-2 h-2 rounded-full ${
@@ -83,7 +101,7 @@ export function ChannelPanel({ sessionId }: ChannelPanelProps) {
                   <Chip size="sm" variant="flat">
                     {evtCount}
                   </Chip>
-                </button>
+                </motion.button>
               )
             })}
           </div>
@@ -91,52 +109,61 @@ export function ChannelPanel({ sessionId }: ChannelPanelProps) {
       </Card>
 
       {/* Selected channel detail */}
-      {selectedChannel && (
-        <>
-          {/* Buffer gauge */}
-          <Card>
-            <CardHeader>
-              <h4 className="font-semibold">
-                Buffer State: {selectedChannel.name || selectedChannel.channelId}
-              </h4>
-            </CardHeader>
-            <CardBody>
-              <ChannelBufferGauge
-                currentSize={selectedBuffer?.currentSize ?? selectedChannel.currentSize}
-                capacity={selectedBuffer?.capacity ?? selectedChannel.capacity}
-                channelType={selectedChannel.channelType}
-                isClosed={selectedChannel.isClosed}
-              />
-            </CardBody>
-          </Card>
+      <AnimatePresence mode="wait">
+        {selectedChannel && (
+          <motion.div
+            key={effectiveSelectedId}
+            className="space-y-4"
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.3 }}
+          >
+            {/* Buffer gauge */}
+            <Card>
+              <CardHeader>
+                <h4 className="font-semibold">
+                  Buffer State: {selectedChannel.name || selectedChannel.channelId}
+                </h4>
+              </CardHeader>
+              <CardBody>
+                <ChannelBufferGauge
+                  currentSize={selectedBuffer?.currentSize ?? selectedChannel.currentSize}
+                  capacity={selectedBuffer?.capacity ?? selectedChannel.capacity}
+                  channelType={selectedChannel.channelType}
+                  isClosed={selectedChannel.isClosed}
+                />
+              </CardBody>
+            </Card>
 
-          {/* Producer / Consumer flow diagram */}
-          <Card>
-            <CardHeader>
-              <h4 className="font-semibold">Producer / Consumer Flow</h4>
-            </CardHeader>
-            <CardBody>
-              <ChannelProducerConsumer channel={selectedChannel} />
-            </CardBody>
-          </Card>
+            {/* Producer / Consumer flow diagram */}
+            <Card>
+              <CardHeader>
+                <h4 className="font-semibold">Producer / Consumer Flow</h4>
+              </CardHeader>
+              <CardBody>
+                <ChannelProducerConsumer channel={selectedChannel} />
+              </CardBody>
+            </Card>
 
-          {/* Timeline */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center justify-between w-full">
-                <h4 className="font-semibold">Event Timeline</h4>
-                <Chip size="sm" variant="flat" color="primary">
-                  {selectedEvents.length} events
-                </Chip>
-              </div>
-            </CardHeader>
-            <Divider />
-            <CardBody>
-              <ChannelTimeline events={selectedEvents} />
-            </CardBody>
-          </Card>
-        </>
-      )}
-    </div>
+            {/* Timeline */}
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between w-full">
+                  <h4 className="font-semibold">Event Timeline</h4>
+                  <Chip size="sm" variant="flat" color="primary">
+                    {selectedEvents.length} events
+                  </Chip>
+                </div>
+              </CardHeader>
+              <Divider />
+              <CardBody>
+                <ChannelTimeline events={selectedEvents} />
+              </CardBody>
+            </Card>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
   )
 }

--- a/frontend/src/components/channels/ChannelProducerConsumer.tsx
+++ b/frontend/src/components/channels/ChannelProducerConsumer.tsx
@@ -1,5 +1,5 @@
 import { Chip } from '@heroui/react'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { FiArrowRight, FiBox } from 'react-icons/fi'
 import type { ChannelState } from '@/hooks/use-channel-events'
 
@@ -16,9 +16,15 @@ export function ChannelProducerConsumer({ channel }: ChannelProducerConsumerProp
 
   if (!hasProducers && !hasConsumers) {
     return (
-      <div className="text-center text-default-400 py-4" data-testid="producer-consumer-empty">
+      <motion.div
+        className="text-center text-default-400 py-4"
+        data-testid="producer-consumer-empty"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+      >
         No producer/consumer activity recorded yet.
-      </div>
+      </motion.div>
     )
   }
 
@@ -28,21 +34,33 @@ export function ChannelProducerConsumer({ channel }: ChannelProducerConsumerProp
       : 0
 
   return (
-    <div className="flex items-center gap-4 py-4" data-testid="producer-consumer-diagram">
+    <motion.div
+      className="flex items-center gap-4 py-4"
+      data-testid="producer-consumer-diagram"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4, delay: 0.1 }}
+    >
       {/* Producers (left) */}
       <div className="flex-1 space-y-2" data-testid="producers-column">
         <div className="text-xs font-semibold text-default-500 uppercase tracking-wide mb-2">
           Producers ({producers.length})
         </div>
-        {producers.map((id) => (
-          <div
-            key={id}
-            className="flex items-center gap-2 p-2 rounded-lg bg-primary/5 border border-primary/20"
-          >
-            <div className="w-2 h-2 rounded-full bg-primary" />
-            <span className="text-xs font-mono truncate">{id}</span>
-          </div>
-        ))}
+        <AnimatePresence mode="popLayout">
+          {producers.map((id, index) => (
+            <motion.div
+              key={id}
+              className="flex items-center gap-2 p-2 rounded-lg bg-primary/5 border border-primary/20"
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.2, delay: index * 0.03 }}
+            >
+              <div className="w-2 h-2 rounded-full bg-primary" />
+              <span className="text-xs font-mono truncate">{id}</span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
       </div>
 
       {/* Animated arrows + channel buffer (middle) */}
@@ -65,9 +83,11 @@ export function ChannelProducerConsumer({ channel }: ChannelProducerConsumerProp
         >
           {/* Fill level */}
           {channel.capacity > 0 && (
-            <div
-              className="absolute bottom-0 left-0 right-0 bg-primary/20 transition-all duration-500"
-              style={{ height: `${fillPercent}%` }}
+            <motion.div
+              className="absolute bottom-0 left-0 right-0 bg-primary/20"
+              initial={{ height: 0 }}
+              animate={{ height: `${fillPercent}%` }}
+              transition={{ duration: 0.8, ease: 'easeOut' }}
             />
           )}
           <div className="relative z-10 flex flex-col items-center">
@@ -108,16 +128,22 @@ export function ChannelProducerConsumer({ channel }: ChannelProducerConsumerProp
         <div className="text-xs font-semibold text-default-500 uppercase tracking-wide mb-2">
           Consumers ({consumers.length})
         </div>
-        {consumers.map((id) => (
-          <div
-            key={id}
-            className="flex items-center gap-2 p-2 rounded-lg bg-secondary/5 border border-secondary/20"
-          >
-            <div className="w-2 h-2 rounded-full bg-secondary" />
-            <span className="text-xs font-mono truncate">{id}</span>
-          </div>
-        ))}
+        <AnimatePresence mode="popLayout">
+          {consumers.map((id, index) => (
+            <motion.div
+              key={id}
+              className="flex items-center gap-2 p-2 rounded-lg bg-secondary/5 border border-secondary/20"
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: 20 }}
+              transition={{ duration: 0.2, delay: index * 0.03 }}
+            >
+              <div className="w-2 h-2 rounded-full bg-secondary" />
+              <span className="text-xs font-mono truncate">{id}</span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
       </div>
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/channels/ChannelTimeline.tsx
+++ b/frontend/src/components/channels/ChannelTimeline.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@heroui/react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { FiArrowUp, FiArrowDown, FiPause, FiXCircle, FiActivity } from 'react-icons/fi'
 import { formatNanoTime } from '@/lib/utils'
 import type { ChannelEvent } from '@/types/api'
@@ -114,55 +115,65 @@ export function ChannelTimeline({ events }: ChannelTimelineProps) {
 
   return (
     <div className="space-y-1" data-testid="channel-timeline">
-      {events.map((event, index) => {
-        const side = getEventSide(event.kind)
-        const isLast = index === events.length - 1
+      <AnimatePresence mode="popLayout">
+        {events.map((event, index) => {
+          const side = getEventSide(event.kind)
+          const isLast = index === events.length - 1
 
-        return (
-          <div key={event.seq} className="flex items-stretch gap-0" data-testid="timeline-event">
-            {/* Left (send) column */}
-            <div className="flex-1 flex justify-end pr-2">
-              {side === 'send' && (
-                <TimelineCard event={event} />
-              )}
-            </div>
-
-            {/* Center spine */}
-            <div className="flex flex-col items-center w-8">
-              <div
-                className={`w-6 h-6 rounded-full flex items-center justify-center text-white bg-${getEventColor(event.kind)}`}
-                style={{
-                  backgroundColor:
-                    getEventColor(event.kind) === 'success'
-                      ? 'rgb(23, 201, 100)'
-                      : getEventColor(event.kind) === 'warning'
-                        ? 'rgb(245, 165, 36)'
-                        : getEventColor(event.kind) === 'danger'
-                          ? 'rgb(243, 18, 96)'
-                          : getEventColor(event.kind) === 'primary'
-                            ? 'rgb(0, 111, 238)'
-                            : getEventColor(event.kind) === 'secondary'
-                              ? 'rgb(126, 34, 206)'
-                              : 'rgb(113, 113, 122)',
-                }}
-              >
-                {getEventIcon(event.kind)}
+          return (
+            <motion.div
+              key={event.seq}
+              className="flex items-stretch gap-0"
+              data-testid="timeline-event"
+              initial={{ opacity: 0, x: side === 'send' ? -20 : 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: side === 'send' ? -20 : 20 }}
+              transition={{ duration: 0.2, delay: index * 0.03 }}
+            >
+              {/* Left (send) column */}
+              <div className="flex-1 flex justify-end pr-2">
+                {side === 'send' && (
+                  <TimelineCard event={event} />
+                )}
               </div>
-              {!isLast && <div className="w-0.5 flex-1 bg-default-200 min-h-[12px]" />}
-            </div>
 
-            {/* Right (receive) column */}
-            <div className="flex-1 pl-2">
-              {side === 'receive' && (
-                <TimelineCard event={event} />
-              )}
-              {side === 'meta' && (
-                <TimelineCard event={event} />
-              )}
-            </div>
-          </div>
-        )
-      })}
+              {/* Center spine */}
+              <div className="flex flex-col items-center w-8">
+                <div
+                  className={`w-6 h-6 rounded-full flex items-center justify-center text-white bg-${getEventColor(event.kind)}`}
+                  style={{
+                    backgroundColor:
+                      getEventColor(event.kind) === 'success'
+                        ? 'rgb(23, 201, 100)'
+                        : getEventColor(event.kind) === 'warning'
+                          ? 'rgb(245, 165, 36)'
+                          : getEventColor(event.kind) === 'danger'
+                            ? 'rgb(243, 18, 96)'
+                            : getEventColor(event.kind) === 'primary'
+                              ? 'rgb(0, 111, 238)'
+                              : getEventColor(event.kind) === 'secondary'
+                                ? 'rgb(126, 34, 206)'
+                                : 'rgb(113, 113, 122)',
+                  }}
+                >
+                  {getEventIcon(event.kind)}
+                </div>
+                {!isLast && <div className="w-0.5 flex-1 bg-default-200 min-h-[12px]" />}
+              </div>
+
+              {/* Right (receive) column */}
+              <div className="flex-1 pl-2">
+                {side === 'receive' && (
+                  <TimelineCard event={event} />
+                )}
+                {side === 'meta' && (
+                  <TimelineCard event={event} />
+                )}
+              </div>
+            </motion.div>
+          )
+        })}
+      </AnimatePresence>
     </div>
   )
 }

--- a/frontend/src/components/flow/FlowBackpressureIndicator.tsx
+++ b/frontend/src/components/flow/FlowBackpressureIndicator.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import type { FlowBackpressure } from '@/types/api'
 
 interface FlowBackpressureIndicatorProps {
@@ -11,15 +12,33 @@ export function FlowBackpressureIndicator({ events }: FlowBackpressureIndicatorP
   const latest = events[events.length - 1]!
 
   return (
-    <div className="space-y-1" data-testid="backpressure-indicator">
-      <Chip
-        size="sm"
-        variant="flat"
-        color="warning"
-        data-testid="backpressure-badge"
+    <motion.div
+      className="space-y-1"
+      data-testid="backpressure-indicator"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3 }}
+    >
+      <motion.div
+        animate={{
+          boxShadow: [
+            '0 0 0 rgba(245, 165, 36, 0)',
+            '0 0 15px rgba(245, 165, 36, 0.3)',
+            '0 0 0 rgba(245, 165, 36, 0)',
+          ],
+        }}
+        transition={{ duration: 2, repeat: Infinity }}
+        className="inline-block rounded-lg"
       >
-        Backpressure ({events.length} event{events.length !== 1 ? 's' : ''})
-      </Chip>
+        <Chip
+          size="sm"
+          variant="flat"
+          color="warning"
+          data-testid="backpressure-badge"
+        >
+          Backpressure ({events.length} event{events.length !== 1 ? 's' : ''})
+        </Chip>
+      </motion.div>
       <div className="text-xs text-default-500">
         <span className="font-mono">Reason: {latest.reason}</span>
         {latest.pendingEmissions > 0 && (
@@ -29,6 +48,6 @@ export function FlowBackpressureIndicator({ events }: FlowBackpressureIndicatorP
           <span className="ml-2">| Buffer: {latest.bufferCapacity}</span>
         )}
       </div>
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/flow/FlowOperatorChain.tsx
+++ b/frontend/src/components/flow/FlowOperatorChain.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import { FiArrowRight } from 'react-icons/fi'
 import type { FlowOperator } from '@/hooks/use-flow-events'
 
@@ -33,10 +34,28 @@ export function FlowOperatorChain({ operators, flowLabel }: FlowOperatorChainPro
         <div className="text-xs text-default-500 font-mono mb-1">{flowLabel}</div>
       )}
       <div className="flex flex-wrap items-center gap-1">
-        <Chip size="sm" variant="bordered" color="default">source</Chip>
-        {sorted.map((op) => (
-          <div key={`${op.flowId}-${op.operatorIndex}`} className="flex items-center gap-1">
-            <FiArrowRight className="text-default-400 shrink-0" size={14} />
+        <motion.div
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3 }}
+        >
+          <Chip size="sm" variant="bordered" color="default">source</Chip>
+        </motion.div>
+        {sorted.map((op, index) => (
+          <motion.div
+            key={`${op.flowId}-${op.operatorIndex}`}
+            className="flex items-center gap-1"
+            initial={{ opacity: 0, x: -10 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.3, delay: (index + 1) * 0.08 }}
+          >
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ duration: 0.2, delay: (index + 1) * 0.08 }}
+            >
+              <FiArrowRight className="text-default-400 shrink-0" size={14} />
+            </motion.div>
             <Chip
               size="sm"
               variant="flat"
@@ -45,10 +64,23 @@ export function FlowOperatorChain({ operators, flowLabel }: FlowOperatorChainPro
               {op.operatorName}
               {op.label ? ` (${op.label})` : ''}
             </Chip>
-          </div>
+          </motion.div>
         ))}
-        <FiArrowRight className="text-default-400 shrink-0" size={14} />
-        <Chip size="sm" variant="bordered" color="success">collect</Chip>
+        <motion.div
+          className="flex items-center gap-1"
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3, delay: (sorted.length + 1) * 0.08 }}
+        >
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ duration: 0.2, delay: (sorted.length + 1) * 0.08 }}
+          >
+            <FiArrowRight className="text-default-400 shrink-0" size={14} />
+          </motion.div>
+          <Chip size="sm" variant="bordered" color="success">collect</Chip>
+        </motion.div>
       </div>
     </div>
   )

--- a/frontend/src/components/flow/FlowPanel.tsx
+++ b/frontend/src/components/flow/FlowPanel.tsx
@@ -1,4 +1,5 @@
 import { Card, CardBody, CardHeader, Chip, Divider } from '@heroui/react'
+import { motion } from 'framer-motion'
 import { useFlowEvents } from '@/hooks/use-flow-events'
 import { FlowOperatorChain } from './FlowOperatorChain'
 import { FlowBackpressureIndicator } from './FlowBackpressureIndicator'
@@ -25,111 +26,120 @@ export function FlowPanel({ sessionId }: FlowPanelProps) {
 
   if (flows.length === 0) {
     return (
-      <Card className="mt-2">
-        <CardBody>
-          <div className="text-center text-default-400 py-8" data-testid="flow-empty">
-            <p className="text-lg font-semibold mb-2">No Flow Activity</p>
-            <p className="text-sm">
-              Flow events will appear here when flows are created and collected.
-            </p>
-          </div>
-        </CardBody>
-      </Card>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+      >
+        <Card className="mt-2">
+          <CardBody>
+            <div className="text-center text-default-400 py-8" data-testid="flow-empty">
+              <p className="text-lg font-semibold mb-2">No Flow Activity</p>
+              <p className="text-sm">
+                Flow events will appear here when flows are created and collected.
+              </p>
+            </div>
+          </CardBody>
+        </Card>
+      </motion.div>
     )
   }
 
   return (
-    <div className="space-y-4 mt-2" data-testid="flow-panel">
+    <motion.div
+      className="space-y-4 mt-2"
+      data-testid="flow-panel"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
       {/* Summary statistics */}
       <div className="grid grid-cols-4 gap-3">
-        <Card shadow="sm">
-          <CardBody className="py-3">
-            <div className="text-2xl font-bold text-primary">{flows.length}</div>
-            <div className="text-xs text-default-500">Total Flows</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-3">
-            <div className="text-2xl font-bold text-secondary">
-              {flows.reduce((sum, f) => sum + f.operators.length, 0)}
-            </div>
-            <div className="text-xs text-default-500">Operators</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-3">
-            <div className="text-2xl font-bold text-success">
-              {flows.reduce((sum, f) => sum + f.emissions.length, 0)}
-            </div>
-            <div className="text-xs text-default-500">Emissions</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-3">
-            <div className={`text-2xl font-bold ${hasBackpressure ? 'text-warning' : 'text-default-300'}`}>
-              {flows.reduce((sum, f) => sum + f.backpressureEvents.length, 0)}
-            </div>
-            <div className="text-xs text-default-500">Backpressure</div>
-          </CardBody>
-        </Card>
+        {[
+          { value: flows.length, label: 'Total Flows', color: 'text-primary' },
+          { value: flows.reduce((sum, f) => sum + f.operators.length, 0), label: 'Operators', color: 'text-secondary' },
+          { value: flows.reduce((sum, f) => sum + f.emissions.length, 0), label: 'Emissions', color: 'text-success' },
+          { value: flows.reduce((sum, f) => sum + f.backpressureEvents.length, 0), label: 'Backpressure', color: hasBackpressure ? 'text-warning' : 'text-default-300' },
+        ].map((stat, index) => (
+          <motion.div
+            key={stat.label}
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 25, delay: index * 0.1 }}
+          >
+            <Card shadow="sm">
+              <CardBody className="py-3">
+                <div className={`text-2xl font-bold ${stat.color}`}>{stat.value}</div>
+                <div className="text-xs text-default-500">{stat.label}</div>
+              </CardBody>
+            </Card>
+          </motion.div>
+        ))}
       </div>
 
       {/* Per-flow detail cards */}
-      {flows.map((flow) => (
-        <Card key={flow.flowId} shadow="sm">
-          <CardHeader className="pb-2">
-            <div className="flex w-full items-center justify-between">
-              <div>
-                <div className="font-semibold">
-                  {flow.label || flow.flowId}
+      {flows.map((flow, index) => (
+        <motion.div
+          key={flow.flowId}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3, delay: index * 0.05 }}
+        >
+          <Card shadow="sm">
+            <CardHeader className="pb-2">
+              <div className="flex w-full items-center justify-between">
+                <div>
+                  <div className="font-semibold">
+                    {flow.label || flow.flowId}
+                  </div>
+                  <div className="text-xs text-default-500 font-mono">
+                    {flow.flowId}
+                  </div>
                 </div>
-                <div className="text-xs text-default-500 font-mono">
-                  {flow.flowId}
+                <div className="flex gap-2">
+                  <Chip size="sm" variant="flat" color={getFlowTypeColor(flow.flowType)}>
+                    {flow.flowType}
+                  </Chip>
+                  <Chip size="sm" variant="bordered" color="default">
+                    {flow.emissions.length} emitted
+                  </Chip>
                 </div>
               </div>
-              <div className="flex gap-2">
-                <Chip size="sm" variant="flat" color={getFlowTypeColor(flow.flowType)}>
-                  {flow.flowType}
-                </Chip>
-                <Chip size="sm" variant="bordered" color="default">
-                  {flow.emissions.length} emitted
-                </Chip>
-              </div>
-            </div>
-          </CardHeader>
-          <CardBody className="pt-0 space-y-4">
-            {/* Operator chain */}
-            <FlowOperatorChain operators={flow.operators} flowLabel={flow.label} />
+            </CardHeader>
+            <CardBody className="pt-0 space-y-4">
+              {/* Operator chain */}
+              <FlowOperatorChain operators={flow.operators} flowLabel={flow.label} />
 
-            {/* Backpressure warning */}
-            <FlowBackpressureIndicator events={flow.backpressureEvents} />
+              {/* Backpressure warning */}
+              <FlowBackpressureIndicator events={flow.backpressureEvents} />
 
-            {/* Value traces */}
-            {flow.valueTraces.length > 0 && (
-              <>
-                <Divider />
-                <FlowValueTrace traces={flow.valueTraces} />
-              </>
-            )}
+              {/* Value traces */}
+              {flow.valueTraces.length > 0 && (
+                <>
+                  <Divider />
+                  <FlowValueTrace traces={flow.valueTraces} />
+                </>
+              )}
 
-            {/* SharedFlow sub-panel */}
-            {flow.flowType === 'SharedFlow' && (
-              <>
-                <Divider />
-                <SharedFlowPanel flow={flow} />
-              </>
-            )}
+              {/* SharedFlow sub-panel */}
+              {flow.flowType === 'SharedFlow' && (
+                <>
+                  <Divider />
+                  <SharedFlowPanel flow={flow} />
+                </>
+              )}
 
-            {/* StateFlow sub-panel */}
-            {flow.flowType === 'StateFlow' && (
-              <>
-                <Divider />
-                <StateFlowPanel flow={flow} />
-              </>
-            )}
-          </CardBody>
-        </Card>
+              {/* StateFlow sub-panel */}
+              {flow.flowType === 'StateFlow' && (
+                <>
+                  <Divider />
+                  <StateFlowPanel flow={flow} />
+                </>
+              )}
+            </CardBody>
+          </Card>
+        </motion.div>
       ))}
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/jobs/JobHierarchyView.tsx
+++ b/frontend/src/components/jobs/JobHierarchyView.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import { JobStateBadge } from './JobStateBadge'
 import type { JobState } from '@/hooks/use-job-events'
 
@@ -7,13 +8,19 @@ interface JobHierarchyViewProps {
   roots: JobState[]
 }
 
-function JobNode({ job, jobs, depth }: { job: JobState; jobs: JobState[]; depth: number }) {
+function JobNode({ job, jobs, depth, index }: { job: JobState; jobs: JobState[]; depth: number; index: number }) {
   // Find children whose parentCoroutineId matches this job's coroutineId
   const children = jobs.filter((j) => j.parentCoroutineId === job.coroutineId)
   const isBlocked = job.waitingForChildren.length > 0
 
   return (
-    <div className="space-y-1" data-testid="job-tree-node">
+    <motion.div
+      className="space-y-1"
+      data-testid="job-tree-node"
+      initial={{ opacity: 0, x: -15 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.3, delay: (depth * 0.1) + (index * 0.05) }}
+    >
       <div
         className="flex items-center gap-2 rounded px-2 py-1 text-xs"
         style={{ marginLeft: `${depth * 20}px` }}
@@ -41,10 +48,10 @@ function JobNode({ job, jobs, depth }: { job: JobState; jobs: JobState[]; depth:
           </Chip>
         )}
       </div>
-      {children.map((child) => (
-        <JobNode key={child.jobId} job={child} jobs={jobs} depth={depth + 1} />
+      {children.map((child, childIndex) => (
+        <JobNode key={child.jobId} job={child} jobs={jobs} depth={depth + 1} index={childIndex} />
       ))}
-    </div>
+    </motion.div>
   )
 }
 
@@ -59,8 +66,8 @@ export function JobHierarchyView({ jobs, roots }: JobHierarchyViewProps) {
 
   return (
     <div className="space-y-1" data-testid="job-hierarchy-view">
-      {roots.map((root) => (
-        <JobNode key={root.jobId} job={root} jobs={jobs} depth={0} />
+      {roots.map((root, index) => (
+        <JobNode key={root.jobId} job={root} jobs={jobs} depth={0} index={index} />
       ))}
     </div>
   )

--- a/frontend/src/components/jobs/JobPanel.tsx
+++ b/frontend/src/components/jobs/JobPanel.tsx
@@ -1,4 +1,5 @@
 import { Card, CardBody, Chip, Divider } from '@heroui/react'
+import { motion } from 'framer-motion'
 import { useJobEvents } from '@/hooks/use-job-events'
 import { JobStateBadge } from './JobStateBadge'
 import { WaitingForChildrenCard } from './WaitingForChildrenCard'
@@ -13,16 +14,22 @@ export function JobPanel({ sessionId }: JobPanelProps) {
 
   if (jobs.length === 0) {
     return (
-      <Card className="mt-2">
-        <CardBody>
-          <div className="text-center text-default-400 py-8" data-testid="jobs-empty">
-            <p className="text-lg font-semibold mb-2">No Job Activity</p>
-            <p className="text-sm">
-              Job state changes and structured concurrency events will appear here.
-            </p>
-          </div>
-        </CardBody>
-      </Card>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+      >
+        <Card className="mt-2">
+          <CardBody>
+            <div className="text-center text-default-400 py-8" data-testid="jobs-empty">
+              <p className="text-lg font-semibold mb-2">No Job Activity</p>
+              <p className="text-sm">
+                Job state changes and structured concurrency events will appear here.
+              </p>
+            </div>
+          </CardBody>
+        </Card>
+      </motion.div>
     )
   }
 
@@ -31,95 +38,114 @@ export function JobPanel({ sessionId }: JobPanelProps) {
   const cancelled = jobs.filter((j) => j.isCancelled).length
 
   return (
-    <div className="space-y-4 mt-2" data-testid="job-panel">
+    <motion.div
+      className="space-y-4 mt-2"
+      data-testid="job-panel"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
       {/* Summary */}
       <div className="grid grid-cols-4 gap-3">
-        <Card shadow="sm">
-          <CardBody className="py-3">
-            <div className="text-2xl font-bold text-primary">{jobs.length}</div>
-            <div className="text-xs text-default-500">Total Jobs</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-3">
-            <div className="text-2xl font-bold text-success">{active}</div>
-            <div className="text-xs text-default-500">Active</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-3">
-            <div className="text-2xl font-bold text-primary">{completed}</div>
-            <div className="text-xs text-default-500">Completed</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-3">
-            <div className="text-2xl font-bold text-warning">{cancelled}</div>
-            <div className="text-xs text-default-500">Cancelled</div>
-          </CardBody>
-        </Card>
+        {[
+          { value: jobs.length, label: 'Total Jobs', color: 'text-primary' },
+          { value: active, label: 'Active', color: 'text-success' },
+          { value: completed, label: 'Completed', color: 'text-primary' },
+          { value: cancelled, label: 'Cancelled', color: 'text-warning' },
+        ].map((stat, index) => (
+          <motion.div
+            key={stat.label}
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 25, delay: index * 0.1 }}
+          >
+            <Card shadow="sm">
+              <CardBody className="py-3">
+                <div className={`text-2xl font-bold ${stat.color}`}>{stat.value}</div>
+                <div className="text-xs text-default-500">{stat.label}</div>
+              </CardBody>
+            </Card>
+          </motion.div>
+        ))}
       </div>
 
       {/* WaitingForChildren cards */}
       {waitingForChildren.length > 0 && (
-        <div className="space-y-2">
+        <motion.div
+          className="space-y-2"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.4, delay: 0.2 }}
+        >
           <h3 className="text-sm font-semibold text-default-600">Structured Concurrency</h3>
           {waitingForChildren.map((evt, idx) => (
-            <WaitingForChildrenCard key={`${evt.seq}-${idx}`} event={evt} />
+            <WaitingForChildrenCard key={`${evt.seq}-${idx}`} event={evt} index={idx} />
           ))}
-        </div>
+        </motion.div>
       )}
 
       <Divider />
 
       {/* Job hierarchy */}
-      <div className="space-y-2">
+      <motion.div
+        className="space-y-2"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4, delay: 0.3 }}
+      >
         <h3 className="text-sm font-semibold text-default-600">Job Hierarchy</h3>
         <Card shadow="sm">
           <CardBody>
             <JobHierarchyView jobs={jobs} roots={roots} />
           </CardBody>
         </Card>
-      </div>
+      </motion.div>
 
       <Divider />
 
       {/* Individual job detail list */}
       <div className="space-y-2">
         <h3 className="text-sm font-semibold text-default-600">Job Details</h3>
-        {jobs.map((job) => (
-          <Card key={job.jobId} shadow="sm">
-            <CardBody>
-              <div className="flex items-center justify-between mb-2">
-                <div>
-                  <div className="font-semibold text-sm">{job.label || job.jobId}</div>
-                  <div className="text-xs text-default-500 font-mono">{job.jobId}</div>
+        {jobs.map((job, index) => (
+          <motion.div
+            key={job.jobId}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: index * 0.05 }}
+          >
+            <Card shadow="sm">
+              <CardBody>
+                <div className="flex items-center justify-between mb-2">
+                  <div>
+                    <div className="font-semibold text-sm">{job.label || job.jobId}</div>
+                    <div className="text-xs text-default-500 font-mono">{job.jobId}</div>
+                  </div>
+                  <div className="flex gap-2">
+                    <JobStateBadge status={job.status} />
+                    {job.childrenCount > 0 && (
+                      <Chip size="sm" variant="bordered" color="default">
+                        {job.childrenCount} children
+                      </Chip>
+                    )}
+                  </div>
                 </div>
-                <div className="flex gap-2">
-                  <JobStateBadge status={job.status} />
-                  {job.childrenCount > 0 && (
-                    <Chip size="sm" variant="bordered" color="default">
-                      {job.childrenCount} children
-                    </Chip>
+                <div className="grid grid-cols-2 gap-2 text-xs">
+                  <div>
+                    <span className="text-default-500">Coroutine: </span>
+                    <span className="font-mono">{job.coroutineId}</span>
+                  </div>
+                  {job.parentCoroutineId && (
+                    <div>
+                      <span className="text-default-500">Parent: </span>
+                      <span className="font-mono">{job.parentCoroutineId}</span>
+                    </div>
                   )}
                 </div>
-              </div>
-              <div className="grid grid-cols-2 gap-2 text-xs">
-                <div>
-                  <span className="text-default-500">Coroutine: </span>
-                  <span className="font-mono">{job.coroutineId}</span>
-                </div>
-                {job.parentCoroutineId && (
-                  <div>
-                    <span className="text-default-500">Parent: </span>
-                    <span className="font-mono">{job.parentCoroutineId}</span>
-                  </div>
-                )}
-              </div>
-            </CardBody>
-          </Card>
+              </CardBody>
+            </Card>
+          </motion.div>
         ))}
       </div>
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/jobs/JobStateBadge.tsx
+++ b/frontend/src/components/jobs/JobStateBadge.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import type { JobStatus } from '@/hooks/use-job-events'
 
 interface JobStateBadgeProps {
@@ -18,14 +19,39 @@ function getStatusColor(status: JobStatus): 'default' | 'primary' | 'success' | 
 }
 
 export function JobStateBadge({ status }: JobStateBadgeProps) {
+  const isActive = status === 'Active'
+
   return (
-    <Chip
-      size="sm"
-      variant="flat"
-      color={getStatusColor(status)}
-      data-testid="job-state-badge"
+    <motion.div
+      initial={{ scale: 0.8, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+      className="inline-flex"
     >
-      {status}
-    </Chip>
+      <motion.div
+        animate={
+          isActive
+            ? {
+                boxShadow: [
+                  '0 0 0 rgba(23, 201, 100, 0)',
+                  '0 0 8px rgba(23, 201, 100, 0.3)',
+                  '0 0 0 rgba(23, 201, 100, 0)',
+                ],
+              }
+            : {}
+        }
+        transition={isActive ? { duration: 1.5, repeat: Infinity } : {}}
+        className="rounded-full"
+      >
+        <Chip
+          size="sm"
+          variant="flat"
+          color={getStatusColor(status)}
+          data-testid="job-state-badge"
+        >
+          {status}
+        </Chip>
+      </motion.div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/jobs/WaitingForChildrenCard.tsx
+++ b/frontend/src/components/jobs/WaitingForChildrenCard.tsx
@@ -1,34 +1,54 @@
 import { Card, CardBody, Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import type { WaitingForChildrenEvent } from '@/types/api'
 
 interface WaitingForChildrenCardProps {
   event: WaitingForChildrenEvent
+  index?: number
 }
 
-export function WaitingForChildrenCard({ event }: WaitingForChildrenCardProps) {
+export function WaitingForChildrenCard({ event, index = 0 }: WaitingForChildrenCardProps) {
   return (
-    <Card shadow="sm" className="border border-primary/30" data-testid="waiting-for-children-card">
-      <CardBody className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Chip size="sm" variant="flat" color="primary">Waiting for Children</Chip>
-          <span className="text-xs text-default-500">
-            {event.activeChildrenCount} active child{event.activeChildrenCount !== 1 ? 'ren' : ''}
-          </span>
-        </div>
-        <div className="text-xs">
-          <span className="text-default-500">Parent: </span>
-          <span className="font-mono">{event.label || event.coroutineId}</span>
-        </div>
-        {event.activeChildrenIds.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {event.activeChildrenIds.map((childId) => (
-              <Chip key={childId} size="sm" variant="bordered" color="secondary">
-                {childId}
-              </Chip>
-            ))}
-          </div>
-        )}
-      </CardBody>
-    </Card>
+    <motion.div
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.3, delay: index * 0.05 }}
+    >
+      <motion.div
+        animate={{
+          boxShadow: [
+            '0 0 0 rgba(245, 165, 36, 0)',
+            '0 0 0 3px rgba(245, 165, 36, 0.15)',
+            '0 0 0 rgba(245, 165, 36, 0)',
+          ],
+        }}
+        transition={{ duration: 2.5, repeat: Infinity }}
+        className="rounded-xl"
+      >
+        <Card shadow="sm" className="border border-primary/30" data-testid="waiting-for-children-card">
+          <CardBody className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Chip size="sm" variant="flat" color="primary">Waiting for Children</Chip>
+              <span className="text-xs text-default-500">
+                {event.activeChildrenCount} active child{event.activeChildrenCount !== 1 ? 'ren' : ''}
+              </span>
+            </div>
+            <div className="text-xs">
+              <span className="text-default-500">Parent: </span>
+              <span className="font-mono">{event.label || event.coroutineId}</span>
+            </div>
+            {event.activeChildrenIds.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {event.activeChildrenIds.map((childId) => (
+                  <Chip key={childId} size="sm" variant="bordered" color="secondary">
+                    {childId}
+                  </Chip>
+                ))}
+              </div>
+            )}
+          </CardBody>
+        </Card>
+      </motion.div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/sync/DeadlockWarning.tsx
+++ b/frontend/src/components/sync/DeadlockWarning.tsx
@@ -1,4 +1,5 @@
 import { Card, CardBody, Chip } from '@heroui/react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { FiAlertTriangle } from 'react-icons/fi'
 import type { DeadlockDetected, PotentialDeadlockWarning } from '@/types/api'
 
@@ -12,45 +13,95 @@ export function DeadlockWarning({ deadlocks, warnings }: DeadlockWarningProps) {
 
   return (
     <div className="space-y-2" data-testid="deadlock-warning">
-      {deadlocks.map((dl, idx) => (
-        <Card key={`deadlock-${dl.seq}-${idx}`} shadow="sm" className="border-2 border-danger">
-          <CardBody className="space-y-2">
-            <div className="flex items-center gap-2">
-              <FiAlertTriangle className="text-danger" size={20} />
-              <span className="font-bold text-danger">Deadlock Detected</span>
-            </div>
-            <p className="text-xs text-default-600" data-testid="deadlock-description">
-              {dl.cycleDescription}
-            </p>
-            <div className="flex flex-wrap gap-1">
-              {dl.involvedCoroutines.map((cId, i) => (
-                <Chip key={cId} size="sm" variant="flat" color="danger">
-                  {dl.involvedCoroutineLabels[i] || cId}
-                </Chip>
-              ))}
-            </div>
-          </CardBody>
-        </Card>
-      ))}
+      <AnimatePresence mode="popLayout">
+        {deadlocks.map((dl, idx) => (
+          <motion.div
+            key={`deadlock-${dl.seq}-${idx}`}
+            initial={{ opacity: 0, x: -20, scale: 0.95 }}
+            animate={{
+              opacity: 1,
+              x: [0, -3, 3, -3, 3, 0],
+              scale: 1,
+            }}
+            exit={{ opacity: 0, x: 20 }}
+            transition={{
+              opacity: { duration: 0.3 },
+              x: { duration: 0.5, delay: 0.3 },
+              scale: { duration: 0.3 },
+            }}
+          >
+            <motion.div
+              animate={{
+                boxShadow: [
+                  '0 0 0 rgba(243, 18, 96, 0)',
+                  '0 0 15px rgba(243, 18, 96, 0.3)',
+                  '0 0 0 rgba(243, 18, 96, 0)',
+                ],
+              }}
+              transition={{ duration: 2, repeat: Infinity }}
+              className="rounded-xl"
+            >
+              <Card shadow="sm" className="border-2 border-danger">
+                <CardBody className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <FiAlertTriangle className="text-danger" size={20} />
+                    <span className="font-bold text-danger">Deadlock Detected</span>
+                  </div>
+                  <p className="text-xs text-default-600" data-testid="deadlock-description">
+                    {dl.cycleDescription}
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {dl.involvedCoroutines.map((cId, i) => (
+                      <Chip key={cId} size="sm" variant="flat" color="danger">
+                        {dl.involvedCoroutineLabels[i] || cId}
+                      </Chip>
+                    ))}
+                  </div>
+                </CardBody>
+              </Card>
+            </motion.div>
+          </motion.div>
+        ))}
 
-      {warnings.map((warn, idx) => (
-        <Card key={`warning-${warn.seq}-${idx}`} shadow="sm" className="border-2 border-warning">
-          <CardBody className="space-y-2">
-            <div className="flex items-center gap-2">
-              <FiAlertTriangle className="text-warning" size={20} />
-              <span className="font-bold text-warning">Potential Deadlock Warning</span>
-            </div>
-            <p className="text-xs text-default-600" data-testid="warning-description">
-              Coroutine <span className="font-mono">{warn.coroutineLabel || warn.coroutineId}</span>{' '}
-              holds mutex <span className="font-mono">{warn.holdingMutexLabel || warn.holdingMutex}</span>{' '}
-              while requesting <span className="font-mono">{warn.requestingMutexLabel || warn.requestingMutex}</span>.
-            </p>
-            <div className="text-xs text-default-500">
-              {warn.recommendation}
-            </div>
-          </CardBody>
-        </Card>
-      ))}
+        {warnings.map((warn, idx) => (
+          <motion.div
+            key={`warning-${warn.seq}-${idx}`}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.3, delay: idx * 0.05 }}
+          >
+            <motion.div
+              animate={{
+                boxShadow: [
+                  '0 0 0 rgba(245, 165, 36, 0)',
+                  '0 0 10px rgba(245, 165, 36, 0.2)',
+                  '0 0 0 rgba(245, 165, 36, 0)',
+                ],
+              }}
+              transition={{ duration: 2, repeat: Infinity }}
+              className="rounded-xl"
+            >
+              <Card shadow="sm" className="border-2 border-warning">
+                <CardBody className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <FiAlertTriangle className="text-warning" size={20} />
+                    <span className="font-bold text-warning">Potential Deadlock Warning</span>
+                  </div>
+                  <p className="text-xs text-default-600" data-testid="warning-description">
+                    Coroutine <span className="font-mono">{warn.coroutineLabel || warn.coroutineId}</span>{' '}
+                    holds mutex <span className="font-mono">{warn.holdingMutexLabel || warn.holdingMutex}</span>{' '}
+                    while requesting <span className="font-mono">{warn.requestingMutexLabel || warn.requestingMutex}</span>.
+                  </p>
+                  <div className="text-xs text-default-500">
+                    {warn.recommendation}
+                  </div>
+                </CardBody>
+              </Card>
+            </motion.div>
+          </motion.div>
+        ))}
+      </AnimatePresence>
     </div>
   )
 }

--- a/frontend/src/components/sync/MutexStateIndicator.tsx
+++ b/frontend/src/components/sync/MutexStateIndicator.tsx
@@ -1,4 +1,5 @@
 import { Card, CardBody, CardHeader, Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import type { MutexState } from '@/hooks/use-sync-events'
 
 interface MutexStateIndicatorProps {
@@ -7,45 +8,73 @@ interface MutexStateIndicatorProps {
 
 export function MutexStateIndicator({ mutex }: MutexStateIndicatorProps) {
   return (
-    <Card shadow="sm" data-testid="mutex-state">
-      <CardHeader className="pb-2">
-        <div className="flex w-full items-center justify-between">
-          <div>
-            <div className="font-semibold text-sm">
-              {mutex.label || mutex.mutexId}
+    <motion.div
+      animate={
+        mutex.isLocked
+          ? {
+              boxShadow: [
+                '0 0 0 0 rgba(243, 18, 96, 0)',
+                '0 0 0 4px rgba(243, 18, 96, 0.15)',
+                '0 0 0 0 rgba(243, 18, 96, 0)',
+              ],
+            }
+          : {
+              boxShadow: [
+                '0 0 0 0 rgba(23, 201, 100, 0)',
+                '0 0 0 4px rgba(23, 201, 100, 0.15)',
+                '0 0 0 0 rgba(23, 201, 100, 0)',
+              ],
+            }
+      }
+      transition={{ duration: 2, repeat: Infinity }}
+      className="rounded-xl"
+    >
+      <Card shadow="sm" data-testid="mutex-state">
+        <CardHeader className="pb-2">
+          <div className="flex w-full items-center justify-between">
+            <div>
+              <div className="font-semibold text-sm">
+                {mutex.label || mutex.mutexId}
+              </div>
+              <div className="text-xs text-default-500 font-mono">{mutex.mutexId}</div>
             </div>
-            <div className="text-xs text-default-500 font-mono">{mutex.mutexId}</div>
+            <motion.div
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+            >
+              <Chip
+                size="sm"
+                variant="flat"
+                color={mutex.isLocked ? 'danger' : 'success'}
+                data-testid="lock-status"
+              >
+                {mutex.isLocked ? 'Locked' : 'Unlocked'}
+              </Chip>
+            </motion.div>
           </div>
-          <Chip
-            size="sm"
-            variant="flat"
-            color={mutex.isLocked ? 'danger' : 'success'}
-            data-testid="lock-status"
-          >
-            {mutex.isLocked ? 'Locked' : 'Unlocked'}
-          </Chip>
-        </div>
-      </CardHeader>
-      <CardBody className="pt-0">
-        <div className="grid grid-cols-3 gap-3 text-xs">
-          <div>
-            <div className="text-default-500">Holder</div>
-            <div className="font-mono font-semibold">
-              {mutex.currentHolder
-                ? mutex.currentHolderLabel || mutex.currentHolder
-                : 'None'}
+        </CardHeader>
+        <CardBody className="pt-0">
+          <div className="grid grid-cols-3 gap-3 text-xs">
+            <div>
+              <div className="text-default-500">Holder</div>
+              <div className="font-mono font-semibold">
+                {mutex.currentHolder
+                  ? mutex.currentHolderLabel || mutex.currentHolder
+                  : 'None'}
+              </div>
+            </div>
+            <div>
+              <div className="text-default-500">Contention</div>
+              <div className="font-semibold">{mutex.contentionCount}</div>
+            </div>
+            <div>
+              <div className="text-default-500">Acquisitions</div>
+              <div className="font-semibold">{mutex.lockAcquisitions}</div>
             </div>
           </div>
-          <div>
-            <div className="text-default-500">Contention</div>
-            <div className="font-semibold">{mutex.contentionCount}</div>
-          </div>
-          <div>
-            <div className="text-default-500">Acquisitions</div>
-            <div className="font-semibold">{mutex.lockAcquisitions}</div>
-          </div>
-        </div>
-      </CardBody>
-    </Card>
+        </CardBody>
+      </Card>
+    </motion.div>
   )
 }

--- a/frontend/src/components/sync/SemaphoreGauge.tsx
+++ b/frontend/src/components/sync/SemaphoreGauge.tsx
@@ -1,4 +1,5 @@
 import { Card, CardBody, CardHeader, Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import type { SemaphoreState } from '@/hooks/use-sync-events'
 
 interface SemaphoreGaugeProps {
@@ -19,6 +20,11 @@ export function SemaphoreGauge({ semaphore }: SemaphoreGaugeProps) {
     ? (usedPermits / semaphore.totalPermits) * 100
     : 0
   const color = getGaugeColor(semaphore.availablePermits, semaphore.totalPermits)
+
+  // SVG arc calculation
+  const circumference = 2 * Math.PI * 40 // r=40
+  const dashArray = (percent / 100) * circumference
+  const dashOffset = circumference - dashArray
 
   return (
     <Card shadow="sm" data-testid="semaphore-gauge">
@@ -50,15 +56,18 @@ export function SemaphoreGauge({ semaphore }: SemaphoreGaugeProps) {
                 strokeWidth="8"
                 className="text-default-200"
               />
-              {/* Used permits arc */}
-              <circle
+              {/* Used permits arc - animated */}
+              <motion.circle
                 cx="50"
                 cy="50"
                 r="40"
                 fill="none"
                 stroke="currentColor"
                 strokeWidth="8"
-                strokeDasharray={`${percent * 2.51} ${251 - percent * 2.51}`}
+                strokeDasharray={circumference}
+                initial={{ strokeDashoffset: circumference }}
+                animate={{ strokeDashoffset: dashOffset }}
+                transition={{ duration: 0.8, ease: 'easeOut' }}
                 className={
                   color === 'danger'
                     ? 'text-danger'
@@ -70,7 +79,14 @@ export function SemaphoreGauge({ semaphore }: SemaphoreGaugeProps) {
               />
             </svg>
             <div className="absolute inset-0 flex flex-col items-center justify-center">
-              <div className="text-lg font-bold">{usedPermits}</div>
+              <motion.div
+                className="text-lg font-bold"
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ type: 'spring', stiffness: 300, damping: 25, delay: 0.3 }}
+              >
+                {usedPermits}
+              </motion.div>
               <div className="text-[10px] text-default-400">used</div>
             </div>
           </div>

--- a/frontend/src/components/sync/SyncPanel.tsx
+++ b/frontend/src/components/sync/SyncPanel.tsx
@@ -1,4 +1,5 @@
 import { Card, CardBody, Divider } from '@heroui/react'
+import { motion } from 'framer-motion'
 import { useSyncEvents } from '@/hooks/use-sync-events'
 import { MutexStateIndicator } from './MutexStateIndicator'
 import { SemaphoreGauge } from './SemaphoreGauge'
@@ -14,65 +15,99 @@ export function SyncPanel({ sessionId }: SyncPanelProps) {
 
   if (mutexes.length === 0 && semaphores.length === 0 && deadlocks.length === 0 && warnings.length === 0) {
     return (
-      <Card className="mt-2">
-        <CardBody>
-          <div className="text-center text-default-400 py-8" data-testid="sync-empty">
-            <p className="text-lg font-semibold mb-2">No Sync Primitives</p>
-            <p className="text-sm">
-              Mutex and semaphore activity will appear here when synchronization primitives are used.
-            </p>
-          </div>
-        </CardBody>
-      </Card>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+      >
+        <Card className="mt-2">
+          <CardBody>
+            <div className="text-center text-default-400 py-8" data-testid="sync-empty">
+              <p className="text-lg font-semibold mb-2">No Sync Primitives</p>
+              <p className="text-sm">
+                Mutex and semaphore activity will appear here when synchronization primitives are used.
+              </p>
+            </div>
+          </CardBody>
+        </Card>
+      </motion.div>
     )
   }
 
   return (
-    <div className="space-y-4 mt-2" data-testid="sync-panel">
+    <motion.div
+      className="space-y-4 mt-2"
+      data-testid="sync-panel"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
       {/* Deadlock warnings at top */}
       <DeadlockWarning deadlocks={deadlocks} warnings={warnings} />
 
       {/* Mutexes */}
       {mutexes.length > 0 && (
-        <div className="space-y-3">
+        <motion.div
+          className="space-y-3"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.4, delay: 0.1 }}
+        >
           <h3 className="text-sm font-semibold text-default-600">
             Mutexes ({mutexes.length})
           </h3>
-          {mutexes.map((mutex) => (
-            <div key={mutex.mutexId} className="space-y-2">
+          {mutexes.map((mutex, index) => (
+            <motion.div
+              key={mutex.mutexId}
+              className="space-y-2"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: index * 0.05 }}
+            >
               <MutexStateIndicator mutex={mutex} />
               {mutex.waitQueue.length > 0 && (
                 <div className="ml-4">
                   <WaitQueueList queue={mutex.waitQueue} title="Mutex Wait Queue" />
                 </div>
               )}
-            </div>
+            </motion.div>
           ))}
-        </div>
+        </motion.div>
       )}
 
       {mutexes.length > 0 && semaphores.length > 0 && <Divider />}
 
       {/* Semaphores */}
       {semaphores.length > 0 && (
-        <div className="space-y-3">
+        <motion.div
+          className="space-y-3"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.4, delay: 0.2 }}
+        >
           <h3 className="text-sm font-semibold text-default-600">
             Semaphores ({semaphores.length})
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {semaphores.map((sem) => (
-              <div key={sem.semaphoreId} className="space-y-2">
+            {semaphores.map((sem, index) => (
+              <motion.div
+                key={sem.semaphoreId}
+                className="space-y-2"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, delay: index * 0.05 }}
+              >
                 <SemaphoreGauge semaphore={sem} />
                 {sem.waitQueue.length > 0 && (
                   <div className="ml-4">
                     <WaitQueueList queue={sem.waitQueue} title="Semaphore Wait Queue" />
                   </div>
                 )}
-              </div>
+              </motion.div>
             ))}
           </div>
-        </div>
+        </motion.div>
       )}
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/sync/WaitQueueList.tsx
+++ b/frontend/src/components/sync/WaitQueueList.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@heroui/react'
+import { motion, AnimatePresence } from 'framer-motion'
 
 interface WaitQueueEntry {
   id: string
@@ -23,16 +24,22 @@ export function WaitQueueList({ queue, title = 'Wait Queue' }: WaitQueueListProp
     <div className="space-y-1" data-testid="wait-queue-list">
       <div className="text-xs text-default-500 font-semibold">{title} ({queue.length})</div>
       <div className="space-y-1 max-h-32 overflow-y-auto">
-        {queue.map((entry, idx) => (
-          <div
-            key={`${entry.id}-${idx}`}
-            className="flex items-center gap-2 rounded bg-default-50 px-2 py-1 text-xs"
-            data-testid="wait-queue-entry"
-          >
-            <Chip size="sm" variant="flat" color="warning">#{idx + 1}</Chip>
-            <span className="font-mono truncate">{entry.label || entry.id}</span>
-          </div>
-        ))}
+        <AnimatePresence mode="popLayout">
+          {queue.map((entry, idx) => (
+            <motion.div
+              key={`${entry.id}-${idx}`}
+              className="flex items-center gap-2 rounded bg-default-50 px-2 py-1 text-xs"
+              data-testid="wait-queue-entry"
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 10 }}
+              transition={{ duration: 0.2, delay: idx * 0.03 }}
+            >
+              <Chip size="sm" variant="flat" color="warning">#{idx + 1}</Chip>
+              <span className="font-mono truncate">{entry.label || entry.id}</span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
       </div>
     </div>
   )

--- a/frontend/src/components/validation/TimingReportView.tsx
+++ b/frontend/src/components/validation/TimingReportView.tsx
@@ -1,4 +1,5 @@
 import { Card, CardBody, Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import type { TimingReport } from '@/types/api'
 
 interface TimingReportViewProps {
@@ -22,77 +23,92 @@ export function TimingReportView({ timing }: TimingReportViewProps) {
   const maxBucketCount = Math.max(1, ...timing.suspendResumeLatencies.map((b) => b.count))
 
   return (
-    <div className="space-y-4" data-testid="timing-report">
+    <motion.div
+      className="space-y-4"
+      data-testid="timing-report"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
       {/* Key metrics */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <Card shadow="sm">
-          <CardBody className="py-2">
-            <div className="text-lg font-bold text-primary">
-              {formatNanos(timing.totalDurationNanos)}
-            </div>
-            <div className="text-xs text-default-500">Total Duration</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-2">
-            <div className="text-lg font-bold text-secondary">{timing.eventCount}</div>
-            <div className="text-xs text-default-500">Events</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-2">
-            <div className="text-lg font-bold text-success">{timing.coroutineCount}</div>
-            <div className="text-xs text-default-500">Coroutines</div>
-          </CardBody>
-        </Card>
-        <Card shadow="sm">
-          <CardBody className="py-2">
-            <div className="text-lg font-bold text-warning">
-              {formatNanos(timing.maxGapNanos)}
-            </div>
-            <div className="text-xs text-default-500">Max Gap</div>
-          </CardBody>
-        </Card>
+        {[
+          { value: formatNanos(timing.totalDurationNanos), label: 'Total Duration', color: 'text-primary' },
+          { value: timing.eventCount, label: 'Events', color: 'text-secondary' },
+          { value: timing.coroutineCount, label: 'Coroutines', color: 'text-success' },
+          { value: formatNanos(timing.maxGapNanos), label: 'Max Gap', color: 'text-warning' },
+        ].map((stat, index) => (
+          <motion.div
+            key={stat.label}
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 25, delay: index * 0.1 }}
+          >
+            <Card shadow="sm">
+              <CardBody className="py-2">
+                <div className={`text-lg font-bold ${stat.color}`}>
+                  {stat.value}
+                </div>
+                <div className="text-xs text-default-500">{stat.label}</div>
+              </CardBody>
+            </Card>
+          </motion.div>
+        ))}
       </div>
 
       {/* Average event interval */}
-      <div className="text-xs text-default-500">
+      <motion.div
+        className="text-xs text-default-500"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.3, delay: 0.4 }}
+      >
         Avg event interval: <span className="font-mono">{formatNanos(timing.avgEventIntervalNanos)}</span>
-      </div>
+      </motion.div>
 
       {/* Latency distribution - horizontal bar chart */}
       {timing.suspendResumeLatencies.length > 0 && (
-        <div className="space-y-2">
+        <motion.div
+          className="space-y-2"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.4, delay: 0.5 }}
+        >
           <div className="text-sm font-semibold text-default-600">
             Suspend/Resume Latency Distribution
           </div>
           <div className="space-y-1">
-            {timing.suspendResumeLatencies.map((bucket) => {
+            {timing.suspendResumeLatencies.map((bucket, index) => {
               const widthPercent = (bucket.count / maxBucketCount) * 100
               return (
-                <div
+                <motion.div
                   key={bucket.label}
                   className="flex items-center gap-2 text-xs"
                   data-testid="latency-bucket"
+                  initial={{ opacity: 0, x: -10 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.3, delay: 0.5 + index * 0.05 }}
                 >
                   <div className="w-24 text-right text-default-500 shrink-0 font-mono">
                     {bucket.label}
                   </div>
                   <div className="flex-1 h-4 bg-default-100 rounded overflow-hidden">
-                    <div
-                      className="h-full bg-primary rounded transition-all duration-300"
-                      style={{ width: `${widthPercent}%` }}
+                    <motion.div
+                      className="h-full bg-primary rounded"
+                      initial={{ width: 0 }}
+                      animate={{ width: `${widthPercent}%` }}
+                      transition={{ duration: 0.8, ease: 'easeOut', delay: 0.5 + index * 0.05 }}
                     />
                   </div>
                   <Chip size="sm" variant="flat" color="default" className="shrink-0">
                     {bucket.count}
                   </Chip>
-                </div>
+                </motion.div>
               )
             })}
           </div>
-        </div>
+        </motion.div>
       )}
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/validation/ValidationPanel.tsx
+++ b/frontend/src/components/validation/ValidationPanel.tsx
@@ -1,4 +1,5 @@
 import { Button, Card, CardBody, Divider } from '@heroui/react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { FiPlay } from 'react-icons/fi'
 import { useValidation } from '@/hooks/use-validation'
 import {
@@ -16,7 +17,13 @@ export function ValidationPanel({ sessionId }: ValidationPanelProps) {
   const { validate, data, isLoading, isError, error } = useValidation(sessionId)
 
   return (
-    <div className="space-y-4 mt-2" data-testid="validation-panel">
+    <motion.div
+      className="space-y-4 mt-2"
+      data-testid="validation-panel"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
       {/* Run button */}
       <Card>
         <CardBody className="flex flex-row items-center justify-between">
@@ -26,85 +33,111 @@ export function ValidationPanel({ sessionId }: ValidationPanelProps) {
               Run validation checks to detect event ordering issues, timing anomalies, and structural problems.
             </div>
           </div>
-          <Button
-            color="primary"
-            startContent={isLoading ? undefined : <FiPlay />}
-            onPress={() => validate()}
-            isLoading={isLoading}
-            data-testid="run-validation-btn"
-          >
-            {isLoading ? 'Running...' : 'Run Validation'}
-          </Button>
+          <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+            <Button
+              color="primary"
+              startContent={isLoading ? undefined : <FiPlay />}
+              onPress={() => validate()}
+              isLoading={isLoading}
+              data-testid="run-validation-btn"
+            >
+              {isLoading ? 'Running...' : 'Run Validation'}
+            </Button>
+          </motion.div>
         </CardBody>
       </Card>
 
       {/* Error state */}
-      {isError && (
-        <Card className="border border-danger/30">
-          <CardBody>
-            <div className="text-danger text-sm" data-testid="validation-error">
-              Validation failed: {error?.message || 'Unknown error'}
-            </div>
-          </CardBody>
-        </Card>
-      )}
+      <AnimatePresence>
+        {isError && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.3 }}
+          >
+            <Card className="border border-danger/30">
+              <CardBody>
+                <div className="text-danger text-sm" data-testid="validation-error">
+                  Validation failed: {error?.message || 'Unknown error'}
+                </div>
+              </CardBody>
+            </Card>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Results */}
-      {data && (
-        <>
-          {/* Summary pass/fail */}
-          <ValidationPassCard
-            valid={data.valid}
-            errorCount={data.errors.length}
-            warningCount={data.warnings.length}
-          />
+      <AnimatePresence mode="wait">
+        {data && (
+          <motion.div
+            key="results"
+            className="space-y-4"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.4 }}
+          >
+            {/* Summary pass/fail */}
+            <ValidationPassCard
+              valid={data.valid}
+              errorCount={data.errors.length}
+              warningCount={data.warnings.length}
+            />
 
-          {/* Errors */}
-          {data.errors.length > 0 && (
+            {/* Errors */}
+            {data.errors.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold text-danger">
+                  Errors ({data.errors.length})
+                </h3>
+                {data.errors.map((err, idx) => (
+                  <ValidationErrorCard key={`${err.code}-${idx}`} error={err} index={idx} />
+                ))}
+              </div>
+            )}
+
+            {/* Warnings */}
+            {data.warnings.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold text-warning">
+                  Warnings ({data.warnings.length})
+                </h3>
+                {data.warnings.map((warn, idx) => (
+                  <ValidationWarningCard key={`${warn.code}-${idx}`} warning={warn} index={idx} />
+                ))}
+              </div>
+            )}
+
+            <Divider />
+
+            {/* Timing report */}
             <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-danger">
-                Errors ({data.errors.length})
-              </h3>
-              {data.errors.map((err, idx) => (
-                <ValidationErrorCard key={`${err.code}-${idx}`} error={err} />
-              ))}
+              <h3 className="text-sm font-semibold text-default-600">Timing Report</h3>
+              <TimingReportView timing={data.timing} />
             </div>
-          )}
-
-          {/* Warnings */}
-          {data.warnings.length > 0 && (
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-warning">
-                Warnings ({data.warnings.length})
-              </h3>
-              {data.warnings.map((warn, idx) => (
-                <ValidationWarningCard key={`${warn.code}-${idx}`} warning={warn} />
-              ))}
-            </div>
-          )}
-
-          <Divider />
-
-          {/* Timing report */}
-          <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-default-600">Timing Report</h3>
-            <TimingReportView timing={data.timing} />
-          </div>
-        </>
-      )}
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* No results yet */}
       {!data && !isLoading && !isError && (
-        <Card>
-          <CardBody>
-            <div className="text-center text-default-400 py-8" data-testid="validation-empty">
-              <p className="text-sm">
-                Click "Run Validation" to analyze this session for issues.
-              </p>
-            </div>
-          </CardBody>
-        </Card>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.4, delay: 0.2 }}
+        >
+          <Card>
+            <CardBody>
+              <div className="text-center text-default-400 py-8" data-testid="validation-empty">
+                <p className="text-sm">
+                  Click "Run Validation" to analyze this session for issues.
+                </p>
+              </div>
+            </CardBody>
+          </Card>
+        </motion.div>
       )}
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/validation/ValidationResultCard.tsx
+++ b/frontend/src/components/validation/ValidationResultCard.tsx
@@ -1,59 +1,106 @@
 import { Card, CardBody, Chip } from '@heroui/react'
+import { motion } from 'framer-motion'
 import { FiCheckCircle, FiXCircle, FiAlertTriangle } from 'react-icons/fi'
 import type { ValidationError, ValidationWarning } from '@/types/api'
 
 interface ValidationErrorCardProps {
   error: ValidationError
+  index?: number
 }
 
-export function ValidationErrorCard({ error }: ValidationErrorCardProps) {
+export function ValidationErrorCard({ error, index = 0 }: ValidationErrorCardProps) {
   return (
-    <Card shadow="sm" className="border border-danger/30" data-testid="validation-error-card">
-      <CardBody className="flex flex-row items-start gap-3">
-        <FiXCircle className="text-danger shrink-0 mt-0.5" size={18} />
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <Chip size="sm" variant="flat" color="danger">{error.code}</Chip>
-          </div>
-          <p className="text-sm text-default-700">{error.message}</p>
-          {(error.eventSeq != null || error.coroutineId) && (
-            <div className="flex gap-2 text-xs text-default-400">
-              {error.eventSeq != null && <span>Event #{error.eventSeq}</span>}
-              {error.coroutineId && <span className="font-mono">{error.coroutineId}</span>}
+    <motion.div
+      initial={{ opacity: 0, x: -20, scale: 0.95 }}
+      animate={{
+        opacity: 1,
+        x: [0, -2, 2, -2, 2, 0],
+        scale: 1,
+      }}
+      transition={{
+        opacity: { duration: 0.3, delay: index * 0.05 },
+        x: { duration: 0.4, delay: 0.3 + index * 0.05 },
+        scale: { duration: 0.3, delay: index * 0.05 },
+      }}
+    >
+      <motion.div
+        animate={{
+          boxShadow: [
+            '0 0 0 rgba(243, 18, 96, 0)',
+            '0 0 8px rgba(243, 18, 96, 0.15)',
+            '0 0 0 rgba(243, 18, 96, 0)',
+          ],
+        }}
+        transition={{ duration: 2, repeat: Infinity }}
+        className="rounded-xl"
+      >
+        <Card shadow="sm" className="border border-danger/30" data-testid="validation-error-card">
+          <CardBody className="flex flex-row items-start gap-3">
+            <FiXCircle className="text-danger shrink-0 mt-0.5" size={18} />
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Chip size="sm" variant="flat" color="danger">{error.code}</Chip>
+              </div>
+              <p className="text-sm text-default-700">{error.message}</p>
+              {(error.eventSeq != null || error.coroutineId) && (
+                <div className="flex gap-2 text-xs text-default-400">
+                  {error.eventSeq != null && <span>Event #{error.eventSeq}</span>}
+                  {error.coroutineId && <span className="font-mono">{error.coroutineId}</span>}
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      </CardBody>
-    </Card>
+          </CardBody>
+        </Card>
+      </motion.div>
+    </motion.div>
   )
 }
 
 interface ValidationWarningCardProps {
   warning: ValidationWarning
+  index?: number
 }
 
-export function ValidationWarningCard({ warning }: ValidationWarningCardProps) {
+export function ValidationWarningCard({ warning, index = 0 }: ValidationWarningCardProps) {
   return (
-    <Card shadow="sm" className="border border-warning/30" data-testid="validation-warning-card">
-      <CardBody className="flex flex-row items-start gap-3">
-        <FiAlertTriangle className="text-warning shrink-0 mt-0.5" size={18} />
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <Chip size="sm" variant="flat" color="warning">{warning.code}</Chip>
-          </div>
-          <p className="text-sm text-default-700">{warning.message}</p>
-          {warning.suggestion && (
-            <p className="text-xs text-default-500">{warning.suggestion}</p>
-          )}
-          {(warning.eventSeq != null || warning.coroutineId) && (
-            <div className="flex gap-2 text-xs text-default-400">
-              {warning.eventSeq != null && <span>Event #{warning.eventSeq}</span>}
-              {warning.coroutineId && <span className="font-mono">{warning.coroutineId}</span>}
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, delay: index * 0.05 }}
+    >
+      <motion.div
+        animate={{
+          boxShadow: [
+            '0 0 0 rgba(245, 165, 36, 0)',
+            '0 0 8px rgba(245, 165, 36, 0.15)',
+            '0 0 0 rgba(245, 165, 36, 0)',
+          ],
+        }}
+        transition={{ duration: 2, repeat: Infinity }}
+        className="rounded-xl"
+      >
+        <Card shadow="sm" className="border border-warning/30" data-testid="validation-warning-card">
+          <CardBody className="flex flex-row items-start gap-3">
+            <FiAlertTriangle className="text-warning shrink-0 mt-0.5" size={18} />
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Chip size="sm" variant="flat" color="warning">{warning.code}</Chip>
+              </div>
+              <p className="text-sm text-default-700">{warning.message}</p>
+              {warning.suggestion && (
+                <p className="text-xs text-default-500">{warning.suggestion}</p>
+              )}
+              {(warning.eventSeq != null || warning.coroutineId) && (
+                <div className="flex gap-2 text-xs text-default-400">
+                  {warning.eventSeq != null && <span>Event #{warning.eventSeq}</span>}
+                  {warning.coroutineId && <span className="font-mono">{warning.coroutineId}</span>}
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      </CardBody>
-    </Card>
+          </CardBody>
+        </Card>
+      </motion.div>
+    </motion.div>
   )
 }
 
@@ -65,33 +112,61 @@ interface ValidationPassCardProps {
 
 export function ValidationPassCard({ valid, errorCount, warningCount }: ValidationPassCardProps) {
   return (
-    <Card shadow="sm" data-testid="validation-summary">
-      <CardBody className="flex flex-row items-center gap-3">
-        {valid ? (
-          <>
-            <FiCheckCircle className="text-success" size={24} />
-            <div>
-              <div className="font-semibold text-success">Validation Passed</div>
-              {warningCount > 0 && (
-                <div className="text-xs text-default-500">
-                  {warningCount} warning{warningCount !== 1 ? 's' : ''}
+    <motion.div
+      initial={{ scale: 0.9, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+    >
+      <motion.div
+        animate={
+          valid
+            ? {
+                boxShadow: [
+                  '0 0 0 rgba(23, 201, 100, 0)',
+                  '0 0 12px rgba(23, 201, 100, 0.2)',
+                  '0 0 0 rgba(23, 201, 100, 0)',
+                ],
+              }
+            : {
+                boxShadow: [
+                  '0 0 0 rgba(243, 18, 96, 0)',
+                  '0 0 12px rgba(243, 18, 96, 0.2)',
+                  '0 0 0 rgba(243, 18, 96, 0)',
+                ],
+              }
+        }
+        transition={{ duration: 2, repeat: Infinity }}
+        className="rounded-xl"
+      >
+        <Card shadow="sm" data-testid="validation-summary">
+          <CardBody className="flex flex-row items-center gap-3">
+            {valid ? (
+              <>
+                <FiCheckCircle className="text-success" size={24} />
+                <div>
+                  <div className="font-semibold text-success">Validation Passed</div>
+                  {warningCount > 0 && (
+                    <div className="text-xs text-default-500">
+                      {warningCount} warning{warningCount !== 1 ? 's' : ''}
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          </>
-        ) : (
-          <>
-            <FiXCircle className="text-danger" size={24} />
-            <div>
-              <div className="font-semibold text-danger">Validation Failed</div>
-              <div className="text-xs text-default-500">
-                {errorCount} error{errorCount !== 1 ? 's' : ''}
-                {warningCount > 0 && `, ${warningCount} warning${warningCount !== 1 ? 's' : ''}`}
-              </div>
-            </div>
-          </>
-        )}
-      </CardBody>
-    </Card>
+              </>
+            ) : (
+              <>
+                <FiXCircle className="text-danger" size={24} />
+                <div>
+                  <div className="font-semibold text-danger">Validation Failed</div>
+                  <div className="text-xs text-default-500">
+                    {errorCount} error{errorCount !== 1 ? 's' : ''}
+                    {warningCount > 0 && `, ${warningCount} warning${warningCount !== 1 ? 's' : ''}`}
+                  </div>
+                </div>
+              </>
+            )}
+          </CardBody>
+        </Card>
+      </motion.div>
+    </motion.div>
   )
 }


### PR DESCRIPTION
## Summary
- Restore Events and Threads as separate tabs (were crammed into Overview)
- Add framer-motion animations to all 5 new panel groups (17 components)
- Match animation quality of existing components (spring physics, staggered entrances, pulsing glows, AnimatePresence)

## Tab structure (before -> after)
Before: Overview (4 sections crammed), Channels, Flow, Sync, Jobs, Validation
After: Coroutines, Events, Threads, Channels, Flow, Sync, Jobs, Validation

## Animations added
- Card entry animations with staggered delays
- Spring scale for stat counters
- AnimatePresence for dynamic lists
- Pulsing glow for active/warning states
- Progress bar animations for gauges
- Shake animations for errors/deadlocks
- Cascade entrance for hierarchy views

## Test plan
- [x] pnpm test passes (80/80)
- [x] pnpm build compiles (pre-existing TS errors unrelated to this PR)
- [ ] All tabs render correctly
- [ ] Animations are smooth and consistent