### PR TITLE
feat: extract coroutine-viz-core library module

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,0 +1,52 @@
+name: CI Core Library
+
+on:
+  push:
+    branches: [main]
+    paths: ['backend/coroutine-viz-core/**']
+  pull_request:
+    branches: [main]
+    paths: ['backend/coroutine-viz-core/**']
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Grant execute permission
+        run: chmod +x gradlew
+
+      - name: Test core library
+        run: ./gradlew :coroutine-viz-core:test
+
+      - name: Generate coverage report
+        run: ./gradlew :coroutine-viz-core:jacocoTestReport
+
+      - name: Build JAR
+        run: ./gradlew :coroutine-viz-core:jar
+
+      - name: Upload coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@v4
+        with:
+          files: backend/coroutine-viz-core/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: core
+          fail_ci_if_error: false
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coroutine-viz-core
+          path: backend/coroutine-viz-core/build/libs/*.jar
+          retention-days: 14

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -16,6 +16,9 @@ application {
 }
 
 dependencies {
+    // Core library (events, wrappers, session, validation)
+    implementation(project(":coroutine-viz-core"))
+
     implementation("org.openfolder:kotlin-asyncapi-ktor:3.1.3")
     implementation("io.ktor:ktor-server-core")
     implementation("io.ktor:ktor-server-cors")

--- a/backend/coroutine-viz-core/build.gradle.kts
+++ b/backend/coroutine-viz-core/build.gradle.kts
@@ -1,0 +1,78 @@
+val kotlin_version: String by project
+
+plugins {
+    kotlin("jvm") version "2.2.20"
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.2.20"
+    id("maven-publish")
+    id("jacoco")
+}
+
+group = "com.jh.coroutine-visualizer"
+version = "0.1.0"
+
+dependencies {
+    // Core dependencies only — no Ktor, no web framework
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
+    implementation("org.slf4j:slf4j-api:2.0.9")
+
+    // Test
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    testImplementation("ch.qos.logback:logback-classic:1.4.14")
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+// Maven publishing configuration
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "com.jh.coroutine-visualizer"
+            artifactId = "coroutine-viz-core"
+            version = project.version.toString()
+
+            from(components["java"])
+
+            pom {
+                name.set("Coroutine Viz Core")
+                description.set("Core library for Kotlin coroutine visualization — events, wrappers, session management, and validation")
+                url.set("https://github.com/hermanngeorge15/visualizer-for-coroutines")
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://opensource.org/licenses/MIT")
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/hermanngeorge15/visualizer-for-coroutines")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR") ?: ""
+                password = System.getenv("GITHUB_TOKEN") ?: ""
+            }
+        }
+    }
+}
+
+// Generate sources JAR
+java {
+    withSourcesJar()
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/AntiPatternDetector.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/AntiPatternDetector.kt
@@ -1,0 +1,298 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.AntiPatternDetected
+import com.jh.proj.coroutineviz.events.AntiPatternSeverity
+import com.jh.proj.coroutineviz.events.AntiPatternType
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineFailed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import com.jh.proj.coroutineviz.events.dispatcher.DispatcherSelected
+import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
+import com.jh.proj.coroutineviz.models.RuntimeSnapshot
+
+/**
+ * Detects anti-patterns in coroutine usage by analyzing events and runtime state.
+ *
+ * Rules:
+ * - GlobalScope usage: coroutines without a structured parent scope
+ * - Blocking on Main: long operations on the main/UI dispatcher
+ * - Leaked coroutines: coroutines that outlive their expected lifecycle
+ * - Unnecessary async-await: async immediately followed by await (could be withContext)
+ * - runBlocking misuse: runBlocking called from a coroutine context
+ * - Coroutine explosion: too many coroutines created in a short window
+ */
+class AntiPatternDetector(
+    private val snapshot: RuntimeSnapshot,
+    private val recorder: EventRecorder,
+    private val sessionId: String = "",
+) {
+    companion object {
+        /** Maximum coroutines created within a 1-second window before flagging explosion. */
+        const val EXPLOSION_THRESHOLD = 100
+
+        /** Time window in nanos for explosion detection (1 second). */
+        const val EXPLOSION_WINDOW_NANOS = 1_000_000_000L
+
+        /** Maximum time in nanos a coroutine can run on Main before flagging (50ms). */
+        const val MAIN_BLOCKING_THRESHOLD_NANOS = 50_000_000L
+    }
+
+    /**
+     * Run all anti-pattern detection rules against current state and events.
+     * Returns a list of findings.
+     */
+    fun detectAll(): List<AntiPatternDetected> {
+        val findings = mutableListOf<AntiPatternDetected>()
+        findings.addAll(detectGlobalScopeUsage())
+        findings.addAll(detectBlockingOnMain())
+        findings.addAll(detectLeakedCoroutines())
+        findings.addAll(detectUnnecessaryAsyncAwait())
+        findings.addAll(detectCoroutineExplosion())
+        return findings
+    }
+
+    /**
+     * Detect coroutines that were created without a parent, suggesting GlobalScope usage.
+     */
+    fun detectGlobalScopeUsage(): List<AntiPatternDetected> {
+        val findings = mutableListOf<AntiPatternDetected>()
+
+        val created =
+            recorder.ofKind("CoroutineCreated")
+                .filterIsInstance<CoroutineCreated>()
+
+        for (event in created) {
+            if (event.parentCoroutineId == null && event.scopeId.isEmpty()) {
+                findings.add(
+                    AntiPatternDetected(
+                        sessionId = event.sessionId,
+                        seq = event.seq,
+                        tsNanos = event.tsNanos,
+                        patternType = AntiPatternType.GLOBAL_SCOPE_USAGE,
+                        severity = AntiPatternSeverity.WARNING,
+                        description =
+                            "Coroutine '${event.label ?: event.coroutineId}' was launched without a structured " +
+                                "parent scope. This may indicate GlobalScope usage.",
+                        suggestion =
+                            "Use a structured CoroutineScope (e.g., viewModelScope, lifecycleScope, or a custom " +
+                                "scope) instead of GlobalScope to ensure proper lifecycle management.",
+                        coroutineId = event.coroutineId,
+                        scopeId = event.scopeId,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+
+    /**
+     * Detect coroutines that run long operations on the Main dispatcher.
+     */
+    fun detectBlockingOnMain(): List<AntiPatternDetected> {
+        val findings = mutableListOf<AntiPatternDetected>()
+
+        val dispatchers =
+            recorder.ofKind("DispatcherSelected")
+                .filterIsInstance<DispatcherSelected>()
+
+        val threadAssignments =
+            recorder.ofKind("ThreadAssigned")
+                .filterIsInstance<ThreadAssigned>()
+
+        // Find coroutines assigned to Main dispatcher
+        val mainCoroutines =
+            dispatchers
+                .filter { it.dispatcherName.contains("Main", ignoreCase = true) }
+                .map { it.coroutineId }
+                .toSet()
+
+        for (coroutineId in mainCoroutines) {
+            val events = recorder.forCoroutine(coroutineId)
+            val started = events.filterIsInstance<CoroutineStarted>().firstOrNull()
+            val completed =
+                events.filterIsInstance<CoroutineCompleted>().firstOrNull()
+                    ?: events.filterIsInstance<CoroutineFailed>().firstOrNull()
+                    ?: events.filterIsInstance<CoroutineCancelled>().firstOrNull()
+
+            if (started != null && completed != null) {
+                val duration = completed.tsNanos - started.tsNanos
+                // Check if the coroutine ran for too long without suspending
+                val suspensions = events.filterIsInstance<CoroutineSuspended>()
+                if (suspensions.isEmpty() && duration > MAIN_BLOCKING_THRESHOLD_NANOS) {
+                    findings.add(
+                        AntiPatternDetected(
+                            sessionId = started.sessionId,
+                            seq = started.seq,
+                            tsNanos = started.tsNanos,
+                            patternType = AntiPatternType.BLOCKING_ON_MAIN,
+                            severity = AntiPatternSeverity.ERROR,
+                            description =
+                                "Coroutine '${started.label ?: coroutineId}' ran for " +
+                                    "${duration / 1_000_000}ms on the Main dispatcher without suspending.",
+                            suggestion =
+                                "Move long-running work to Dispatchers.IO or Dispatchers.Default using " +
+                                    "withContext(). Keep Main dispatcher for UI updates only.",
+                            coroutineId = coroutineId,
+                        ),
+                    )
+                }
+            }
+        }
+
+        return findings
+    }
+
+    /**
+     * Detect coroutines that appear to be leaked (started but never completed/cancelled).
+     */
+    fun detectLeakedCoroutines(): List<AntiPatternDetected> {
+        val findings = mutableListOf<AntiPatternDetected>()
+
+        val allCreated =
+            recorder.ofKind("CoroutineCreated")
+                .filterIsInstance<CoroutineCreated>()
+                .map { it.coroutineId }
+                .toSet()
+
+        val allTerminated =
+            (
+                recorder.ofKind("CoroutineCompleted").map { (it as CoroutineEvent).coroutineId } +
+                    recorder.ofKind("CoroutineCancelled").map { (it as CoroutineEvent).coroutineId } +
+                    recorder.ofKind("CoroutineFailed").map { (it as CoroutineEvent).coroutineId }
+            ).toSet()
+
+        val leaked = allCreated - allTerminated
+
+        // Check if the leaked coroutines are actually still active (not just in-progress)
+        for (coroutineId in leaked) {
+            val node = snapshot.coroutines[coroutineId]
+            // Only flag if the scope is completed but the coroutine isn't
+            if (node != null && node.state.toString() != "ACTIVE") {
+                findings.add(
+                    AntiPatternDetected(
+                        sessionId = sessionId,
+                        seq = 0,
+                        tsNanos = System.nanoTime(),
+                        patternType = AntiPatternType.LEAKED_COROUTINE,
+                        severity = AntiPatternSeverity.WARNING,
+                        description =
+                            "Coroutine '${node.label ?: coroutineId}' was created but never completed " +
+                                "or cancelled. It may be leaked.",
+                        suggestion =
+                            "Ensure all coroutines are properly cancelled when no longer needed. Use structured " +
+                                "concurrency to automatically cancel child coroutines.",
+                        coroutineId = coroutineId,
+                        affectedEntities = listOf(coroutineId),
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+
+    /**
+     * Detect unnecessary async-await patterns where withContext would be simpler.
+     * Identifies async { ... }.await() that could be withContext { ... }.
+     */
+    fun detectUnnecessaryAsyncAwait(): List<AntiPatternDetected> {
+        val findings = mutableListOf<AntiPatternDetected>()
+
+        val awaits = recorder.ofKind("DeferredAwaitStarted")
+        val created =
+            recorder.ofKind("CoroutineCreated")
+                .filterIsInstance<CoroutineCreated>()
+
+        for (await in awaits) {
+            val awaitEvent = await as? VizEvent ?: continue
+            // Look for coroutines that were created and immediately awaited
+            // by their parent (same parent coroutine creating and awaiting)
+            val coroutineId = (await as? com.jh.proj.coroutineviz.events.deferred.DeferredAwaitStarted)?.coroutineId
+            val awaiterId = (await as? com.jh.proj.coroutineviz.events.deferred.DeferredAwaitStarted)?.awaiterId
+
+            if (coroutineId != null && awaiterId != null) {
+                val createdEvent = created.find { it.coroutineId == coroutineId }
+                // If the awaiter is the parent, this is likely async { }.await()
+                if (createdEvent?.parentCoroutineId == awaiterId) {
+                    // Check if there are other coroutines between create and await
+                    val createdBetween =
+                        created.filter {
+                            it.parentCoroutineId == awaiterId &&
+                                it.seq > createdEvent.seq &&
+                                it.seq < awaitEvent.seq
+                        }
+                    if (createdBetween.isEmpty()) {
+                        findings.add(
+                            AntiPatternDetected(
+                                sessionId = awaitEvent.sessionId,
+                                seq = awaitEvent.seq,
+                                tsNanos = awaitEvent.tsNanos,
+                                patternType = AntiPatternType.UNNECESSARY_ASYNC_AWAIT,
+                                severity = AntiPatternSeverity.INFO,
+                                description =
+                                    "Coroutine '${createdEvent.label ?: coroutineId}' appears to be " +
+                                        "an async { }.await() pattern.",
+                                suggestion =
+                                    "Consider using withContext(dispatcher) { } instead of " +
+                                        "async { }.await() when you don't need concurrent execution.",
+                                coroutineId = coroutineId,
+                                affectedEntities = listOf(coroutineId, awaiterId),
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        return findings
+    }
+
+    /**
+     * Detect coroutine explosion — too many coroutines created in a short time window.
+     */
+    fun detectCoroutineExplosion(): List<AntiPatternDetected> {
+        val findings = mutableListOf<AntiPatternDetected>()
+
+        val created =
+            recorder.ofKind("CoroutineCreated")
+                .filterIsInstance<CoroutineCreated>()
+                .sortedBy { it.tsNanos }
+
+        if (created.size < EXPLOSION_THRESHOLD) return findings
+
+        // Sliding window detection
+        var windowStart = 0
+        for (windowEnd in created.indices) {
+            while (created[windowEnd].tsNanos - created[windowStart].tsNanos > EXPLOSION_WINDOW_NANOS) {
+                windowStart++
+            }
+            val count = windowEnd - windowStart + 1
+            if (count >= EXPLOSION_THRESHOLD) {
+                val sessionId = created[windowEnd].sessionId
+                findings.add(
+                    AntiPatternDetected(
+                        sessionId = sessionId,
+                        seq = created[windowEnd].seq,
+                        tsNanos = created[windowEnd].tsNanos,
+                        patternType = AntiPatternType.COROUTINE_EXPLOSION,
+                        severity = AntiPatternSeverity.WARNING,
+                        description = "$count coroutines created within 1 second. This may indicate unbounded coroutine creation.",
+                        suggestion =
+                            "Consider using a bounded mechanism like a Semaphore, Channel, or " +
+                                "Flow.flatMapMerge(concurrency) to limit concurrent coroutines.",
+                        affectedEntities = created.subList(windowStart, windowEnd + 1).map { it.coroutineId },
+                    ),
+                )
+                break // Report once per window
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/EventRecorder.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/EventRecorder.kt
@@ -1,0 +1,36 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+
+class EventRecorder {
+    private val events = mutableListOf<VizEvent>()
+    private val eventsByCoroutine = mutableMapOf<String, MutableList<VizEvent>>()
+    private val eventsByKind = mutableMapOf<String, MutableList<VizEvent>>()
+
+    fun record(event: VizEvent) {
+        events.add(event)
+
+        if (event is CoroutineEvent) {
+            eventsByCoroutine.getOrPut(event.coroutineId) { mutableListOf() }
+                .add(event)
+        }
+
+        eventsByKind.getOrPut(event.kind, { mutableListOf() }).add(event)
+    }
+
+    fun all(): List<VizEvent> {
+        return events.toList()
+    }
+
+    fun forCoroutine(coroutineId: String): List<VizEvent> = eventsByCoroutine.getOrElse(coroutineId, { emptyList() })
+
+    fun ofKind(kind: String): List<VizEvent> = eventsByKind.getOrElse(kind, { emptyList() })
+
+    fun inTimeRange(
+        startTime: Long,
+        endTime: Long,
+    ): List<VizEvent> {
+        return events.filter { it.tsNanos in startTime..endTime }
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/EventSelector.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/EventSelector.kt
@@ -1,0 +1,39 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+
+/**
+ * Utility extension functions for filtering event lists.
+ *
+ * Provides convenient, type-safe ways to select subsets of events
+ * by type, coroutine ID, or sequence number range.
+ *
+ * Filter events to only those of a specific type [T].
+ *
+ * Usage: `events.ofType<CoroutineCreated>()`
+ */
+inline fun <reified T : VizEvent> List<VizEvent>.ofType(): List<T> {
+    return filterIsInstance<T>()
+}
+
+/**
+ * Filter events to only those belonging to a specific coroutine.
+ *
+ * Only [CoroutineEvent] instances are checked; non-coroutine events are excluded.
+ */
+fun List<VizEvent>.forCoroutine(id: String): List<VizEvent> {
+    return filter { event ->
+        event is CoroutineEvent && event.coroutineId == id
+    }
+}
+
+/**
+ * Filter events to only those within a sequence number range (inclusive).
+ */
+fun List<VizEvent>.inSequenceRange(
+    from: Long,
+    to: Long,
+): List<VizEvent> {
+    return filter { it.seq in from..to }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/HierarchyValidator.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/HierarchyValidator.kt
@@ -1,0 +1,151 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+
+/**
+ * Validates parent-child relationships in the coroutine hierarchy.
+ *
+ * Rules enforced:
+ * - Children must be created after their parent is created
+ * - Parent must not complete before all of its children (structured concurrency)
+ */
+object HierarchyValidator {
+    private val TERMINAL_KINDS = setOf("CoroutineCompleted", "CoroutineCancelled", "CoroutineFailed")
+
+    /**
+     * Run all hierarchy validation rules against the given event list.
+     *
+     * @param events Full event stream (may contain events for multiple coroutines)
+     * @return List of [ValidationResult] -- one per rule per parent-child pair
+     */
+    fun validate(events: List<VizEvent>): List<ValidationResult> {
+        val results = mutableListOf<ValidationResult>()
+
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+
+        // Build parent-child relationships from CoroutineCreated events
+        val createEvents = coroutineEvents.filterIsInstance<CoroutineCreated>()
+
+        if (createEvents.isEmpty()) {
+            results +=
+                ValidationResult.Pass(
+                    "HierarchyValidation",
+                    "No coroutine creation events to validate",
+                )
+            return results
+        }
+
+        for (childCreated in createEvents) {
+            val parentId = childCreated.parentCoroutineId ?: continue
+
+            results += checkChildCreatedWithinParentScope(childCreated, parentId, byCoroutine)
+            results += checkParentNotCompletedBeforeChildren(childCreated, parentId, byCoroutine)
+        }
+
+        if (results.isEmpty()) {
+            results +=
+                ValidationResult.Pass(
+                    "HierarchyValidation",
+                    "No parent-child relationships to validate (all coroutines are roots)",
+                )
+        }
+
+        return results
+    }
+
+    private fun checkChildCreatedWithinParentScope(
+        childCreated: CoroutineCreated,
+        parentId: String,
+        byCoroutine: Map<String, List<CoroutineEvent>>,
+    ): ValidationResult {
+        val ruleName = "ChildCreatedWithinParentScope"
+        val parentEvents = byCoroutine[parentId]
+
+        if (parentEvents == null) {
+            return ValidationResult.Fail(
+                ruleName,
+                "Child ${childCreated.coroutineId} references non-existent parent $parentId",
+                "CoroutineCreated at seq=${childCreated.seq} references parentCoroutineId=$parentId " +
+                    "but no events exist for that coroutine",
+            )
+        }
+
+        val parentCreated = parentEvents.filterIsInstance<CoroutineCreated>().firstOrNull()
+        return if (parentCreated == null) {
+            ValidationResult.Fail(
+                ruleName,
+                "Parent $parentId has no CoroutineCreated event",
+                "Child ${childCreated.coroutineId} references parent $parentId which has events " +
+                    "but no CoroutineCreated",
+            )
+        } else if (childCreated.seq > parentCreated.seq) {
+            ValidationResult.Pass(
+                ruleName,
+                "Child ${childCreated.coroutineId} created (seq=${childCreated.seq}) " +
+                    "after parent $parentId (seq=${parentCreated.seq})",
+            )
+        } else {
+            ValidationResult.Fail(
+                ruleName,
+                "Child ${childCreated.coroutineId} created before parent $parentId",
+                "Child created at seq=${childCreated.seq} but parent created at seq=${parentCreated.seq}",
+            )
+        }
+    }
+
+    private fun checkParentNotCompletedBeforeChildren(
+        childCreated: CoroutineCreated,
+        parentId: String,
+        byCoroutine: Map<String, List<CoroutineEvent>>,
+    ): ValidationResult {
+        val ruleName = "ParentNotCompletedBeforeChildren"
+        val parentEvents =
+            byCoroutine[parentId] ?: return ValidationResult.Pass(
+                ruleName,
+                "Parent $parentId has no events (skipped)",
+            )
+
+        val childEvents =
+            byCoroutine[childCreated.coroutineId] ?: return ValidationResult.Pass(
+                ruleName,
+                "Child ${childCreated.coroutineId} has no events beyond creation (skipped)",
+            )
+
+        val parentCompleted =
+            parentEvents
+                .firstOrNull { it is CoroutineCompleted }
+                ?: return ValidationResult.Pass(
+                    ruleName,
+                    "Parent $parentId has not completed (skipped)",
+                )
+
+        val childTerminal =
+            childEvents
+                .firstOrNull { it.kind in TERMINAL_KINDS }
+
+        return if (childTerminal == null) {
+            // Child hasn't terminated -- if parent completed that's a problem
+            ValidationResult.Fail(
+                ruleName,
+                "Parent $parentId completed before child ${childCreated.coroutineId} terminated",
+                "Parent completed at seq=${parentCompleted.seq} but child has no terminal event",
+            )
+        } else if (parentCompleted.seq >= childTerminal.seq) {
+            ValidationResult.Pass(
+                ruleName,
+                "Parent $parentId (completed seq=${parentCompleted.seq}) " +
+                    "waited for child ${childCreated.coroutineId} (terminal seq=${childTerminal.seq})",
+            )
+        } else {
+            ValidationResult.Fail(
+                ruleName,
+                "Parent $parentId completed before child ${childCreated.coroutineId}",
+                "Parent completed at seq=${parentCompleted.seq} but child terminated at seq=${childTerminal.seq}",
+            )
+        }
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/LifecycleValidator.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/LifecycleValidator.kt
@@ -1,0 +1,128 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+
+/**
+ * Validates coroutine lifecycle correctness across an event stream.
+ *
+ * Rules enforced:
+ * - Every [CoroutineCreated] must have a matching [CoroutineStarted]
+ * - Every started coroutine must reach a terminal state (Completed, Cancelled, or Failed)
+ * - No events should appear for a coroutine after its terminal event
+ */
+object LifecycleValidator {
+    private val TERMINAL_KINDS = setOf("CoroutineCompleted", "CoroutineCancelled", "CoroutineFailed")
+
+    /**
+     * Run all lifecycle validation rules against the given event list.
+     *
+     * @param events Full event stream (may contain events for multiple coroutines)
+     * @return List of [ValidationResult] -- one per rule per coroutine
+     */
+    fun validate(events: List<VizEvent>): List<ValidationResult> {
+        val results = mutableListOf<ValidationResult>()
+
+        // Group coroutine events by coroutine ID
+        val byCoroutine =
+            events
+                .filterIsInstance<CoroutineEvent>()
+                .groupBy { it.coroutineId }
+
+        for ((coroutineId, coroutineEvents) in byCoroutine) {
+            val sorted = coroutineEvents.sortedBy { it.seq }
+            results += checkCreatedHasStarted(coroutineId, sorted)
+            results += checkStartedHasTerminal(coroutineId, sorted)
+            results += checkNoEventsAfterTerminal(coroutineId, sorted)
+        }
+
+        if (byCoroutine.isEmpty()) {
+            results +=
+                ValidationResult.Pass(
+                    "LifecycleValidation",
+                    "No coroutine events to validate",
+                )
+        }
+
+        return results
+    }
+
+    private fun checkCreatedHasStarted(
+        coroutineId: String,
+        events: List<CoroutineEvent>,
+    ): ValidationResult {
+        val ruleName = "CreatedHasStarted"
+        val hasCreated = events.any { it is CoroutineCreated }
+        val hasStarted = events.any { it is CoroutineStarted }
+
+        return if (!hasCreated) {
+            ValidationResult.Pass(ruleName, "Coroutine $coroutineId has no Created event (skipped)")
+        } else if (hasStarted) {
+            ValidationResult.Pass(ruleName, "Coroutine $coroutineId: Created is followed by Started")
+        } else {
+            ValidationResult.Fail(
+                ruleName,
+                "Coroutine $coroutineId was created but never started",
+                "CoroutineCreated found at seq=${events.first { it is CoroutineCreated }.seq} " +
+                    "but no matching CoroutineStarted exists",
+            )
+        }
+    }
+
+    private fun checkStartedHasTerminal(
+        coroutineId: String,
+        events: List<CoroutineEvent>,
+    ): ValidationResult {
+        val ruleName = "StartedHasTerminal"
+        val hasStarted = events.any { it is CoroutineStarted }
+        val hasTerminal = events.any { it.kind in TERMINAL_KINDS }
+
+        return if (!hasStarted) {
+            ValidationResult.Pass(ruleName, "Coroutine $coroutineId not started (skipped)")
+        } else if (hasTerminal) {
+            val terminalKind = events.first { it.kind in TERMINAL_KINDS }.kind
+            ValidationResult.Pass(
+                ruleName,
+                "Coroutine $coroutineId: Started coroutine reached terminal state ($terminalKind)",
+            )
+        } else {
+            ValidationResult.Fail(
+                ruleName,
+                "Coroutine $coroutineId was started but never terminated",
+                "CoroutineStarted found but no terminal event " +
+                    "(CoroutineCompleted, CoroutineCancelled, or CoroutineFailed) exists",
+            )
+        }
+    }
+
+    private fun checkNoEventsAfterTerminal(
+        coroutineId: String,
+        events: List<CoroutineEvent>,
+    ): ValidationResult {
+        val ruleName = "NoEventsAfterTerminal"
+        val terminalEvent =
+            events.firstOrNull { it.kind in TERMINAL_KINDS }
+                ?: return ValidationResult.Pass(
+                    ruleName,
+                    "Coroutine $coroutineId has no terminal event (skipped)",
+                )
+
+        val eventsAfterTerminal = events.filter { it.seq > terminalEvent.seq }
+
+        return if (eventsAfterTerminal.isEmpty()) {
+            ValidationResult.Pass(
+                ruleName,
+                "Coroutine $coroutineId: No events after terminal event (${terminalEvent.kind})",
+            )
+        } else {
+            ValidationResult.Fail(
+                ruleName,
+                "Coroutine $coroutineId has ${eventsAfterTerminal.size} event(s) after terminal state",
+                "Terminal event ${terminalEvent.kind} at seq=${terminalEvent.seq}, " +
+                    "but found: ${eventsAfterTerminal.map { "${it.kind}@seq=${it.seq}" }}",
+            )
+        }
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/SequenceChecker.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/SequenceChecker.kt
@@ -1,0 +1,91 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.VizEvent
+
+/**
+ * Validates event ordering and sequence number integrity.
+ *
+ * Checks that events appear in the expected order and that
+ * sequence numbers are unique across the event stream.
+ */
+object SequenceChecker {
+    /**
+     * Check that event types appear in the expected order within the event list.
+     *
+     * This does not require the events to be strictly contiguous -- other event
+     * types may appear between the expected ones. It only verifies that the
+     * relative order of the specified kinds is preserved.
+     *
+     * @param events The event list to check (should be sorted by sequence number)
+     * @param expectedSequence List of event kind strings in expected order
+     * @return [ValidationResult.Pass] if order is correct, [ValidationResult.Fail] otherwise
+     */
+    fun checkOrdering(
+        events: List<VizEvent>,
+        expectedSequence: List<String>,
+    ): ValidationResult {
+        val ruleName = "EventOrdering"
+
+        if (expectedSequence.isEmpty()) {
+            return ValidationResult.Pass(ruleName, "Empty expected sequence, nothing to check")
+        }
+
+        val sortedEvents = events.sortedBy { it.seq }
+        var expectedIndex = 0
+
+        for (event in sortedEvents) {
+            if (expectedIndex < expectedSequence.size && event.kind == expectedSequence[expectedIndex]) {
+                expectedIndex++
+            }
+        }
+
+        return if (expectedIndex == expectedSequence.size) {
+            ValidationResult.Pass(
+                ruleName,
+                "All ${expectedSequence.size} expected event types found in correct order",
+            )
+        } else {
+            val missing = expectedSequence.subList(expectedIndex, expectedSequence.size)
+            ValidationResult.Fail(
+                ruleName,
+                "Event ordering violation",
+                "Expected event types not found in order. " +
+                    "Matched $expectedIndex/${expectedSequence.size}. " +
+                    "Missing or out-of-order: $missing",
+            )
+        }
+    }
+
+    /**
+     * Check that no two events share the same sequence number.
+     *
+     * Duplicate sequence numbers indicate a bug in the event emission logic,
+     * as each event should have a globally unique sequence number within a session.
+     *
+     * @param events The event list to check
+     * @return [ValidationResult.Pass] if all sequence numbers are unique,
+     *         [ValidationResult.Fail] if duplicates are found
+     */
+    fun checkNoDuplicateSequenceNumbers(events: List<VizEvent>): ValidationResult {
+        val ruleName = "NoDuplicateSequenceNumbers"
+
+        val seqCounts = events.groupBy { it.seq }.filter { it.value.size > 1 }
+
+        return if (seqCounts.isEmpty()) {
+            ValidationResult.Pass(
+                ruleName,
+                "All ${events.size} events have unique sequence numbers",
+            )
+        } else {
+            val duplicates =
+                seqCounts.map { (seq, evts) ->
+                    "seq=$seq appears ${evts.size} times (kinds: ${evts.map { it.kind }})"
+                }
+            ValidationResult.Fail(
+                ruleName,
+                "Duplicate sequence numbers detected",
+                "Found ${seqCounts.size} duplicate sequence number(s): ${duplicates.joinToString("; ")}",
+            )
+        }
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/StructuredConcurrencyValidator.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/StructuredConcurrencyValidator.kt
@@ -1,0 +1,165 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineFailed
+
+/**
+ * Validates structured concurrency rules across an event stream.
+ *
+ * Rules enforced:
+ * - Parent cancellation should cause children to be cancelled
+ * - Child failure should propagate to parent (unless SupervisorJob)
+ */
+object StructuredConcurrencyValidator {
+    /**
+     * Run all structured concurrency validation rules against the given event list.
+     *
+     * @param events Full event stream (may contain events for multiple coroutines)
+     * @return List of [ValidationResult] -- one per rule per relevant relationship
+     */
+    fun validate(events: List<VizEvent>): List<ValidationResult> {
+        val results = mutableListOf<ValidationResult>()
+
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+
+        // Build parent -> children map
+        val parentToChildren = mutableMapOf<String, MutableList<String>>()
+        val createEvents = coroutineEvents.filterIsInstance<CoroutineCreated>()
+
+        for (created in createEvents) {
+            val parentId = created.parentCoroutineId ?: continue
+            parentToChildren.getOrPut(parentId) { mutableListOf() }.add(created.coroutineId)
+        }
+
+        if (parentToChildren.isEmpty()) {
+            results +=
+                ValidationResult.Pass(
+                    "StructuredConcurrency",
+                    "No parent-child relationships to validate",
+                )
+            return results
+        }
+
+        results += checkParentCancellationPropagation(byCoroutine, parentToChildren)
+        results += checkChildFailurePropagation(byCoroutine, parentToChildren)
+
+        return results
+    }
+
+    private fun checkParentCancellationPropagation(
+        byCoroutine: Map<String, List<CoroutineEvent>>,
+        parentToChildren: Map<String, List<String>>,
+    ): List<ValidationResult> {
+        val results = mutableListOf<ValidationResult>()
+        val ruleName = "ParentCancellationPropagation"
+
+        for ((parentId, childIds) in parentToChildren) {
+            val parentEvents = byCoroutine[parentId] ?: continue
+            val parentCancelled = parentEvents.firstOrNull { it is CoroutineCancelled } ?: continue
+
+            for (childId in childIds) {
+                val childEvents = byCoroutine[childId] ?: continue
+                val childCancelled = childEvents.firstOrNull { it is CoroutineCancelled }
+                val childFailed = childEvents.firstOrNull { it is CoroutineFailed }
+
+                // Child should be cancelled or failed (failure could trigger the parent cancel)
+                if (childCancelled != null || childFailed != null) {
+                    results +=
+                        ValidationResult.Pass(
+                            ruleName,
+                            "Parent $parentId cancelled -> child $childId also terminated",
+                        )
+                } else {
+                    // Check if child completed before parent was cancelled (which is fine)
+                    val childTerminal =
+                        childEvents.firstOrNull {
+                            it.kind in setOf("CoroutineCompleted", "CoroutineCancelled", "CoroutineFailed")
+                        }
+
+                    if (childTerminal != null && childTerminal.seq < parentCancelled.seq) {
+                        results +=
+                            ValidationResult.Pass(
+                                ruleName,
+                                "Child $childId completed (seq=${childTerminal.seq}) before parent " +
+                                    "$parentId cancelled (seq=${parentCancelled.seq})",
+                            )
+                    } else {
+                        results +=
+                            ValidationResult.Fail(
+                                ruleName,
+                                "Parent $parentId cancelled but child $childId was not cancelled",
+                                "Parent cancelled at seq=${parentCancelled.seq} but child $childId " +
+                                    "has no cancellation or failure event",
+                            )
+                    }
+                }
+            }
+        }
+
+        if (results.isEmpty()) {
+            results += ValidationResult.Pass(ruleName, "No parent cancellations to validate")
+        }
+
+        return results
+    }
+
+    private fun checkChildFailurePropagation(
+        byCoroutine: Map<String, List<CoroutineEvent>>,
+        parentToChildren: Map<String, List<String>>,
+    ): List<ValidationResult> {
+        val results = mutableListOf<ValidationResult>()
+        val ruleName = "ChildFailurePropagation"
+
+        for ((parentId, childIds) in parentToChildren) {
+            val parentEvents = byCoroutine[parentId] ?: continue
+
+            for (childId in childIds) {
+                val childEvents = byCoroutine[childId] ?: continue
+                val childFailed = childEvents.firstOrNull { it is CoroutineFailed } ?: continue
+
+                // Child failed -- parent should eventually be cancelled or failed
+                // (unless using SupervisorJob)
+                val parentTerminal =
+                    parentEvents.firstOrNull {
+                        it.kind in setOf("CoroutineCancelled", "CoroutineFailed")
+                    }
+
+                if (parentTerminal != null) {
+                    results +=
+                        ValidationResult.Pass(
+                            ruleName,
+                            "Child $childId failed -> parent $parentId also terminated (${parentTerminal.kind})",
+                        )
+                } else {
+                    // Parent may have completed normally if it's a SupervisorJob
+                    val parentCompleted = parentEvents.firstOrNull { it.kind == "CoroutineCompleted" }
+                    if (parentCompleted != null) {
+                        results +=
+                            ValidationResult.Pass(
+                                ruleName,
+                                "Child $childId failed but parent $parentId completed (likely SupervisorJob)",
+                            )
+                    } else {
+                        results +=
+                            ValidationResult.Fail(
+                                ruleName,
+                                "Child $childId failed but parent $parentId did not terminate",
+                                "Child failed at seq=${childFailed.seq} but parent $parentId " +
+                                    "has no terminal event (expected cancellation or failure propagation)",
+                            )
+                    }
+                }
+            }
+        }
+
+        if (results.isEmpty()) {
+            results += ValidationResult.Pass(ruleName, "No child failures to validate")
+        }
+
+        return results
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/SyncValidators.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/SyncValidators.kt
@@ -1,0 +1,307 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.DeadlockDetected
+import com.jh.proj.coroutineviz.events.MutexEvent
+import com.jh.proj.coroutineviz.events.MutexLockAcquired
+import com.jh.proj.coroutineviz.events.MutexLockRequested
+import com.jh.proj.coroutineviz.events.MutexUnlocked
+import com.jh.proj.coroutineviz.events.SemaphorePermitAcquired
+import com.jh.proj.coroutineviz.events.SemaphorePermitReleased
+import com.jh.proj.coroutineviz.events.SemaphoreStateChanged
+
+/**
+ * Validator for Mutex synchronization patterns.
+ *
+ * Provides assertions for:
+ * - Mutual exclusion verification
+ * - No deadlock conditions
+ * - Fairness (FIFO ordering)
+ * - Lock/unlock pairing
+ */
+class MutexValidator(private val recorder: EventRecorder) {
+    /**
+     * Verify that no deadlocks were detected during execution
+     */
+    fun verifyNoDeadlock() {
+        val deadlocks = recorder.ofKind("DeadlockDetected")
+        if (deadlocks.isNotEmpty()) {
+            val deadlock = deadlocks.first() as DeadlockDetected
+            throw AssertionError(
+                "Deadlock detected involving coroutines: ${deadlock.involvedCoroutines}\n" +
+                    "Cycle: ${deadlock.cycleDescription}",
+            )
+        }
+    }
+
+    /**
+     * Verify that only one coroutine held the mutex at any time
+     */
+    fun verifyMutualExclusion(mutexId: String) {
+        val events =
+            recorder.all().filter {
+                it is MutexEvent && (it as MutexEvent).mutexId == mutexId
+            }
+
+        var currentHolder: String? = null
+
+        for (event in events) {
+            when (event) {
+                is MutexLockAcquired -> {
+                    if (currentHolder != null) {
+                        throw AssertionError(
+                            "Mutex $mutexId held by $currentHolder when ${event.acquirerId} acquired it",
+                        )
+                    }
+                    currentHolder = event.acquirerId
+                }
+                is MutexUnlocked -> {
+                    if (currentHolder != event.releaserId) {
+                        throw AssertionError(
+                            "Mutex $mutexId released by ${event.releaserId} but held by $currentHolder",
+                        )
+                    }
+                    currentHolder = null
+                }
+                else -> {}
+            }
+        }
+    }
+
+    /**
+     * Verify FIFO ordering for queued lock requests
+     */
+    fun verifyFairness(mutexId: String) {
+        val requests =
+            recorder.ofKind("MutexLockRequested")
+                .filterIsInstance<MutexLockRequested>()
+                .filter { it.mutexId == mutexId && it.queuePosition > 0 }
+                .sortedBy { it.seq }
+
+        val acquisitions =
+            recorder.ofKind("MutexLockAcquired")
+                .filterIsInstance<MutexLockAcquired>()
+                .filter { it.mutexId == mutexId && it.waitDurationNanos > 0 }
+                .sortedBy { it.seq }
+
+        // The acquisition order should match request order for queued requests
+        val requestOrder = requests.map { it.requesterId }
+        val acquisitionOrder = acquisitions.map { it.acquirerId }
+
+        for (i in requestOrder.indices) {
+            if (i < acquisitionOrder.size && requestOrder[i] != acquisitionOrder[i]) {
+                throw AssertionError(
+                    "Mutex $mutexId fairness violation: " +
+                        "Request order: $requestOrder, Acquisition order: $acquisitionOrder",
+                )
+            }
+        }
+    }
+
+    /**
+     * Verify all locks are eventually unlocked
+     */
+    fun verifyNoLockLeaks(mutexId: String) {
+        val acquireCount =
+            recorder.ofKind("MutexLockAcquired")
+                .filterIsInstance<MutexLockAcquired>()
+                .count { it.mutexId == mutexId }
+
+        val releaseCount =
+            recorder.ofKind("MutexUnlocked")
+                .filterIsInstance<MutexUnlocked>()
+                .count { it.mutexId == mutexId }
+
+        if (acquireCount != releaseCount) {
+            throw AssertionError(
+                "Mutex $mutexId lock leak: $acquireCount acquires but only $releaseCount releases",
+            )
+        }
+    }
+
+    /**
+     * Get contention statistics for a mutex
+     */
+    fun getContentionStats(mutexId: String): MutexContentionStats {
+        val requests =
+            recorder.ofKind("MutexLockRequested")
+                .filterIsInstance<MutexLockRequested>()
+                .filter { it.mutexId == mutexId }
+
+        val acquisitions =
+            recorder.ofKind("MutexLockAcquired")
+                .filterIsInstance<MutexLockAcquired>()
+                .filter { it.mutexId == mutexId }
+
+        val unlocks =
+            recorder.ofKind("MutexUnlocked")
+                .filterIsInstance<MutexUnlocked>()
+                .filter { it.mutexId == mutexId }
+
+        val contentionRequests = requests.count { it.isLocked }
+        val waitTimes = acquisitions.map { it.waitDurationNanos }
+        val holdTimes = unlocks.map { it.holdDurationNanos }
+
+        return MutexContentionStats(
+            totalRequests = requests.size,
+            contentionRequests = contentionRequests,
+            contentionRate = if (requests.isNotEmpty()) contentionRequests.toDouble() / requests.size else 0.0,
+            avgWaitTimeNanos = waitTimes.average().takeIf { !it.isNaN() } ?: 0.0,
+            maxWaitTimeNanos = waitTimes.maxOrNull() ?: 0,
+            avgHoldTimeNanos = holdTimes.average().takeIf { !it.isNaN() } ?: 0.0,
+            maxHoldTimeNanos = holdTimes.maxOrNull() ?: 0,
+        )
+    }
+}
+
+data class MutexContentionStats(
+    val totalRequests: Int,
+    val contentionRequests: Int,
+    val contentionRate: Double,
+    val avgWaitTimeNanos: Double,
+    val maxWaitTimeNanos: Long,
+    val avgHoldTimeNanos: Double,
+    val maxHoldTimeNanos: Long,
+)
+
+/**
+ * Validator for Semaphore synchronization patterns.
+ *
+ * Provides assertions for:
+ * - Permit bound verification
+ * - No permit leaks
+ * - Utilization metrics
+ */
+class SemaphoreValidator(private val recorder: EventRecorder) {
+    /**
+     * Verify the semaphore never exceeds its permit limit
+     */
+    fun verifyPermitBounds(
+        semaphoreId: String,
+        maxPermits: Int,
+    ) {
+        val stateChanges =
+            recorder.ofKind("SemaphoreStateChanged")
+                .filterIsInstance<SemaphoreStateChanged>()
+                .filter { it.semaphoreId == semaphoreId }
+
+        for (state in stateChanges) {
+            if (state.activeHolders.size > maxPermits) {
+                throw AssertionError(
+                    "Semaphore $semaphoreId permit limit exceeded: " +
+                        "${state.activeHolders.size} holders but only $maxPermits permits",
+                )
+            }
+            if (state.availablePermits < 0) {
+                throw AssertionError(
+                    "Semaphore $semaphoreId has negative permits: ${state.availablePermits}",
+                )
+            }
+            if (state.availablePermits > state.totalPermits) {
+                throw AssertionError(
+                    "Semaphore $semaphoreId has more permits than total: " +
+                        "${state.availablePermits} > ${state.totalPermits}",
+                )
+            }
+        }
+    }
+
+    /**
+     * Verify all permits are eventually released
+     */
+    fun verifyNoPermitLeaks(
+        semaphoreId: String,
+        totalPermits: Int,
+    ) {
+        val finalState =
+            recorder.ofKind("SemaphoreStateChanged")
+                .filterIsInstance<SemaphoreStateChanged>()
+                .filter { it.semaphoreId == semaphoreId }
+                .lastOrNull()
+
+        if (finalState != null && finalState.availablePermits != totalPermits) {
+            throw AssertionError(
+                "Semaphore $semaphoreId permit leak: " +
+                    "only ${finalState.availablePermits}/$totalPermits permits available at end",
+            )
+        }
+    }
+
+    /**
+     * Verify acquire/release counts match
+     */
+    fun verifyBalancedOperations(semaphoreId: String) {
+        val acquireCount =
+            recorder.ofKind("SemaphorePermitAcquired")
+                .filterIsInstance<SemaphorePermitAcquired>()
+                .count { it.semaphoreId == semaphoreId }
+
+        val releaseCount =
+            recorder.ofKind("SemaphorePermitReleased")
+                .filterIsInstance<SemaphorePermitReleased>()
+                .count { it.semaphoreId == semaphoreId }
+
+        if (acquireCount != releaseCount) {
+            throw AssertionError(
+                "Semaphore $semaphoreId unbalanced operations: " +
+                    "$acquireCount acquires but $releaseCount releases",
+            )
+        }
+    }
+
+    /**
+     * Get utilization statistics for a semaphore
+     */
+    fun getUtilizationStats(semaphoreId: String): SemaphoreUtilizationStats {
+        val stateChanges =
+            recorder.ofKind("SemaphoreStateChanged")
+                .filterIsInstance<SemaphoreStateChanged>()
+                .filter { it.semaphoreId == semaphoreId }
+
+        val acquires =
+            recorder.ofKind("SemaphorePermitAcquired")
+                .filterIsInstance<SemaphorePermitAcquired>()
+                .filter { it.semaphoreId == semaphoreId }
+
+        val releases =
+            recorder.ofKind("SemaphorePermitReleased")
+                .filterIsInstance<SemaphorePermitReleased>()
+                .filter { it.semaphoreId == semaphoreId }
+
+        val utilizationSamples =
+            stateChanges.map { state ->
+                (state.totalPermits - state.availablePermits).toDouble() / state.totalPermits
+            }
+
+        val waitTimes = acquires.map { it.waitDurationNanos }
+        val holdTimes = releases.map { it.holdDurationNanos }
+
+        val maxConcurrent = stateChanges.maxOfOrNull { it.activeHolders.size } ?: 0
+        val maxWaiting = stateChanges.maxOfOrNull { it.waitingCoroutines.size } ?: 0
+
+        return SemaphoreUtilizationStats(
+            totalAcquires = acquires.size,
+            totalReleases = releases.size,
+            avgUtilization = utilizationSamples.average().takeIf { !it.isNaN() } ?: 0.0,
+            maxUtilization = utilizationSamples.maxOrNull() ?: 0.0,
+            maxConcurrentHolders = maxConcurrent,
+            maxWaitingQueue = maxWaiting,
+            avgWaitTimeNanos = waitTimes.average().takeIf { !it.isNaN() } ?: 0.0,
+            maxWaitTimeNanos = waitTimes.maxOrNull() ?: 0,
+            avgHoldTimeNanos = holdTimes.average().takeIf { !it.isNaN() } ?: 0.0,
+            maxHoldTimeNanos = holdTimes.maxOrNull() ?: 0,
+        )
+    }
+}
+
+data class SemaphoreUtilizationStats(
+    val totalAcquires: Int,
+    val totalReleases: Int,
+    val avgUtilization: Double,
+    val maxUtilization: Double,
+    val maxConcurrentHolders: Int,
+    val maxWaitingQueue: Int,
+    val avgWaitTimeNanos: Double,
+    val maxWaitTimeNanos: Long,
+    val avgHoldTimeNanos: Double,
+    val maxHoldTimeNanos: Long,
+)

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/TimingAnalyzer.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/TimingAnalyzer.kt
@@ -1,0 +1,94 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineResumed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import kotlinx.serialization.Serializable
+
+/**
+ * Timing report containing duration and suspension analysis.
+ *
+ * @property coroutineDurations Map of coroutine ID to total duration in nanoseconds
+ *                              (from first event to last event)
+ * @property suspensionDurations Map of coroutine ID to list of individual suspension
+ *                               durations in nanoseconds
+ * @property totalDuration Overall duration of the event stream in nanoseconds
+ */
+@Serializable
+data class TimingReport(
+    val coroutineDurations: Map<String, Long>,
+    val suspensionDurations: Map<String, List<Long>>,
+    val totalDuration: Long,
+)
+
+/**
+ * Analyzes timing characteristics of coroutine event streams.
+ *
+ * Computes:
+ * - Per-coroutine durations (first event to last event)
+ * - Per-coroutine suspension durations (Suspended to Resumed pairs)
+ * - Overall event stream duration
+ */
+object TimingAnalyzer {
+    /**
+     * Analyze the given events and produce a [TimingReport].
+     *
+     * @param events Full event stream (may contain events for multiple coroutines)
+     * @return Timing analysis report
+     */
+    fun analyze(events: List<VizEvent>): TimingReport {
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+
+        val coroutineDurations = mutableMapOf<String, Long>()
+        val suspensionDurations = mutableMapOf<String, List<Long>>()
+
+        for ((coroutineId, cEvents) in byCoroutine) {
+            val sorted = cEvents.sortedBy { it.tsNanos }
+
+            // Total duration: first event to last event
+            if (sorted.size >= 2) {
+                coroutineDurations[coroutineId] = sorted.last().tsNanos - sorted.first().tsNanos
+            } else if (sorted.size == 1) {
+                coroutineDurations[coroutineId] = 0L
+            }
+
+            // Suspension durations: pair Suspended with the next Resumed
+            val suspensions = mutableListOf<Long>()
+            var lastSuspended: CoroutineSuspended? = null
+
+            for (event in sorted) {
+                when (event) {
+                    is CoroutineSuspended -> {
+                        lastSuspended = event
+                    }
+                    is CoroutineResumed -> {
+                        if (lastSuspended != null) {
+                            suspensions.add(event.tsNanos - lastSuspended.tsNanos)
+                            lastSuspended = null
+                        }
+                    }
+                    else -> {}
+                }
+            }
+
+            suspensionDurations[coroutineId] = suspensions
+        }
+
+        // Total stream duration
+        val totalDuration =
+            if (events.size >= 2) {
+                val allTs = events.map { it.tsNanos }
+                allTs.max() - allTs.min()
+            } else {
+                0L
+            }
+
+        return TimingReport(
+            coroutineDurations = coroutineDurations,
+            suspensionDurations = suspensionDurations,
+            totalDuration = totalDuration,
+        )
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/ValidationResult.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/checksystem/ValidationResult.kt
@@ -1,0 +1,31 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Result of a validation rule execution.
+ *
+ * Each validator produces one or more [ValidationResult] instances indicating
+ * whether a specific rule passed or failed for the given event stream.
+ */
+@Serializable
+sealed class ValidationResult {
+    abstract val ruleName: String
+    abstract val message: String
+
+    @Serializable
+    @SerialName("Pass")
+    data class Pass(
+        override val ruleName: String,
+        override val message: String,
+    ) : ValidationResult()
+
+    @Serializable
+    @SerialName("Fail")
+    data class Fail(
+        override val ruleName: String,
+        override val message: String,
+        val details: String,
+    ) : ValidationResult()
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/ActorEvents.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/ActorEvents.kt
@@ -1,0 +1,162 @@
+package com.jh.proj.coroutineviz.events
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ============================================================================
+// Actor Pattern Events
+// ============================================================================
+
+/**
+ * Emitted when an actor is created.
+ *
+ * @property actorId Unique identifier for this actor
+ * @property coroutineId The coroutine backing this actor
+ * @property name Human-readable name for the actor
+ * @property mailboxCapacity Capacity of the actor's message channel
+ */
+@Serializable
+@SerialName("ActorCreated")
+data class ActorCreated(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val actorId: String,
+    val coroutineId: String,
+    val name: String?,
+    val mailboxCapacity: Int,
+) : VizEvent {
+    override val kind: String get() = "ActorCreated"
+}
+
+/**
+ * Emitted when a message is sent to an actor's mailbox.
+ *
+ * @property actorId Target actor
+ * @property senderId Coroutine that sent the message
+ * @property messageType Type/class of the message
+ * @property messagePreview String preview of the message content
+ * @property mailboxSize Current mailbox size after enqueueing
+ */
+@Serializable
+@SerialName("ActorMessageSent")
+data class ActorMessageSent(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val actorId: String,
+    val senderId: String,
+    val messageType: String,
+    val messagePreview: String,
+    val mailboxSize: Int,
+) : VizEvent {
+    override val kind: String get() = "ActorMessageSent"
+}
+
+/**
+ * Emitted when an actor begins processing a message.
+ *
+ * @property actorId The actor processing the message
+ * @property messageType Type of the message being processed
+ * @property messagePreview Preview of the message content
+ * @property queueWaitNanos Time the message spent in the mailbox
+ */
+@Serializable
+@SerialName("ActorMessageProcessing")
+data class ActorMessageProcessing(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val actorId: String,
+    val messageType: String,
+    val messagePreview: String,
+    val queueWaitNanos: Long,
+) : VizEvent {
+    override val kind: String get() = "ActorMessageProcessing"
+}
+
+/**
+ * Emitted when an actor finishes processing a message.
+ *
+ * @property actorId The actor that processed the message
+ * @property messageType Type of the processed message
+ * @property processingDurationNanos How long processing took
+ * @property success Whether processing completed successfully
+ */
+@Serializable
+@SerialName("ActorMessageProcessed")
+data class ActorMessageProcessed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val actorId: String,
+    val messageType: String,
+    val processingDurationNanos: Long,
+    val success: Boolean,
+) : VizEvent {
+    override val kind: String get() = "ActorMessageProcessed"
+}
+
+/**
+ * Emitted when an actor's internal state changes.
+ *
+ * @property actorId The actor whose state changed
+ * @property oldStatePreview Preview of the previous state
+ * @property newStatePreview Preview of the new state
+ * @property stateType Type/class of the state object
+ */
+@Serializable
+@SerialName("ActorStateChanged")
+data class ActorStateChanged(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val actorId: String,
+    val oldStatePreview: String,
+    val newStatePreview: String,
+    val stateType: String,
+) : VizEvent {
+    override val kind: String get() = "ActorStateChanged"
+}
+
+/**
+ * Emitted when the actor's mailbox size changes significantly.
+ *
+ * @property actorId The actor
+ * @property currentSize Current number of messages in the mailbox
+ * @property capacity Maximum capacity
+ * @property pendingSenders Number of senders currently suspended waiting to send
+ */
+@Serializable
+@SerialName("ActorMailboxChanged")
+data class ActorMailboxChanged(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val actorId: String,
+    val currentSize: Int,
+    val capacity: Int,
+    val pendingSenders: Int,
+) : VizEvent {
+    override val kind: String get() = "ActorMailboxChanged"
+}
+
+/**
+ * Emitted when an actor is closed/stopped.
+ *
+ * @property actorId The closed actor
+ * @property reason Why the actor was closed
+ * @property totalMessagesProcessed Total messages processed during lifetime
+ */
+@Serializable
+@SerialName("ActorClosed")
+data class ActorClosed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val actorId: String,
+    val reason: String?,
+    val totalMessagesProcessed: Long,
+) : VizEvent {
+    override val kind: String get() = "ActorClosed"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/AntiPatternEvents.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/AntiPatternEvents.kt
@@ -1,0 +1,66 @@
+package com.jh.proj.coroutineviz.events
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ============================================================================
+// Anti-Pattern Detection Events
+// ============================================================================
+
+/**
+ * Severity levels for detected anti-patterns.
+ */
+@Serializable
+enum class AntiPatternSeverity {
+    ERROR,
+    WARNING,
+    INFO,
+}
+
+/**
+ * Categories of anti-patterns.
+ */
+@Serializable
+enum class AntiPatternType {
+    GLOBAL_SCOPE_USAGE,
+    BLOCKING_ON_MAIN,
+    LEAKED_COROUTINE,
+    UNNECESSARY_ASYNC_AWAIT,
+    RUN_BLOCKING_MISUSE,
+    COROUTINE_EXPLOSION,
+    UNHANDLED_EXCEPTION,
+    MISSING_CANCELLATION_CHECK,
+    SHARED_MUTABLE_STATE,
+    WRONG_DISPATCHER,
+}
+
+/**
+ * Emitted when an anti-pattern is detected in coroutine usage.
+ *
+ * Anti-patterns are code patterns that, while syntactically valid,
+ * lead to bugs, performance issues, or maintenance problems.
+ *
+ * @property patternType The category of anti-pattern detected
+ * @property severity How serious this pattern is
+ * @property description Human-readable description of the issue
+ * @property suggestion Recommended fix or alternative approach
+ * @property coroutineId The coroutine where the pattern was detected, if applicable
+ * @property scopeId The scope where the pattern was detected, if applicable
+ * @property affectedEntities IDs of coroutines/resources involved
+ */
+@Serializable
+@SerialName("AntiPatternDetected")
+data class AntiPatternDetected(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val patternType: AntiPatternType,
+    val severity: AntiPatternSeverity,
+    val description: String,
+    val suggestion: String,
+    val coroutineId: String? = null,
+    val scopeId: String? = null,
+    val affectedEntities: List<String> = emptyList(),
+) : VizEvent {
+    override val kind: String get() = "AntiPatternDetected"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/DeadlockEvents.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/DeadlockEvents.kt
@@ -1,0 +1,86 @@
+package com.jh.proj.coroutineviz.events
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ============================================================================
+// Deadlock Detection Events
+// ============================================================================
+
+/**
+ * Emitted when a deadlock is detected in the system
+ */
+@Serializable
+@SerialName("DeadlockDetected")
+data class DeadlockDetected(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val involvedCoroutines: List<String>,
+    val involvedCoroutineLabels: List<String?>,
+    val involvedMutexes: List<String>,
+    val involvedMutexLabels: List<String?>,
+    // coroutineId -> waitingForMutexId
+    val waitGraph: Map<String, String>,
+    // mutexId -> heldByCoroutineId
+    val holdGraph: Map<String, String>,
+    // Human-readable cycle description
+    val cycleDescription: String,
+) : VizEvent {
+    override val kind: String get() = "DeadlockDetected"
+}
+
+/**
+ * Emitted when a potential deadlock pattern is detected (warning, not actual deadlock)
+ */
+@Serializable
+@SerialName("PotentialDeadlockWarning")
+data class PotentialDeadlockWarning(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val coroutineId: String,
+    val coroutineLabel: String?,
+    val holdingMutex: String,
+    val holdingMutexLabel: String?,
+    val requestingMutex: String,
+    val requestingMutexLabel: String?,
+    val recommendation: String,
+) : VizEvent {
+    override val kind: String get() = "PotentialDeadlockWarning"
+}
+
+/**
+ * Represents a node in the wait-for graph for deadlock detection
+ */
+data class WaitGraphNode(
+    val coroutineId: String,
+    val coroutineLabel: String?,
+    val holdingMutexIds: Set<String>,
+    val waitingForMutexId: String?,
+)
+
+/**
+ * Result of deadlock analysis
+ */
+sealed class DeadlockAnalysisResult {
+    data object NoDeadlock : DeadlockAnalysisResult()
+
+    data class DeadlockFound(
+        // Coroutine IDs in the cycle
+        val cycle: List<String>,
+        // Corresponding labels
+        val cycleLabels: List<String?>,
+        // Mutex IDs involved
+        val involvedMutexes: List<String>,
+        // Corresponding labels
+        val mutexLabels: List<String?>,
+    ) : DeadlockAnalysisResult()
+
+    data class PotentialDeadlock(
+        val coroutineId: String,
+        val holdingMutex: String,
+        val requestingMutex: String,
+        val reason: String,
+    ) : DeadlockAnalysisResult()
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/MutexEvents.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/MutexEvents.kt
@@ -1,0 +1,130 @@
+package com.jh.proj.coroutineviz.events
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ============================================================================
+// Mutex Event Types - For visualizing mutual exclusion synchronization
+// ============================================================================
+
+/**
+ * Base interface for all Mutex-related events
+ */
+@Serializable
+sealed interface MutexEvent : VizEvent {
+    val mutexId: String
+    val mutexLabel: String?
+}
+
+/**
+ * Emitted when a new Mutex is created
+ */
+@Serializable
+@SerialName("MutexCreated")
+data class MutexCreated(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val mutexId: String,
+    override val mutexLabel: String?,
+    val ownerCoroutineId: String? = null,
+) : MutexEvent {
+    override val kind: String get() = "MutexCreated"
+}
+
+/**
+ * Emitted when a coroutine requests to acquire a mutex lock
+ */
+@Serializable
+@SerialName("MutexLockRequested")
+data class MutexLockRequested(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val mutexId: String,
+    override val mutexLabel: String?,
+    val requesterId: String,
+    val requesterLabel: String?,
+    // Current state when requested
+    val isLocked: Boolean,
+    // Position in wait queue (0 if acquired immediately)
+    val queuePosition: Int,
+) : MutexEvent {
+    override val kind: String get() = "MutexLockRequested"
+}
+
+/**
+ * Emitted when a coroutine successfully acquires a mutex lock
+ */
+@Serializable
+@SerialName("MutexLockAcquired")
+data class MutexLockAcquired(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val mutexId: String,
+    override val mutexLabel: String?,
+    val acquirerId: String,
+    val acquirerLabel: String?,
+    // How long waited for lock
+    val waitDurationNanos: Long,
+) : MutexEvent {
+    override val kind: String get() = "MutexLockAcquired"
+}
+
+/**
+ * Emitted when a coroutine releases a mutex lock
+ */
+@Serializable
+@SerialName("MutexUnlocked")
+data class MutexUnlocked(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val mutexId: String,
+    override val mutexLabel: String?,
+    val releaserId: String,
+    val releaserLabel: String?,
+    // Who gets the lock next
+    val nextWaiterId: String?,
+    // How long lock was held
+    val holdDurationNanos: Long,
+) : MutexEvent {
+    override val kind: String get() = "MutexUnlocked"
+}
+
+/**
+ * Emitted when a coroutine attempts tryLock and fails
+ */
+@Serializable
+@SerialName("MutexTryLockFailed")
+data class MutexTryLockFailed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val mutexId: String,
+    override val mutexLabel: String?,
+    val requesterId: String,
+    val requesterLabel: String?,
+    // Who currently holds the lock
+    val currentOwnerId: String?,
+) : MutexEvent {
+    override val kind: String get() = "MutexTryLockFailed"
+}
+
+/**
+ * Emitted when the mutex wait queue changes
+ */
+@Serializable
+@SerialName("MutexQueueChanged")
+data class MutexQueueChanged(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val mutexId: String,
+    override val mutexLabel: String?,
+    val waitingCoroutineIds: List<String>,
+    val waitingLabels: List<String?>,
+) : MutexEvent {
+    override val kind: String get() = "MutexQueueChanged"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/SelectEvents.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/SelectEvents.kt
@@ -1,0 +1,98 @@
+package com.jh.proj.coroutineviz.events
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ============================================================================
+// Select Expression Events
+// ============================================================================
+
+/**
+ * Emitted when a select expression begins evaluation.
+ *
+ * @property selectId Unique identifier for this select invocation
+ * @property coroutineId ID of the coroutine executing the select
+ * @property clauseCount Number of clauses registered in this select
+ */
+@Serializable
+@SerialName("SelectStarted")
+data class SelectStarted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val selectId: String,
+    val coroutineId: String,
+    val clauseCount: Int,
+) : VizEvent {
+    override val kind: String get() = "SelectStarted"
+}
+
+/**
+ * Emitted when a clause is registered in a select expression.
+ *
+ * @property selectId The select expression this clause belongs to
+ * @property clauseIndex Index of the clause in the select block (0-based)
+ * @property clauseType Type of clause: "onReceive", "onSend", "onAwait", "onTimeout", "onJoin"
+ * @property channelId Channel ID for onReceive/onSend clauses
+ * @property deferredId Deferred ID for onAwait clauses
+ * @property timeoutMillis Timeout for onTimeout clauses
+ */
+@Serializable
+@SerialName("SelectClauseRegistered")
+data class SelectClauseRegistered(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val selectId: String,
+    val coroutineId: String,
+    val clauseIndex: Int,
+    val clauseType: String,
+    val channelId: String? = null,
+    val deferredId: String? = null,
+    val timeoutMillis: Long? = null,
+    val label: String? = null,
+) : VizEvent {
+    override val kind: String get() = "SelectClauseRegistered"
+}
+
+/**
+ * Emitted when a clause wins the select race.
+ *
+ * @property selectId The select expression
+ * @property winnerClauseIndex Index of the winning clause
+ * @property winnerClauseType Type of the winning clause
+ * @property waitDurationNanos How long the select waited before a clause was ready
+ */
+@Serializable
+@SerialName("SelectClauseWon")
+data class SelectClauseWon(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val selectId: String,
+    val coroutineId: String,
+    val winnerClauseIndex: Int,
+    val winnerClauseType: String,
+    val waitDurationNanos: Long,
+) : VizEvent {
+    override val kind: String get() = "SelectClauseWon"
+}
+
+/**
+ * Emitted when a select expression completes.
+ *
+ * @property selectId The select expression
+ * @property totalDurationNanos Total time from SelectStarted to completion
+ */
+@Serializable
+@SerialName("SelectCompleted")
+data class SelectCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val selectId: String,
+    val coroutineId: String,
+    val totalDurationNanos: Long,
+) : VizEvent {
+    override val kind: String get() = "SelectCompleted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/SemaphoreEvents.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/SemaphoreEvents.kt
@@ -1,0 +1,131 @@
+package com.jh.proj.coroutineviz.events
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ============================================================================
+// Semaphore Event Types - For visualizing permit-based synchronization
+// ============================================================================
+
+/**
+ * Base interface for all Semaphore-related events
+ */
+@Serializable
+sealed interface SemaphoreEvent : VizEvent {
+    val semaphoreId: String
+    val semaphoreLabel: String?
+}
+
+/**
+ * Emitted when a new Semaphore is created
+ */
+@Serializable
+@SerialName("SemaphoreCreated")
+data class SemaphoreCreated(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val semaphoreId: String,
+    override val semaphoreLabel: String?,
+    val totalPermits: Int,
+) : SemaphoreEvent {
+    override val kind: String get() = "SemaphoreCreated"
+}
+
+/**
+ * Emitted when a coroutine requests to acquire a permit
+ */
+@Serializable
+@SerialName("SemaphoreAcquireRequested")
+data class SemaphoreAcquireRequested(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val semaphoreId: String,
+    override val semaphoreLabel: String?,
+    val requesterId: String,
+    val requesterLabel: String?,
+    val availablePermits: Int,
+    // Usually 1, but can be more
+    val permitsRequested: Int,
+) : SemaphoreEvent {
+    override val kind: String get() = "SemaphoreAcquireRequested"
+}
+
+/**
+ * Emitted when a coroutine successfully acquires a permit
+ */
+@Serializable
+@SerialName("SemaphorePermitAcquired")
+data class SemaphorePermitAcquired(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val semaphoreId: String,
+    override val semaphoreLabel: String?,
+    val acquirerId: String,
+    val acquirerLabel: String?,
+    val remainingPermits: Int,
+    val waitDurationNanos: Long,
+) : SemaphoreEvent {
+    override val kind: String get() = "SemaphorePermitAcquired"
+}
+
+/**
+ * Emitted when a coroutine releases a permit
+ */
+@Serializable
+@SerialName("SemaphorePermitReleased")
+data class SemaphorePermitReleased(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val semaphoreId: String,
+    override val semaphoreLabel: String?,
+    val releaserId: String,
+    val releaserLabel: String?,
+    val newAvailablePermits: Int,
+    val holdDurationNanos: Long,
+) : SemaphoreEvent {
+    override val kind: String get() = "SemaphorePermitReleased"
+}
+
+/**
+ * Emitted when a coroutine attempts tryAcquire and fails
+ */
+@Serializable
+@SerialName("SemaphoreTryAcquireFailed")
+data class SemaphoreTryAcquireFailed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val semaphoreId: String,
+    override val semaphoreLabel: String?,
+    val requesterId: String,
+    val requesterLabel: String?,
+    val availablePermits: Int,
+    val permitsRequested: Int,
+) : SemaphoreEvent {
+    override val kind: String get() = "SemaphoreTryAcquireFailed"
+}
+
+/**
+ * Emitted when the overall semaphore state changes
+ */
+@Serializable
+@SerialName("SemaphoreStateChanged")
+data class SemaphoreStateChanged(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val semaphoreId: String,
+    override val semaphoreLabel: String?,
+    val availablePermits: Int,
+    val totalPermits: Int,
+    val activeHolders: List<String>,
+    val activeHolderLabels: List<String?>,
+    val waitingCoroutines: List<String>,
+    val waitingLabels: List<String?>,
+) : SemaphoreEvent {
+    override val kind: String get() = "SemaphoreStateChanged"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/SuspensionPoint.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/SuspensionPoint.kt
@@ -1,0 +1,48 @@
+package com.jh.proj.coroutineviz.events
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Captures information about where a suspension occurred in user code.
+ */
+@Serializable
+data class SuspensionPoint(
+    // Method name
+    val function: String,
+    // Source file
+    val fileName: String? = null,
+    // Line number
+    val lineNumber: Int? = null,
+    // "delay", "withContext", "join", "await"
+    val reason: String,
+) {
+    companion object {
+        /**
+         * Helper to capture suspension point from current stack trace.
+         * @param reason The reason for suspension (e.g., "delay", "await")
+         * @param skipFrames Number of stack frames to skip (default 2)
+         */
+        fun capture(
+            reason: String,
+            skipFrames: Int = 2,
+        ): SuspensionPoint {
+            val stackTrace = Throwable().stackTrace
+
+            // Find first non-coroutines-infrastructure frame
+            val relevantFrame =
+                stackTrace
+                    .drop(skipFrames)
+                    .firstOrNull { frame ->
+                        !frame.className.startsWith("kotlinx.coroutines") &&
+                            !frame.className.contains("VizScope")
+                    }
+
+            return SuspensionPoint(
+                function = relevantFrame?.methodName ?: "unknown",
+                fileName = relevantFrame?.fileName,
+                lineNumber = relevantFrame?.lineNumber?.takeIf { it >= 0 },
+                reason = reason,
+            )
+        }
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/VizEvent.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/VizEvent.kt
@@ -1,0 +1,28 @@
+package com.jh.proj.coroutineviz.events
+
+/**
+ * Base interface for all visualization events.
+ * All events in the system must implement this interface.
+ *
+ * Note: Not sealed to allow extension from subpackages.
+ */
+interface VizEvent {
+    val sessionId: String
+    val seq: Long
+    val tsNanos: Long
+    val kind: String
+}
+
+/**
+ * Base interface for coroutine lifecycle events.
+ * Events that track a specific coroutine's state changes.
+ *
+ * Note: Not sealed to allow extension from subpackages.
+ */
+interface CoroutineEvent : VizEvent {
+    val coroutineId: String
+    val jobId: String
+    val parentCoroutineId: String?
+    val scopeId: String
+    val label: String?
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/WaitingForChildren.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/WaitingForChildren.kt
@@ -1,0 +1,22 @@
+package com.jh.proj.coroutineviz.events
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("WaitingForChildren")
+data class WaitingForChildren(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val activeChildrenCount: Int,
+    // Coroutine IDs of active children
+    val activeChildrenIds: List<String>,
+) : CoroutineEvent {
+    override val kind: String get() = "WaitingForChildren"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelBufferStateChanged.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelBufferStateChanged.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when the buffer state of a Channel changes (after send or receive).
+ *
+ * @property channelId ID of the Channel
+ * @property currentSize Current number of elements in the buffer
+ * @property capacity Maximum capacity of the channel buffer
+ */
+@Serializable
+@SerialName("ChannelBufferStateChanged")
+data class ChannelBufferStateChanged(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val currentSize: Int,
+    val capacity: Int,
+) : VizEvent {
+    override val kind: String get() = "ChannelBufferStateChanged"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelClosed.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelClosed.kt
@@ -1,0 +1,23 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a Channel is closed.
+ *
+ * @property channelId ID of the closed Channel
+ * @property cause Description of the close cause, if any
+ */
+@Serializable
+@SerialName("ChannelClosed")
+data class ChannelClosed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val cause: String? = null,
+) : VizEvent {
+    override val kind: String get() = "ChannelClosed"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelCreated.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelCreated.kt
@@ -1,0 +1,28 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when an instrumented Channel is created.
+ *
+ * @property channelId Unique identifier for this Channel instance
+ * @property name Optional human-readable name for the channel
+ * @property capacity The buffer capacity of the channel
+ * @property channelType Type of channel: RENDEZVOUS, BUFFERED, CONFLATED, UNLIMITED
+ */
+@Serializable
+@SerialName("ChannelCreated")
+data class ChannelCreated(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val name: String? = null,
+    val capacity: Int,
+    // RENDEZVOUS, BUFFERED, CONFLATED, UNLIMITED
+    val channelType: String,
+) : VizEvent {
+    override val kind: String get() = "ChannelCreated"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveCompleted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveCompleted.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a receive operation from a Channel completes with a value.
+ *
+ * @property channelId ID of the Channel
+ * @property coroutineId ID of the receiving coroutine
+ * @property valueDescription Preview of the received value
+ */
+@Serializable
+@SerialName("ChannelReceiveCompleted")
+data class ChannelReceiveCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+    val valueDescription: String,
+) : VizEvent {
+    override val kind: String get() = "ChannelReceiveCompleted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveStarted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveStarted.kt
@@ -1,0 +1,23 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine begins receiving from a Channel.
+ *
+ * @property channelId ID of the Channel being received from
+ * @property coroutineId ID of the receiving coroutine
+ */
+@Serializable
+@SerialName("ChannelReceiveStarted")
+data class ChannelReceiveStarted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+) : VizEvent {
+    override val kind: String get() = "ChannelReceiveStarted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveSuspended.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelReceiveSuspended.kt
@@ -1,0 +1,23 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a receive operation suspends because the channel is empty.
+ *
+ * @property channelId ID of the Channel
+ * @property coroutineId ID of the suspended receiving coroutine
+ */
+@Serializable
+@SerialName("ChannelReceiveSuspended")
+data class ChannelReceiveSuspended(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+) : VizEvent {
+    override val kind: String get() = "ChannelReceiveSuspended"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendCompleted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendCompleted.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a send operation to a Channel completes successfully.
+ *
+ * @property channelId ID of the Channel
+ * @property coroutineId ID of the sending coroutine
+ * @property valueDescription Preview of the value that was sent
+ */
+@Serializable
+@SerialName("ChannelSendCompleted")
+data class ChannelSendCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+    val valueDescription: String,
+) : VizEvent {
+    override val kind: String get() = "ChannelSendCompleted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendStarted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendStarted.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine begins sending a value to a Channel.
+ *
+ * @property channelId ID of the Channel being sent to
+ * @property coroutineId ID of the sending coroutine
+ * @property valueDescription Preview of the value being sent
+ */
+@Serializable
+@SerialName("ChannelSendStarted")
+data class ChannelSendStarted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+    val valueDescription: String,
+) : VizEvent {
+    override val kind: String get() = "ChannelSendStarted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendSuspended.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/channel/ChannelSendSuspended.kt
@@ -1,0 +1,27 @@
+package com.jh.proj.coroutineviz.events.channel
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a send operation suspends because the channel buffer is full.
+ *
+ * @property channelId ID of the Channel
+ * @property coroutineId ID of the suspended sending coroutine
+ * @property bufferSize Current number of elements in the buffer
+ * @property capacity Maximum capacity of the channel buffer
+ */
+@Serializable
+@SerialName("ChannelSendSuspended")
+data class ChannelSendSuspended(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val channelId: String,
+    val coroutineId: String,
+    val bufferSize: Int,
+    val capacity: Int,
+) : VizEvent {
+    override val kind: String get() = "ChannelSendSuspended"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineBodyCompleted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineBodyCompleted.kt
@@ -1,0 +1,30 @@
+package com.jh.proj.coroutineviz.events.coroutine
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine's own code has finished executing.
+ *
+ * This is distinct from [CoroutineCompleted] - at this point the coroutine's
+ * body has finished, but it may still be waiting for child coroutines to
+ * complete (structured concurrency). The coroutine transitions to
+ * WAITING_FOR_CHILDREN state.
+ *
+ * Lifecycle: (body execution) → BODY_COMPLETED → [CoroutineCompleted]
+ */
+@Serializable
+@SerialName("CoroutineBodyCompleted")
+data class CoroutineBodyCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+) : CoroutineEvent {
+    override val kind: String get() = "CoroutineBodyCompleted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineCancelled.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineCancelled.kt
@@ -1,0 +1,35 @@
+package com.jh.proj.coroutineviz.events.coroutine
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine is cancelled.
+ *
+ * Cancellation can occur due to:
+ * - Explicit cancellation via [Job.cancel]
+ * - Parent cancellation (structured concurrency)
+ * - Sibling failure causing parent cancellation
+ *
+ * This is a terminal event - the coroutine will not execute further.
+ *
+ * @property cause Description of why the coroutine was cancelled
+ *
+ * Lifecycle: (any state) → CANCELLED (terminal)
+ */
+@Serializable
+@SerialName("CoroutineCancelled")
+data class CoroutineCancelled(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val cause: String?,
+) : CoroutineEvent {
+    override val kind: String get() = "CoroutineCancelled"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineCompleted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineCompleted.kt
@@ -1,0 +1,30 @@
+package com.jh.proj.coroutineviz.events.coroutine
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine has fully completed.
+ *
+ * This is a terminal event indicating successful completion. Both the
+ * coroutine's own code and all child coroutines have finished successfully.
+ * This is one of the three possible terminal states (along with
+ * [CoroutineCancelled] and [CoroutineFailed]).
+ *
+ * Lifecycle: [CoroutineBodyCompleted] → COMPLETED (terminal)
+ */
+@Serializable
+@SerialName("CoroutineCompleted")
+data class CoroutineCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+) : CoroutineEvent {
+    override val kind: String get() = "CoroutineCompleted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineCreated.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineCreated.kt
@@ -1,0 +1,28 @@
+package com.jh.proj.coroutineviz.events.coroutine
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a new coroutine is created via [vizLaunch] or [vizAsync].
+ *
+ * This is the first event in a coroutine's lifecycle. At this point the
+ * coroutine exists but has not yet started executing.
+ *
+ * Lifecycle: CREATED → [CoroutineStarted]
+ */
+@Serializable
+@SerialName("CoroutineCreated")
+data class CoroutineCreated(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+) : CoroutineEvent {
+    override val kind: String get() = "CoroutineCreated"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineFailed.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineFailed.kt
@@ -1,0 +1,36 @@
+package com.jh.proj.coroutineviz.events.coroutine
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine fails with an unhandled exception.
+ *
+ * This is a terminal event indicating the coroutine threw an exception
+ * that was not caught. In structured concurrency, this typically causes
+ * the parent and siblings to be cancelled as well.
+ *
+ * @property exceptionType Fully qualified exception class name
+ * @property message Exception message
+ * @property stackTrace Stack trace frames for debugging
+ *
+ * Lifecycle: (any state) → FAILED (terminal)
+ */
+@Serializable
+@SerialName("CoroutineFailed")
+data class CoroutineFailed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val exceptionType: String?,
+    val message: String?,
+    val stackTrace: List<String>,
+) : CoroutineEvent {
+    override val kind: String get() = "CoroutineFailed"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineResumed.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineResumed.kt
@@ -1,0 +1,29 @@
+package com.jh.proj.coroutineviz.events.coroutine
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a suspended coroutine resumes execution.
+ *
+ * This event marks the transition back from SUSPENDED to ACTIVE state.
+ * The coroutine has been assigned a thread and continues executing
+ * from where it suspended.
+ *
+ * Lifecycle: [CoroutineSuspended] → RESUMED → (continues execution)
+ */
+@Serializable
+@SerialName("CoroutineResumed")
+data class CoroutineResumed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+) : CoroutineEvent {
+    override val kind: String get() = "CoroutineResumed"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineStarted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineStarted.kt
@@ -1,0 +1,28 @@
+package com.jh.proj.coroutineviz.events.coroutine
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine begins executing its body.
+ *
+ * This event marks the transition from CREATED to ACTIVE state.
+ * The coroutine is now running on a thread.
+ *
+ * Lifecycle: [CoroutineCreated] → STARTED → (execution)
+ */
+@Serializable
+@SerialName("CoroutineStarted")
+data class CoroutineStarted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+) : CoroutineEvent {
+    override val kind: String get() = "CoroutineStarted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineSuspended.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/coroutine/CoroutineSuspended.kt
@@ -1,0 +1,37 @@
+package com.jh.proj.coroutineviz.events.coroutine
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.SuspensionPoint
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine suspends execution.
+ *
+ * Suspension occurs at suspension points like [delay], [await], [join],
+ * or [withContext]. The coroutine releases its thread and will be
+ * resumed later when the suspending operation completes.
+ *
+ * @property reason Why the coroutine suspended (e.g., "delay", "await", "join")
+ * @property durationMillis Expected duration if known (e.g., for delay)
+ * @property suspensionPoint Source code location where suspension occurred
+ *
+ * Lifecycle: ACTIVE → SUSPENDED → [CoroutineResumed]
+ */
+@Serializable
+@SerialName("CoroutineSuspended")
+data class CoroutineSuspended(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val reason: String,
+    val durationMillis: Long? = null,
+    val suspensionPoint: SuspensionPoint? = null,
+) : CoroutineEvent {
+    override val kind: String get() = "CoroutineSuspended"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/deferred/DeferredAwaitCompleted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/deferred/DeferredAwaitCompleted.kt
@@ -1,0 +1,32 @@
+package com.jh.proj.coroutineviz.events.deferred
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when [Deferred.await] completes and returns the value.
+ *
+ * This event follows [DeferredAwaitStarted] and indicates the awaiting
+ * coroutine has received the deferred value and will resume execution.
+ *
+ * @property deferredId Unique identifier for the Deferred instance
+ * @property coroutineId ID of the coroutine that owns the Deferred
+ * @property awaiterId ID of the coroutine that called await(), if known
+ * @property scopeId ID of the owning VizScope
+ * @property label Optional label for the deferred
+ */
+@Serializable
+@SerialName("DeferredAwaitCompleted")
+data class DeferredAwaitCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val deferredId: String,
+    val coroutineId: String,
+    val awaiterId: String?,
+    val scopeId: String,
+    val label: String?,
+) : VizEvent {
+    override val kind: String get() = "DeferredAwaitCompleted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/deferred/DeferredAwaitStarted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/deferred/DeferredAwaitStarted.kt
@@ -1,0 +1,35 @@
+package com.jh.proj.coroutineviz.events.deferred
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when [Deferred.await] is called.
+ *
+ * This event marks the start of an await operation. The awaiting coroutine
+ * will suspend until the deferred value is available. Pairs with
+ * [DeferredAwaitCompleted] when the await finishes.
+ *
+ * @property deferredId Unique identifier for the Deferred instance
+ * @property coroutineId ID of the coroutine that owns the Deferred
+ * @property awaiterId ID of the coroutine calling await(), if known
+ * @property scopeId ID of the owning VizScope
+ * @property label Optional label for the deferred
+ */
+@Serializable
+@SerialName("DeferredAwaitStarted")
+data class DeferredAwaitStarted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val deferredId: String,
+    // The deferred's coroutine
+    val coroutineId: String,
+    // Who is waiting
+    val awaiterId: String?,
+    val scopeId: String,
+    val label: String?,
+) : VizEvent {
+    override val kind: String get() = "DeferredAwaitStarted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/deferred/DeferredValueAvailable.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/deferred/DeferredValueAvailable.kt
@@ -1,0 +1,30 @@
+package com.jh.proj.coroutineviz.events.deferred
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a Deferred's value becomes available.
+ *
+ * This event is emitted when the async coroutine completes and its result
+ * is ready to be retrieved via [await]. Any coroutines waiting on this
+ * deferred will be able to resume.
+ *
+ * @property deferredId Unique identifier for the Deferred instance
+ */
+@Serializable
+@SerialName("DeferredValueAvailable")
+data class DeferredValueAvailable(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val deferredId: String,
+) : CoroutineEvent {
+    override val kind: String get() = "DeferredValueAvailable"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/dispatcher/DispatcherSelected.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/dispatcher/DispatcherSelected.kt
@@ -1,0 +1,34 @@
+package com.jh.proj.coroutineviz.events.dispatcher
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a dispatcher is selected for a coroutine.
+ *
+ * This event is emitted by [InstrumentedDispatcher] when dispatch() is called,
+ * before the coroutine is assigned to a thread. It indicates which dispatcher
+ * will handle the coroutine's execution.
+ *
+ * @property dispatcherId Unique identifier for the dispatcher instance
+ * @property dispatcherName Human-readable name (e.g., "Dispatchers.Default")
+ * @property queueDepth Number of pending tasks in dispatcher queue, if available
+ */
+@Serializable
+@SerialName("DispatcherSelected")
+data class DispatcherSelected(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val dispatcherId: String,
+    val dispatcherName: String,
+    val queueDepth: Int? = null,
+) : CoroutineEvent {
+    override val kind: String get() = "DispatcherSelected"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/dispatcher/ThreadAssigned.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/dispatcher/ThreadAssigned.kt
@@ -1,0 +1,34 @@
+package com.jh.proj.coroutineviz.events.dispatcher
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine is assigned to a specific thread.
+ *
+ * This event is emitted when the coroutine actually starts running on a thread,
+ * which may be different from when the dispatcher was selected. It enables
+ * thread activity visualization showing which coroutines ran on which threads.
+ *
+ * @property threadId System thread ID (from [Thread.threadId])
+ * @property threadName Human-readable thread name
+ * @property dispatcherName Name of the dispatcher that assigned this thread
+ */
+@Serializable
+@SerialName("ThreadAssigned")
+data class ThreadAssigned(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val threadId: Long,
+    val threadName: String,
+    val dispatcherName: String?,
+) : CoroutineEvent {
+    override val kind: String get() = "ThreadAssigned"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowBackpressure.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowBackpressure.kt
@@ -1,0 +1,26 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when backpressure is detected in a Flow.
+ * This occurs when producer is faster than consumer.
+ */
+@Serializable
+data class FlowBackpressure(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val flowId: String,
+    val collectorId: String,
+    // "slow_collector", "buffer_full", "conflated"
+    val reason: String,
+    val pendingEmissions: Int,
+    val bufferCapacity: Int?,
+    // How long producer waited
+    val durationNanos: Long?,
+    val coroutineId: String? = null,
+) : VizEvent {
+    override val kind = "FlowBackpressure"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowBufferOverflow.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowBufferOverflow.kt
@@ -1,0 +1,34 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a buffered Flow's buffer overflows.
+ *
+ * This event indicates backpressure - the producer is emitting values faster
+ * than the collector can process them. Depending on the overflow strategy,
+ * values may be dropped or the producer may suspend.
+ *
+ * @property coroutineId ID of the coroutine involved
+ * @property flowId ID of the Flow with the overflowing buffer
+ * @property droppedValue Preview of the dropped value, if applicable
+ * @property bufferSize Current size of the buffer
+ * @property overflowStrategy Strategy used: "SUSPEND", "DROP_LATEST", or "DROP_OLDEST"
+ */
+@Serializable
+@SerialName("FlowBufferOverflow")
+data class FlowBufferOverflow(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val coroutineId: String,
+    val flowId: String,
+    val droppedValue: String?,
+    val bufferSize: Int,
+    // "SUSPEND", "DROP_LATEST", "DROP_OLDEST"
+    val overflowStrategy: String,
+) : VizEvent {
+    override val kind: String get() = "FlowBufferOverflow"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowCollectionCancelled.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowCollectionCancelled.kt
@@ -1,0 +1,33 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a Flow collection is cancelled before completion.
+ *
+ * Collection can be cancelled due to coroutine cancellation, explicit
+ * cancellation, or operators like [take] that cancel after receiving
+ * enough values.
+ *
+ * @property coroutineId ID of the collecting coroutine
+ * @property flowId ID of the cancelled Flow
+ * @property collectorId ID of the collection instance
+ * @property reason Description of why collection was cancelled
+ * @property emittedCount Number of values emitted before cancellation
+ */
+@Serializable
+@SerialName("FlowCollectionCancelled")
+data class FlowCollectionCancelled(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val coroutineId: String,
+    val flowId: String,
+    val collectorId: String,
+    val reason: String?,
+    val emittedCount: Int,
+) : VizEvent {
+    override val kind: String get() = "FlowCollectionCancelled"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowCollectionCompleted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowCollectionCompleted.kt
@@ -1,0 +1,33 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a Flow collection completes successfully.
+ *
+ * This indicates the flow finished emitting all values and the collector
+ * has processed them. This is one of the terminal events for flow collection
+ * (along with [FlowCollectionCancelled]).
+ *
+ * @property coroutineId ID of the collecting coroutine
+ * @property flowId ID of the completed Flow
+ * @property collectorId ID of the collection instance
+ * @property totalEmissions Total number of values emitted
+ * @property durationNanos Time from collection start to completion in nanoseconds
+ */
+@Serializable
+@SerialName("FlowCollectionCompleted")
+data class FlowCollectionCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val coroutineId: String,
+    val flowId: String,
+    val collectorId: String,
+    val totalEmissions: Int,
+    val durationNanos: Long,
+) : VizEvent {
+    override val kind: String get() = "FlowCollectionCompleted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowCollectionStarted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowCollectionStarted.kt
@@ -1,0 +1,31 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a coroutine starts collecting from a Flow.
+ *
+ * Collection begins when [collect], [first], [toList], or similar terminal
+ * operators are called. For cold flows, this triggers the flow to start
+ * producing values.
+ *
+ * @property coroutineId ID of the coroutine collecting the flow
+ * @property flowId ID of the Flow being collected
+ * @property collectorId Unique identifier for this collection instance
+ * @property label Optional human-readable label
+ */
+@Serializable
+@SerialName("FlowCollectionStarted")
+data class FlowCollectionStarted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val coroutineId: String,
+    val flowId: String,
+    val collectorId: String,
+    val label: String? = null,
+) : VizEvent {
+    override val kind: String get() = "FlowCollectionStarted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowCreated.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowCreated.kt
@@ -1,0 +1,34 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when an instrumented Flow is created.
+ *
+ * This event marks the creation of a Flow that will emit values.
+ * Different flow types have different behaviors regarding collection
+ * and value sharing.
+ *
+ * @property coroutineId ID of the coroutine that created the flow
+ * @property flowId Unique identifier for this Flow instance
+ * @property flowType Type of flow: "Cold", "Hot", "StateFlow", "SharedFlow"
+ * @property label Optional human-readable label
+ * @property scopeId ID of the owning VizScope, if applicable
+ */
+@Serializable
+@SerialName("FlowCreated")
+data class FlowCreated(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val coroutineId: String,
+    val flowId: String,
+    // "Cold", "Hot", "StateFlow", "SharedFlow"
+    val flowType: String,
+    val label: String? = null,
+    val scopeId: String? = null,
+) : VizEvent {
+    override val kind: String get() = "FlowCreated"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowOperatorApplied.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowOperatorApplied.kt
@@ -1,0 +1,27 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a Flow operator is applied to create a derived Flow.
+ * Tracks the operator chain for visualization.
+ */
+@Serializable
+data class FlowOperatorApplied(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val flowId: String,
+    // The upstream flow this operator transforms
+    val sourceFlowId: String,
+    // "map", "filter", "transform", "flatMapConcat", etc.
+    val operatorName: String,
+    // Position in operator chain (0 = first operator)
+    val operatorIndex: Int,
+    val label: String? = null,
+    // If created within a coroutine context
+    val coroutineId: String? = null,
+) : VizEvent {
+    override val kind = "FlowOperatorApplied"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowValueEmitted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowValueEmitted.kt
@@ -1,0 +1,36 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a Flow emits a value to a collector.
+ *
+ * This event is emitted for each value that flows from producer to collector.
+ * The value is captured as a preview string for debugging purposes.
+ *
+ * @property coroutineId ID of the coroutine involved in the emission
+ * @property flowId ID of the Flow emitting the value
+ * @property collectorId ID of the collector receiving the value
+ * @property sequenceNumber Order of this emission (0-indexed)
+ * @property valuePreview String representation of the value (truncated to 200 chars)
+ * @property valueType Fully qualified class name of the emitted value
+ */
+@Serializable
+@SerialName("FlowValueEmitted")
+data class FlowValueEmitted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val coroutineId: String,
+    val flowId: String,
+    val collectorId: String,
+    val sequenceNumber: Int,
+    // toString() of value, truncated to 200 chars
+    val valuePreview: String,
+    // Class name of the value
+    val valueType: String,
+) : VizEvent {
+    override val kind: String get() = "FlowValueEmitted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowValueFiltered.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowValueFiltered.kt
@@ -1,0 +1,26 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a value is filtered (either passed or dropped) by a filter operator.
+ */
+@Serializable
+data class FlowValueFiltered(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val flowId: String,
+    // "filter", "filterNot", "filterIsInstance", "distinctUntilChanged"
+    val operatorName: String,
+    val valuePreview: String,
+    val valueType: String,
+    // true = value passed filter, false = value dropped
+    val passed: Boolean,
+    val sequenceNumber: Int,
+    val coroutineId: String? = null,
+    val collectorId: String? = null,
+) : VizEvent {
+    override val kind = "FlowValueFiltered"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowValueTransformed.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/FlowValueTransformed.kt
@@ -1,0 +1,26 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a value passes through a transform operator.
+ * Tracks input -> output transformation for visualization.
+ */
+@Serializable
+data class FlowValueTransformed(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val flowId: String,
+    val operatorName: String,
+    val inputValuePreview: String,
+    val outputValuePreview: String,
+    val inputType: String,
+    val outputType: String,
+    val sequenceNumber: Int,
+    val coroutineId: String? = null,
+    val collectorId: String? = null,
+) : VizEvent {
+    override val kind = "FlowValueTransformed"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/SharedFlowEmission.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/SharedFlowEmission.kt
@@ -1,0 +1,25 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a value is emitted to a SharedFlow.
+ */
+@Serializable
+data class SharedFlowEmission(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val flowId: String,
+    val valuePreview: String,
+    val valueType: String,
+    val subscriberCount: Int,
+    // Current replay cache size
+    val replayCache: Int,
+    val extraBufferCapacity: Int,
+    val coroutineId: String? = null,
+    val label: String? = null,
+) : VizEvent {
+    override val kind = "SharedFlowEmission"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/SharedFlowSubscription.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/SharedFlowSubscription.kt
@@ -1,0 +1,24 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a collector subscribes to or unsubscribes from a SharedFlow.
+ */
+@Serializable
+data class SharedFlowSubscription(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val flowId: String,
+    val collectorId: String,
+    // "subscribed" or "unsubscribed"
+    val action: String,
+    // Total subscribers after this action
+    val subscriberCount: Int,
+    val coroutineId: String? = null,
+    val label: String? = null,
+) : VizEvent {
+    override val kind = "SharedFlowSubscription"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/StateFlowValueChanged.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/flow/StateFlowValueChanged.kt
@@ -1,0 +1,24 @@
+package com.jh.proj.coroutineviz.events.flow
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a StateFlow's value changes.
+ */
+@Serializable
+data class StateFlowValueChanged(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val flowId: String,
+    val oldValuePreview: String,
+    val newValuePreview: String,
+    val valueType: String,
+    // Number of active collectors
+    val subscriberCount: Int,
+    val coroutineId: String? = null,
+    val label: String? = null,
+) : VizEvent {
+    override val kind = "StateFlowValueChanged"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/job/JobCancellationRequested.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/job/JobCancellationRequested.kt
@@ -1,0 +1,32 @@
+package com.jh.proj.coroutineviz.events.job
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when [Job.cancel] is explicitly called.
+ *
+ * This marks the *request* for cancellation, not completion. The actual
+ * cancellation may take time as the coroutine reaches suspension points.
+ * [CoroutineCancelled] is emitted when cancellation actually completes.
+ *
+ * @property requestedBy ID of the coroutine/entity that requested cancellation
+ * @property cause Reason for cancellation, if provided
+ */
+@Serializable
+@SerialName("JobCancellationRequested")
+data class JobCancellationRequested(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val requestedBy: String? = null,
+    val cause: String? = null,
+) : CoroutineEvent {
+    override val kind: String get() = "JobCancellationRequested"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/job/JobJoinCompleted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/job/JobJoinCompleted.kt
@@ -1,0 +1,30 @@
+package com.jh.proj.coroutineviz.events.job
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when [Job.join] completes and the waiting coroutine resumes.
+ *
+ * This event follows [JobJoinRequested] and indicates the job has finished
+ * (either completed, cancelled, or failed). The waiting coroutine will
+ * now resume execution.
+ *
+ * @property waitingCoroutineId ID of the coroutine that called join(), if known
+ */
+@Serializable
+@SerialName("JobJoinCompleted")
+data class JobJoinCompleted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val waitingCoroutineId: String? = null,
+) : CoroutineEvent {
+    override val kind: String get() = "JobJoinCompleted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/job/JobJoinRequested.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/job/JobJoinRequested.kt
@@ -1,0 +1,30 @@
+package com.jh.proj.coroutineviz.events.job
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when [Job.join] is called on a job.
+ *
+ * This indicates a coroutine is suspending to wait for this job to complete.
+ * The waiting coroutine will remain suspended until the job finishes,
+ * at which point [JobJoinCompleted] is emitted.
+ *
+ * @property waitingCoroutineId ID of the coroutine that called join(), if known
+ */
+@Serializable
+@SerialName("JobJoinRequested")
+data class JobJoinRequested(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val waitingCoroutineId: String? = null,
+) : CoroutineEvent {
+    override val kind: String get() = "JobJoinRequested"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/job/JobStateChanged.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/events/job/JobStateChanged.kt
@@ -1,0 +1,36 @@
+package com.jh.proj.coroutineviz.events.job
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when a Job's state changes.
+ *
+ * Tracks the real-time state of jobs for frontend visualization.
+ * Job state is independent of coroutine state - a job can be cancelled
+ * while the coroutine is still completing its cancellation logic.
+ *
+ * @property isActive True if the job is still running
+ * @property isCompleted True if the job has finished (successfully or not)
+ * @property isCancelled True if the job was cancelled
+ * @property childrenCount Number of active child jobs
+ */
+@Serializable
+@SerialName("JobStateChanged")
+data class JobStateChanged(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    override val coroutineId: String,
+    override val jobId: String,
+    override val parentCoroutineId: String?,
+    override val scopeId: String,
+    override val label: String?,
+    val isActive: Boolean,
+    val isCompleted: Boolean,
+    val isCancelled: Boolean,
+    val childrenCount: Int = 0,
+) : CoroutineEvent {
+    override val kind: String get() = "JobStateChanged"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/CoroutineNode.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/CoroutineNode.kt
@@ -1,0 +1,29 @@
+package com.jh.proj.coroutineviz.models
+
+/**
+ * Represents the current state of a single coroutine in the runtime snapshot.
+ *
+ * CoroutineNode is the primary data structure used by [RuntimeSnapshot] to track
+ * coroutine state. It is mutable to allow efficient updates as events are applied.
+ *
+ * @property id Unique identifier for this coroutine (e.g., "coroutine-1")
+ * @property jobId Identifier for the associated Job (e.g., "job-coroutine-1")
+ * @property parentId ID of the parent coroutine, or null if this is a root coroutine
+ * @property scopeId ID of the VizScope that owns this coroutine
+ * @property label Optional human-readable label for this coroutine
+ * @property state Current lifecycle state of the coroutine
+ * @property threadId ID of the thread currently executing this coroutine, if any
+ * @property threadName Name of the thread currently executing this coroutine, if any
+ * @property dispatcherName Name of the dispatcher this coroutine is using
+ */
+data class CoroutineNode(
+    val id: String,
+    val jobId: String,
+    val parentId: String?,
+    val scopeId: String,
+    val label: String?,
+    var state: CoroutineState,
+    var threadId: Long? = null,
+    var threadName: String? = null,
+    var dispatcherName: String? = null,
+)

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/CoroutineState.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/CoroutineState.kt
@@ -1,0 +1,36 @@
+package com.jh.proj.coroutineviz.models
+
+/**
+ * Lifecycle states for a coroutine.
+ *
+ * These states represent the complete lifecycle of a coroutine from creation
+ * to termination. The state machine follows this general flow:
+ *
+ * ```
+ * CREATED → ACTIVE ⇄ SUSPENDED → WAITING_FOR_CHILDREN → COMPLETED
+ *                                                     ↘ CANCELLED
+ *                                                     ↘ FAILED
+ * ```
+ */
+enum class CoroutineState {
+    /** Coroutine has been created but not yet started. */
+    CREATED,
+
+    /** Coroutine is actively executing code on a thread. */
+    ACTIVE,
+
+    /** Coroutine is suspended, waiting to be resumed (e.g., during delay or await). */
+    SUSPENDED,
+
+    /** Coroutine's own code has finished, but it's waiting for child coroutines to complete. */
+    WAITING_FOR_CHILDREN,
+
+    /** Coroutine has completed successfully (including all children). */
+    COMPLETED,
+
+    /** Coroutine was cancelled (by parent, explicit cancellation, or child failure). */
+    CANCELLED,
+
+    /** Coroutine failed with an exception. */
+    FAILED,
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/CoroutineTimeline.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/CoroutineTimeline.kt
@@ -1,0 +1,36 @@
+package com.jh.proj.coroutineviz.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Timeline view for a specific coroutine, with computed durations and aggregated information.
+ */
+@Serializable
+data class CoroutineTimeline(
+    val coroutineId: String,
+    val name: String,
+    val state: String,
+    // Total time from creation to completion (nanos)
+    val totalDuration: Long?,
+    // Time spent actively running (not suspended)
+    val activeDuration: Long? = null,
+    // Time spent suspended
+    val suspendedDuration: Long? = null,
+    val parentId: String? = null,
+    val childrenIds: List<String> = emptyList(),
+    val events: List<TimelineEventSummary> = emptyList(),
+)
+
+/**
+ * Simplified event summary for timeline display
+ */
+@Serializable
+data class TimelineEventSummary(
+    val seq: Long,
+    val tsNanos: Long,
+    val kind: String,
+    val threadName: String? = null,
+    val dispatcherName: String? = null,
+    // For suspension events
+    val reason: String? = null,
+)

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/HierarchyNode.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/HierarchyNode.kt
@@ -1,0 +1,53 @@
+package com.jh.proj.coroutineviz.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a coroutine in the hierarchy tree projection.
+ *
+ * HierarchyNode is used by [ProjectionService] to build parent-child relationship
+ * trees for visualization. Unlike [CoroutineNode], this model is serializable
+ * and includes computed fields like children lists and timing information.
+ *
+ * @property id Unique coroutine identifier
+ * @property parentId ID of parent coroutine, null for root coroutines
+ * @property children List of child coroutine IDs
+ * @property name Display name (label or generated)
+ * @property scopeId ID of the owning VizScope
+ * @property state Current state as a string
+ * @property createdAtNanos Timestamp when coroutine was created
+ * @property completedAtNanos Timestamp when coroutine finished, if applicable
+ * @property dispatcherId ID of the assigned dispatcher
+ * @property dispatcherName Human-readable dispatcher name
+ * @property currentThreadId ID of thread currently executing, if any
+ * @property currentThreadName Name of thread currently executing, if any
+ * @property jobId Associated Job identifier
+ * @property exceptionType Type of exception if failed
+ * @property exceptionMessage Exception message if failed
+ */
+@Serializable
+data class HierarchyNode(
+    // coroutineId
+    val id: String,
+    // parentCoroutineId
+    val parentId: String?,
+    // child coroutine IDs
+    val children: List<String> = emptyList(),
+    // label or generated name
+    val name: String,
+    val scopeId: String,
+    // "CREATED", "RUNNING", "SUSPENDED", "COMPLETED", "CANCELLED", "FAILED"
+    val state: String,
+    val createdAtNanos: Long,
+    val completedAtNanos: Long? = null,
+    val dispatcherId: String? = null,
+    val dispatcherName: String? = null,
+    val currentThreadId: Long? = null,
+    val currentThreadName: String? = null,
+    val jobId: String,
+    // If failed
+    val exceptionType: String? = null,
+    val exceptionMessage: String? = null,
+    val activeChildrenIds: List<String> = emptyList(),
+    val activeChildrenCount: Int = 0,
+)

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/RuntimeSnapshot.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/RuntimeSnapshot.kt
@@ -1,0 +1,32 @@
+package com.jh.proj.coroutineviz.models
+
+import kotlinx.coroutines.Job
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Current state snapshot of all coroutines in a session.
+ *
+ * RuntimeSnapshot provides a mutable view of the current coroutine states,
+ * updated incrementally by [EventApplier] as events are processed. This is
+ * the "current state" in an event-sourcing architecture.
+ *
+ * The snapshot is optimized for fast lookups by coroutine ID, making it
+ * efficient to query the current state of any coroutine.
+ *
+ * @property coroutines Map of coroutine ID to [CoroutineNode] state
+ */
+class RuntimeSnapshot {
+    val coroutines: MutableMap<String, CoroutineNode> = mutableMapOf()
+    private val jobToCoroutineId = ConcurrentHashMap<Job, String>()
+
+    fun registerJob(
+        job: Job,
+        coroutineId: String,
+    ) {
+        jobToCoroutineId[job] = coroutineId
+    }
+
+    fun getCoroutineIdFromJob(job: Job): String? {
+        return jobToCoroutineId[job]
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/SessionInfo.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/SessionInfo.kt
@@ -1,0 +1,20 @@
+package com.jh.proj.coroutineviz.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Summary information about a visualization session.
+ *
+ * Used by [SessionManager] to provide a lightweight overview of sessions
+ * without exposing full session state.
+ *
+ * @property sessionId Unique session identifier
+ * @property coroutineCount Number of coroutines tracked in this session
+ * @property eventCount Total number of events recorded
+ */
+@Serializable
+data class SessionInfo(
+    val sessionId: String,
+    val coroutineCount: Int,
+    val eventCount: Int,
+)

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/ThreadEvent.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/models/ThreadEvent.kt
@@ -1,0 +1,27 @@
+package com.jh.proj.coroutineviz.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Records a coroutine's assignment to or release from a thread.
+ *
+ * ThreadEvent is used by [ProjectionService] to track thread activity over time,
+ * enabling visualizations of which coroutines ran on which threads and when.
+ *
+ * @property coroutineId ID of the coroutine involved
+ * @property threadId System thread ID
+ * @property threadName Human-readable thread name
+ * @property timestamp Nanosecond timestamp of the event
+ * @property eventType Type of thread event: "ASSIGNED" or "RELEASED"
+ * @property dispatcherName Name of the dispatcher that assigned the thread
+ */
+@Serializable
+data class ThreadEvent(
+    val coroutineId: String,
+    val threadId: Long,
+    val threadName: String,
+    val timestamp: Long,
+    // "ASSIGNED", "RELEASED"
+    val eventType: String,
+    val dispatcherName: String? = null,
+)

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/ChannelEventContext.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/ChannelEventContext.kt
@@ -1,0 +1,156 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.channel.ChannelBufferStateChanged
+import com.jh.proj.coroutineviz.events.channel.ChannelClosed
+import com.jh.proj.coroutineviz.events.channel.ChannelCreated
+import com.jh.proj.coroutineviz.events.channel.ChannelReceiveCompleted
+import com.jh.proj.coroutineviz.events.channel.ChannelReceiveStarted
+import com.jh.proj.coroutineviz.events.channel.ChannelReceiveSuspended
+import com.jh.proj.coroutineviz.events.channel.ChannelSendCompleted
+import com.jh.proj.coroutineviz.events.channel.ChannelSendStarted
+import com.jh.proj.coroutineviz.events.channel.ChannelSendSuspended
+
+/**
+ * ChannelEventContext carries common Channel metadata for event creation.
+ *
+ * This provides extension functions that automatically fill in common fields
+ * when emitting Channel-related events, following the same pattern as FlowEventContext.
+ *
+ * Usage:
+ * ```kotlin
+ * val ctx = ChannelEventContext(session, channelId, "my-channel", 0, "RENDEZVOUS")
+ * session.send(ctx.channelCreated())
+ * session.send(ctx.channelSendStarted(coroutineId, "value"))
+ * ```
+ */
+data class ChannelEventContext(
+    val session: VizSession,
+    val channelId: String,
+    val name: String? = null,
+    val capacity: Int,
+    // RENDEZVOUS, BUFFERED, CONFLATED, UNLIMITED
+    val channelType: String,
+) {
+    val sessionId: String get() = session.sessionId
+
+    fun nextSeq(): Long = session.nextSeq()
+
+    fun timestamp(): Long = System.nanoTime()
+}
+
+// ============================================================================
+// Channel Lifecycle Events
+// ============================================================================
+
+fun ChannelEventContext.channelCreated(): ChannelCreated =
+    ChannelCreated(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        name = name,
+        capacity = capacity,
+        channelType = channelType,
+    )
+
+fun ChannelEventContext.channelClosed(cause: String? = null): ChannelClosed =
+    ChannelClosed(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        cause = cause,
+    )
+
+// ============================================================================
+// Channel Send Events
+// ============================================================================
+
+fun ChannelEventContext.channelSendStarted(
+    coroutineId: String,
+    valueDescription: String,
+): ChannelSendStarted =
+    ChannelSendStarted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        coroutineId = coroutineId,
+        valueDescription = valueDescription,
+    )
+
+fun ChannelEventContext.channelSendCompleted(
+    coroutineId: String,
+    valueDescription: String,
+): ChannelSendCompleted =
+    ChannelSendCompleted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        coroutineId = coroutineId,
+        valueDescription = valueDescription,
+    )
+
+fun ChannelEventContext.channelSendSuspended(
+    coroutineId: String,
+    bufferSize: Int,
+): ChannelSendSuspended =
+    ChannelSendSuspended(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        coroutineId = coroutineId,
+        bufferSize = bufferSize,
+        capacity = capacity,
+    )
+
+// ============================================================================
+// Channel Receive Events
+// ============================================================================
+
+fun ChannelEventContext.channelReceiveStarted(coroutineId: String): ChannelReceiveStarted =
+    ChannelReceiveStarted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        coroutineId = coroutineId,
+    )
+
+fun ChannelEventContext.channelReceiveCompleted(
+    coroutineId: String,
+    valueDescription: String,
+): ChannelReceiveCompleted =
+    ChannelReceiveCompleted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        coroutineId = coroutineId,
+        valueDescription = valueDescription,
+    )
+
+fun ChannelEventContext.channelReceiveSuspended(coroutineId: String): ChannelReceiveSuspended =
+    ChannelReceiveSuspended(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        coroutineId = coroutineId,
+    )
+
+// ============================================================================
+// Channel Buffer Events
+// ============================================================================
+
+fun ChannelEventContext.channelBufferStateChanged(currentSize: Int): ChannelBufferStateChanged =
+    ChannelBufferStateChanged(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        channelId = channelId,
+        currentSize = currentSize,
+        capacity = capacity,
+    )

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/EventApplier.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/EventApplier.kt
@@ -1,0 +1,131 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineBodyCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineFailed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineResumed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
+import com.jh.proj.coroutineviz.models.CoroutineNode
+import com.jh.proj.coroutineviz.models.CoroutineState
+import com.jh.proj.coroutineviz.models.RuntimeSnapshot
+import org.slf4j.LoggerFactory
+
+/**
+ * Applies events to update the [RuntimeSnapshot] state.
+ *
+ * The EventApplier is responsible for translating events into state changes
+ * in the runtime snapshot. It implements the "apply" side of event sourcing,
+ * where events are the source of truth and state is derived from them.
+ *
+ * Each event type triggers specific state transitions:
+ * - [CoroutineCreated] → Creates new [CoroutineNode] with CREATED state
+ * - [CoroutineStarted] → Transitions to ACTIVE state
+ * - [CoroutineSuspended] → Transitions to SUSPENDED state
+ * - [CoroutineResumed] → Transitions back to ACTIVE state
+ * - [CoroutineBodyCompleted] → Transitions to WAITING_FOR_CHILDREN state
+ * - [CoroutineCompleted] → Transitions to COMPLETED state
+ * - [CoroutineCancelled] → Transitions to CANCELLED state
+ * - [CoroutineFailed] → Transitions to FAILED state
+ * - [ThreadAssigned] → Updates thread information on the node
+ *
+ * @property snapshot The runtime snapshot to update
+ */
+class EventApplier(
+    private val snapshot: RuntimeSnapshot,
+) {
+    fun apply(event: VizEvent) {
+        when (event) {
+            is CoroutineCreated -> handleCreated(event)
+            is CoroutineStarted -> handleStarted(event)
+            is CoroutineBodyCompleted -> handleBodyCompleted(event)
+            is CoroutineCompleted -> handleCompleted(event)
+            is CoroutineCancelled -> handleCancelled(event)
+            is CoroutineSuspended -> handleSuspended(event)
+            is CoroutineResumed -> handleResumed(event)
+            is ThreadAssigned -> handleThreadAssigned(event)
+            is CoroutineFailed -> handleFailed(event)
+            // Later: DispatcherSelected, ThreadAssigned, Flow events, etc.
+            else -> {
+                // For now we ignore other event types
+            }
+        }
+    }
+
+    private fun handleCreated(e: CoroutineCreated) {
+        snapshot.coroutines[e.coroutineId] =
+            CoroutineNode(
+                id = e.coroutineId,
+                jobId = e.jobId,
+                parentId = e.parentCoroutineId,
+                scopeId = e.scopeId,
+                label = e.label,
+                state = CoroutineState.CREATED,
+            )
+    }
+
+    private fun handleStarted(e: CoroutineStarted) {
+        val node = snapshot.coroutines[e.coroutineId]
+
+        if (node == null) {
+            logger.warn("Received CoroutineStarted for unknown coroutine: ${e.coroutineId}")
+            return
+        }
+
+        if (node.state != CoroutineState.CREATED) {
+            logger.warn("Invalid state transition: ${node.state} -> ACTIVE for ${e.coroutineId}")
+        }
+
+        snapshot.coroutines[e.coroutineId]?.state = CoroutineState.ACTIVE
+    }
+
+    private fun handleBodyCompleted(e: CoroutineBodyCompleted) {
+        val node = snapshot.coroutines[e.coroutineId]
+
+        if (node == null) {
+            logger.warn("Received CoroutineBodyCompleted for unknown coroutine: ${e.coroutineId}")
+            return
+        }
+
+        // Transition to WAITING_FOR_CHILDREN state
+        // This indicates the coroutine's code has finished but it's waiting for children
+        snapshot.coroutines[e.coroutineId]?.state = CoroutineState.WAITING_FOR_CHILDREN
+    }
+
+    private fun handleCompleted(e: CoroutineCompleted) {
+        // Final completion - all children have also completed
+        snapshot.coroutines[e.coroutineId]?.state = CoroutineState.COMPLETED
+    }
+
+    private fun handleCancelled(e: CoroutineCancelled) {
+        snapshot.coroutines[e.coroutineId]?.state = CoroutineState.CANCELLED
+    }
+
+    private fun handleSuspended(e: CoroutineSuspended) {
+        snapshot.coroutines[e.coroutineId]?.state = CoroutineState.SUSPENDED
+    }
+
+    private fun handleResumed(e: CoroutineResumed) {
+        snapshot.coroutines[e.coroutineId]?.state = CoroutineState.ACTIVE
+    }
+
+    private fun handleThreadAssigned(e: ThreadAssigned) {
+        snapshot.coroutines[e.coroutineId]?.apply {
+            threadId = e.threadId
+            threadName = e.threadName
+            dispatcherName = e.dispatcherName
+        }
+    }
+
+    private fun handleFailed(e: CoroutineFailed) {
+        snapshot.coroutines[e.coroutineId]?.state = CoroutineState.FAILED
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(EventApplier::class.java)
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/EventBus.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/EventBus.kt
@@ -1,0 +1,77 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.slf4j.LoggerFactory
+
+/**
+ * Real-time event distribution bus using Kotlin Flow.
+ *
+ * The EventBus provides pub/sub functionality for [VizEvent] instances,
+ * allowing multiple subscribers to receive events as they occur. It uses
+ * a [MutableSharedFlow] with a large buffer (10,000 events) to handle
+ * bursts of events without blocking emitters.
+ *
+ * If the buffer overflows, oldest events are dropped to prevent backpressure
+ * from blocking event emission. This trade-off prioritizes real-time
+ * responsiveness over guaranteed delivery.
+ *
+ * Usage:
+ * ```kotlin
+ * // Subscribe to events
+ * eventBus.stream().collect { event ->
+ *     println("Received: ${event.kind}")
+ * }
+ *
+ * // Emit events (non-blocking)
+ * eventBus.send(event)
+ * ```
+ */
+class EventBus {
+    private val logger = LoggerFactory.getLogger(EventBus::class.java)
+
+    private val flow =
+        MutableSharedFlow<VizEvent>(
+            extraBufferCapacity = 10_000,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    /** Callback invoked on each successful emit. */
+    var onEmit: (() -> Unit)? = null
+
+    /** Callback invoked when an event is dropped. */
+    var onDrop: (() -> Unit)? = null
+
+    /**
+     * Non-suspending event emission.
+     * Returns true if event was emitted, false if buffer is full (rare).
+     */
+    fun send(event: VizEvent): Boolean {
+        val emitted = flow.tryEmit(event)
+        if (emitted) {
+            onEmit?.invoke()
+        } else {
+            logger.error("Event buffer full! Dropped event: ${event.kind} (seq=${event.seq})")
+            onDrop?.invoke()
+        }
+        return emitted
+    }
+
+    /**
+     * Suspending version for compatibility.
+     * Use this if you need backpressure handling.
+     */
+    suspend fun sendSuspend(event: VizEvent) {
+        flow.emit(event)
+    }
+
+    /**
+     * Get a Flow to subscribe to events.
+     *
+     * @return Cold flow that emits all future events
+     */
+    fun stream(): Flow<VizEvent> = flow.asSharedFlow()
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/EventContext.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/EventContext.kt
@@ -1,0 +1,273 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.SuspensionPoint
+import com.jh.proj.coroutineviz.events.WaitingForChildren
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineBodyCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineFailed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineResumed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
+import com.jh.proj.coroutineviz.events.job.JobCancellationRequested
+import com.jh.proj.coroutineviz.events.job.JobJoinCompleted
+import com.jh.proj.coroutineviz.events.job.JobJoinRequested
+import com.jh.proj.coroutineviz.events.job.JobStateChanged
+
+/**
+ * EventContext carries common coroutine metadata for event creation.
+ *
+ * This eliminates repetitive boilerplate when emitting events by providing
+ * extension functions that automatically fill in common fields.
+ *
+ * Usage:
+ * ```kotlin
+ * val ctx = EventContext(session, coroutineId, jobId, parentId, scopeId, label)
+ * session.send(ctx.coroutineStarted())
+ * session.send(ctx.jobJoinRequested(waitingCoroutineId))
+ * ```
+ */
+data class EventContext(
+    val session: VizSession,
+    val coroutineId: String,
+    val jobId: String,
+    val parentCoroutineId: String?,
+    val scopeId: String,
+    val label: String?,
+) {
+    // Common fields derived from context
+    val sessionId: String get() = session.sessionId
+
+    // Helper methods
+    fun nextSeq(): Long = session.nextSeq()
+
+    fun timestamp(): Long = System.nanoTime()
+}
+
+// ============================================================================
+// Coroutine Lifecycle Events
+// ============================================================================
+
+fun EventContext.coroutineCreated(): CoroutineCreated =
+    CoroutineCreated(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+    )
+
+fun EventContext.coroutineStarted(): CoroutineStarted =
+    CoroutineStarted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+    )
+
+fun EventContext.coroutineBodyCompleted(): CoroutineBodyCompleted =
+    CoroutineBodyCompleted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+    )
+
+fun EventContext.coroutineCompleted(): CoroutineCompleted =
+    CoroutineCompleted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+    )
+
+fun EventContext.coroutineCancelled(cause: String?): CoroutineCancelled =
+    CoroutineCancelled(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        cause = cause,
+    )
+
+fun EventContext.coroutineFailed(
+    exceptionType: String?,
+    message: String?,
+): CoroutineFailed =
+    CoroutineFailed(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        exceptionType = exceptionType,
+        stackTrace = emptyList(),
+        message = message,
+    )
+
+// ============================================================================
+// Suspension & Resumption Events
+// ============================================================================
+
+fun EventContext.coroutineSuspended(
+    reason: String,
+    durationMillis: Long? = null,
+    suspensionPoint: SuspensionPoint? = null,
+): CoroutineSuspended =
+    CoroutineSuspended(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        reason = reason,
+        durationMillis = durationMillis,
+        suspensionPoint = suspensionPoint,
+    )
+
+fun EventContext.coroutineResumed(): CoroutineResumed =
+    CoroutineResumed(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+    )
+
+// ============================================================================
+// Job Operation Events
+// ============================================================================
+
+fun EventContext.jobJoinRequested(waitingCoroutineId: String?): JobJoinRequested =
+    JobJoinRequested(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        waitingCoroutineId = waitingCoroutineId,
+    )
+
+fun EventContext.jobJoinCompleted(waitingCoroutineId: String?): JobJoinCompleted =
+    JobJoinCompleted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        waitingCoroutineId = waitingCoroutineId,
+    )
+
+fun EventContext.jobCancellationRequested(
+    requestedBy: String?,
+    cause: String?,
+): JobCancellationRequested =
+    JobCancellationRequested(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        requestedBy = requestedBy,
+        cause = cause,
+    )
+
+fun EventContext.jobStateChanged(
+    isActive: Boolean,
+    isCompleted: Boolean,
+    isCancelled: Boolean,
+    childrenCount: Int = 0,
+): JobStateChanged =
+    JobStateChanged(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        isActive = isActive,
+        isCompleted = isCompleted,
+        isCancelled = isCancelled,
+        childrenCount = childrenCount,
+    )
+
+// ============================================================================
+// Thread Assignment Events
+// ============================================================================
+
+fun EventContext.threadAssigned(
+    threadId: Long,
+    threadName: String,
+    dispatcherName: String?,
+): ThreadAssigned =
+    ThreadAssigned(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        threadId = threadId,
+        threadName = threadName,
+        dispatcherName = dispatcherName,
+    )
+
+fun EventContext.waitingForChildren(
+    activeChildrenCount: Int,
+    activeChildrenIds: List<String>,
+): WaitingForChildren =
+    WaitingForChildren(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId,
+        jobId = jobId,
+        parentCoroutineId = parentCoroutineId,
+        scopeId = scopeId,
+        label = label,
+        activeChildrenCount = activeChildrenCount,
+        activeChildrenIds = activeChildrenIds,
+    )

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/EventStore.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/EventStore.kt
@@ -1,0 +1,62 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+/**
+ * Append-only event log for persisting visualization events.
+ *
+ * The EventStore provides durable storage of all events emitted during
+ * a session. Events are stored in emission order and can be replayed
+ * to reconstruct state or for debugging purposes.
+ *
+ * This implementation uses [ArrayDeque] with a [ReentrantReadWriteLock]
+ * for thread-safe concurrent access. When the store reaches [maxEvents],
+ * the oldest events are evicted to bound memory usage.
+ *
+ * @param maxEvents Maximum number of events to retain. Oldest events
+ *   are evicted when this limit is exceeded.
+ */
+class EventStore(private val maxEvents: Int = 100_000) {
+    private val events = ArrayDeque<VizEvent>()
+    private val lock = ReentrantReadWriteLock()
+
+    /** Optional callback invoked each time an event is evicted. */
+    var onEvict: (() -> Unit)? = null
+
+    /**
+     * Append an event to the store.
+     * If the store exceeds [maxEvents], the oldest event is evicted.
+     *
+     * @param event The event to store
+     */
+    fun append(event: VizEvent) {
+        lock.write {
+            events.addLast(event)
+            while (events.size > maxEvents) {
+                events.removeFirst()
+                onEvict?.invoke()
+            }
+        }
+    }
+
+    /**
+     * Retrieve all stored events in emission order.
+     *
+     * @return Defensive copy of all events
+     */
+    fun all(): List<VizEvent> =
+        lock.read {
+            events.toList()
+        }
+
+    /**
+     * Current number of stored events.
+     */
+    fun size(): Int =
+        lock.read {
+            events.size
+        }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/FlowEventContext.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/FlowEventContext.kt
@@ -1,0 +1,297 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.flow.FlowBackpressure
+import com.jh.proj.coroutineviz.events.flow.FlowBufferOverflow
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionCancelled
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionCompleted
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionStarted
+import com.jh.proj.coroutineviz.events.flow.FlowCreated
+import com.jh.proj.coroutineviz.events.flow.FlowOperatorApplied
+import com.jh.proj.coroutineviz.events.flow.FlowValueEmitted
+import com.jh.proj.coroutineviz.events.flow.FlowValueFiltered
+import com.jh.proj.coroutineviz.events.flow.FlowValueTransformed
+import com.jh.proj.coroutineviz.events.flow.SharedFlowEmission
+import com.jh.proj.coroutineviz.events.flow.SharedFlowSubscription
+import com.jh.proj.coroutineviz.events.flow.StateFlowValueChanged
+
+/**
+ * FlowEventContext carries common Flow metadata for event creation.
+ *
+ * This provides extension functions that automatically fill in common fields
+ * when emitting Flow-related events, similar to EventContext for coroutines.
+ *
+ * Usage:
+ * ```kotlin
+ * val ctx = FlowEventContext(session, flowId, "Cold", "my-flow", coroutineId)
+ * session.send(ctx.flowCreated())
+ * session.send(ctx.flowValueEmitted(collectorId, 0, value))
+ * ```
+ */
+data class FlowEventContext(
+    val session: VizSession,
+    val flowId: String,
+    // "Cold", "Hot", "StateFlow", "SharedFlow"
+    val flowType: String,
+    val label: String? = null,
+    val coroutineId: String? = null,
+    val scopeId: String? = null,
+    // For operator chains
+    val sourceFlowId: String? = null,
+    val operatorIndex: Int = 0,
+) {
+    val sessionId: String get() = session.sessionId
+
+    fun nextSeq(): Long = session.nextSeq()
+
+    fun timestamp(): Long = System.nanoTime()
+
+    /**
+     * Create a child context for an operator in the chain.
+     */
+    fun forOperator(
+        newFlowId: String,
+        operatorName: String,
+        newOperatorIndex: Int,
+    ): FlowEventContext =
+        copy(
+            flowId = newFlowId,
+            sourceFlowId = this.flowId,
+            operatorIndex = newOperatorIndex,
+        )
+}
+
+// ============================================================================
+// Flow Lifecycle Events
+// ============================================================================
+
+fun FlowEventContext.flowCreated(): FlowCreated =
+    FlowCreated(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId ?: "unknown",
+        flowId = flowId,
+        flowType = flowType,
+        label = label,
+        scopeId = scopeId,
+    )
+
+fun FlowEventContext.flowCollectionStarted(collectorId: String): FlowCollectionStarted =
+    FlowCollectionStarted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId ?: "unknown",
+        flowId = flowId,
+        collectorId = collectorId,
+        label = label,
+    )
+
+fun FlowEventContext.flowValueEmitted(
+    collectorId: String,
+    sequenceNumber: Int,
+    value: Any?,
+): FlowValueEmitted =
+    FlowValueEmitted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId ?: "unknown",
+        flowId = flowId,
+        collectorId = collectorId,
+        sequenceNumber = sequenceNumber,
+        valuePreview = value?.toString()?.take(200) ?: "null",
+        valueType = value?.javaClass?.simpleName ?: "null",
+    )
+
+fun FlowEventContext.flowCollectionCompleted(
+    collectorId: String,
+    totalEmissions: Int,
+    durationNanos: Long,
+): FlowCollectionCompleted =
+    FlowCollectionCompleted(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId ?: "unknown",
+        flowId = flowId,
+        collectorId = collectorId,
+        totalEmissions = totalEmissions,
+        durationNanos = durationNanos,
+    )
+
+fun FlowEventContext.flowCollectionCancelled(
+    collectorId: String,
+    reason: String?,
+    emittedCount: Int,
+): FlowCollectionCancelled =
+    FlowCollectionCancelled(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId ?: "unknown",
+        flowId = flowId,
+        collectorId = collectorId,
+        reason = reason,
+        emittedCount = emittedCount,
+    )
+
+fun FlowEventContext.flowBufferOverflow(
+    droppedValue: Any?,
+    bufferSize: Int,
+    overflowStrategy: String,
+): FlowBufferOverflow =
+    FlowBufferOverflow(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        coroutineId = coroutineId ?: "unknown",
+        flowId = flowId,
+        droppedValue = droppedValue?.toString()?.take(100),
+        bufferSize = bufferSize,
+        overflowStrategy = overflowStrategy,
+    )
+
+// ============================================================================
+// Flow Operator Events
+// ============================================================================
+
+fun FlowEventContext.flowOperatorApplied(operatorName: String): FlowOperatorApplied =
+    FlowOperatorApplied(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        flowId = flowId,
+        sourceFlowId = sourceFlowId ?: flowId,
+        operatorName = operatorName,
+        operatorIndex = operatorIndex,
+        label = label,
+        coroutineId = coroutineId,
+    )
+
+fun FlowEventContext.flowValueTransformed(
+    operatorName: String,
+    inputValue: Any?,
+    outputValue: Any?,
+    sequenceNumber: Int,
+    collectorId: String? = null,
+): FlowValueTransformed =
+    FlowValueTransformed(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        flowId = flowId,
+        operatorName = operatorName,
+        inputValuePreview = inputValue?.toString()?.take(200) ?: "null",
+        outputValuePreview = outputValue?.toString()?.take(200) ?: "null",
+        inputType = inputValue?.javaClass?.simpleName ?: "null",
+        outputType = outputValue?.javaClass?.simpleName ?: "null",
+        sequenceNumber = sequenceNumber,
+        coroutineId = coroutineId,
+        collectorId = collectorId,
+    )
+
+fun FlowEventContext.flowValueFiltered(
+    operatorName: String,
+    value: Any?,
+    passed: Boolean,
+    sequenceNumber: Int,
+    collectorId: String? = null,
+): FlowValueFiltered =
+    FlowValueFiltered(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        flowId = flowId,
+        operatorName = operatorName,
+        valuePreview = value?.toString()?.take(200) ?: "null",
+        valueType = value?.javaClass?.simpleName ?: "null",
+        passed = passed,
+        sequenceNumber = sequenceNumber,
+        coroutineId = coroutineId,
+        collectorId = collectorId,
+    )
+
+fun FlowEventContext.flowBackpressure(
+    collectorId: String,
+    reason: String,
+    pendingEmissions: Int,
+    bufferCapacity: Int? = null,
+    durationNanos: Long? = null,
+): FlowBackpressure =
+    FlowBackpressure(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        flowId = flowId,
+        collectorId = collectorId,
+        reason = reason,
+        pendingEmissions = pendingEmissions,
+        bufferCapacity = bufferCapacity,
+        durationNanos = durationNanos,
+        coroutineId = coroutineId,
+    )
+
+// ============================================================================
+// StateFlow Events
+// ============================================================================
+
+fun FlowEventContext.stateFlowValueChanged(
+    oldValue: Any?,
+    newValue: Any?,
+    subscriberCount: Int,
+): StateFlowValueChanged =
+    StateFlowValueChanged(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        flowId = flowId,
+        oldValuePreview = oldValue?.toString()?.take(200) ?: "null",
+        newValuePreview = newValue?.toString()?.take(200) ?: "null",
+        valueType = newValue?.javaClass?.simpleName ?: "null",
+        subscriberCount = subscriberCount,
+        coroutineId = coroutineId,
+        label = label,
+    )
+
+// ============================================================================
+// SharedFlow Events
+// ============================================================================
+
+fun FlowEventContext.sharedFlowEmission(
+    value: Any?,
+    subscriberCount: Int,
+    replayCache: Int,
+    extraBufferCapacity: Int,
+): SharedFlowEmission =
+    SharedFlowEmission(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        flowId = flowId,
+        valuePreview = value?.toString()?.take(200) ?: "null",
+        valueType = value?.javaClass?.simpleName ?: "null",
+        subscriberCount = subscriberCount,
+        replayCache = replayCache,
+        extraBufferCapacity = extraBufferCapacity,
+        coroutineId = coroutineId,
+        label = label,
+    )
+
+fun FlowEventContext.sharedFlowSubscription(
+    collectorId: String,
+    // "subscribed" or "unsubscribed"
+    action: String,
+    subscriberCount: Int,
+): SharedFlowSubscription =
+    SharedFlowSubscription(
+        sessionId = sessionId,
+        seq = nextSeq(),
+        tsNanos = timestamp(),
+        flowId = flowId,
+        collectorId = collectorId,
+        action = action,
+        subscriberCount = subscriberCount,
+        coroutineId = coroutineId,
+        label = label,
+    )

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/JobStatusMonitor.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/JobStatusMonitor.kt
@@ -1,0 +1,85 @@
+package com.jh.proj.coroutineviz.session
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+class JobStatusMonitor(
+    private val session: VizSession,
+    private val poolingIntervalMs: Long = 30L,
+) {
+    private val trackedJobs = ConcurrentHashMap<String, TrackedJob>()
+    private var monitorJob: Job? = null
+
+    fun track(
+        job: Job,
+        jobId: String,
+        coroutineId: String,
+    ) {
+        trackedJobs[coroutineId] =
+            TrackedJob(
+                coroutineId = coroutineId,
+                jobId = jobId,
+                job = job,
+                lastChildrenCount = job.children.count(),
+            )
+    }
+
+    fun start() {
+        monitorJob =
+            session.sessionScope.launch {
+                while (isActive) {
+                    delay(poolingIntervalMs)
+                    pollAllJobs()
+                }
+            }
+    }
+
+    private fun pollAllJobs() {
+        trackedJobs.values.forEach { tracked ->
+            val currentChildrenCount = tracked.job.children.count()
+            // Only emit if children count changed
+            if (currentChildrenCount != tracked.lastChildrenCount) {
+                val ctx =
+                    EventContext(
+                        session = session,
+                        coroutineId = tracked.coroutineId,
+                        jobId = tracked.jobId,
+                        // Could enhance this
+                        parentCoroutineId = null,
+                        scopeId = "unknown",
+                        label = null,
+                    )
+
+                session.send(
+                    ctx.jobStateChanged(
+                        isActive = tracked.job.isActive,
+                        isCompleted = tracked.job.isCompleted,
+                        isCancelled = tracked.job.isCancelled,
+                        childrenCount = currentChildrenCount,
+                    ),
+                )
+
+                tracked.lastChildrenCount = currentChildrenCount
+            }
+
+            // Cleanup completed jobs
+            if (tracked.job.isCompleted) {
+                trackedJobs.remove(tracked.coroutineId)
+            }
+        }
+    }
+
+    fun stop() {
+        monitorJob?.cancel()
+    }
+
+    private data class TrackedJob(
+        val coroutineId: String,
+        val jobId: String,
+        val job: Job,
+        var lastChildrenCount: Int,
+    )
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/ProjectionService.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/ProjectionService.kt
@@ -1,0 +1,277 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.WaitingForChildren
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineBodyCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineFailed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineResumed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import com.jh.proj.coroutineviz.events.dispatcher.DispatcherSelected
+import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
+import com.jh.proj.coroutineviz.events.job.JobStateChanged
+import com.jh.proj.coroutineviz.models.CoroutineTimeline
+import com.jh.proj.coroutineviz.models.HierarchyNode
+import com.jh.proj.coroutineviz.models.ThreadEvent
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Computes derived views (projections) from raw events.
+ *
+ * The ProjectionService subscribes to the [EventBus] and maintains
+ * computed views that are useful for visualization, such as:
+ * - Coroutine hierarchy trees (parent-child relationships)
+ * - Thread activity timelines (which coroutines ran on which threads)
+ * - Individual coroutine timelines with computed durations
+ *
+ * This implements the "read model" side of CQRS, where projections are
+ * optimized for specific query patterns rather than being normalized.
+ *
+ * Usage:
+ * ```kotlin
+ * val hierarchy = projectionService.getHierarchyTree()
+ * val threadActivity = projectionService.getThreadActivity()
+ * val timeline = projectionService.getCoroutineTimeline(coroutineId)
+ * ```
+ *
+ * @property session The session to subscribe to for events
+ */
+class ProjectionService(
+    private val session: VizSession,
+) {
+    // In-memory state
+    private val coroutines = ConcurrentHashMap<String, HierarchyNode>()
+    private val threadActivity = ConcurrentHashMap<String, MutableList<ThreadEvent>>()
+
+    init {
+        // Subscribe to event bus
+        session.sessionScope.launch {
+            session.eventBus.stream().collect { event ->
+                processEvent(event)
+            }
+        }
+    }
+
+    private fun processEvent(event: VizEvent) {
+        when (event) {
+            is CoroutineCreated -> {
+                coroutines[event.coroutineId] =
+                    HierarchyNode(
+                        id = event.coroutineId,
+                        parentId = event.parentCoroutineId,
+                        name = event.label ?: event.coroutineId,
+                        scopeId = event.scopeId,
+                        state = "CREATED",
+                        createdAtNanos = event.tsNanos,
+                        jobId = event.jobId,
+                    )
+
+                // Add to parent's children list
+                event.parentCoroutineId?.let { parentId ->
+                    coroutines[parentId]?.let { parent ->
+                        coroutines[parentId] =
+                            parent.copy(
+                                children = parent.children + event.coroutineId,
+                            )
+                    }
+                }
+            }
+
+            is CoroutineStarted -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] = node.copy(state = "RUNNING")
+                }
+            }
+
+            is ThreadAssigned -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] =
+                        node.copy(
+                            currentThreadId = event.threadId,
+                            currentThreadName = event.threadName,
+                        )
+                }
+
+                // Track thread activity
+                threadActivity.getOrPut(event.threadId.toString()) { mutableListOf() }
+                    .add(
+                        ThreadEvent(
+                            coroutineId = event.coroutineId,
+                            threadId = event.threadId,
+                            threadName = event.threadName,
+                            timestamp = event.tsNanos,
+                            eventType = "ASSIGNED",
+                            dispatcherName = event.dispatcherName,
+                        ),
+                    )
+            }
+
+            is CoroutineSuspended -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] = node.copy(state = "SUSPENDED")
+                }
+            }
+
+            is CoroutineCompleted -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] =
+                        node.copy(
+                            state = "COMPLETED",
+                            completedAtNanos = event.tsNanos,
+                        )
+                }
+            }
+
+            is CoroutineCancelled -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] =
+                        node.copy(
+                            state = "CANCELLED",
+                            completedAtNanos = event.tsNanos,
+                        )
+                }
+            }
+
+            is CoroutineFailed -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] =
+                        node.copy(
+                            state = "FAILED",
+                            completedAtNanos = event.tsNanos,
+                        )
+                }
+            }
+
+            is CoroutineResumed -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] = node.copy(state = "RUNNING")
+                }
+            }
+
+            is CoroutineBodyCompleted -> {
+                // Body finished, but coroutine may still be waiting for children
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] = node.copy(state = "WAITING_FOR_CHILDREN")
+                }
+            }
+
+            is DispatcherSelected -> {
+                // Track dispatcher information
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] =
+                        node.copy(
+                            dispatcherId = event.dispatcherId,
+                            dispatcherName = event.dispatcherName,
+                        )
+                }
+            }
+
+            is WaitingForChildren -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    coroutines[event.coroutineId] =
+                        node.copy(
+                            state = "WAITING_FOR_CHILDREN",
+                            activeChildrenIds = event.activeChildrenIds,
+                            activeChildrenCount = event.activeChildrenCount,
+                        )
+                }
+            }
+
+            is JobStateChanged -> {
+                coroutines[event.coroutineId]?.let { node ->
+                    val newState =
+                        when {
+                            event.isCancelled -> "CANCELLED"
+                            event.isCompleted -> "COMPLETED"
+                            !event.isActive && event.childrenCount > 0 -> "WAITING_FOR_CHILDREN"
+                            event.isActive -> "ACTIVE"
+                            else -> node.state
+                        }
+
+                    coroutines[event.coroutineId] =
+                        node.copy(
+                            state = newState,
+                        )
+                }
+            }
+
+            // Ignore other event types (job operations, deferred, etc.)
+            else -> { /* Ignore events we don't track in hierarchy */ }
+        }
+    }
+
+    /**
+     * Get hierarchy tree, optionally filtered by scopeId
+     */
+    fun getHierarchyTree(scopeId: String? = null): List<HierarchyNode> {
+        val filtered =
+            coroutines.values
+                .filter { scopeId == null || it.scopeId == scopeId }
+
+        // Find root nodes (no parent)
+        val roots = filtered.filter { it.parentId == null }
+
+        // Return full tree (children are referenced by IDs)
+        return buildTree(roots, filtered)
+    }
+
+    private fun buildTree(
+        roots: List<HierarchyNode>,
+        allNodes: List<HierarchyNode>,
+    ): List<HierarchyNode> {
+        // Could return flat list or nested structure
+        // Frontend can rebuild tree from parent/children IDs
+        return allNodes.sortedBy { it.createdAtNanos }
+    }
+
+    /**
+     * Get thread activity timeline
+     */
+    fun getThreadActivity(): Map<String, List<ThreadEvent>> {
+        return threadActivity.mapValues { (_, events) ->
+            events.sortedBy { it.timestamp }
+        }
+    }
+
+    /**
+     * Get timeline for specific coroutine
+     */
+    fun getCoroutineTimeline(coroutineId: String): CoroutineTimeline? {
+        val node = coroutines[coroutineId] ?: return null
+
+        // Could aggregate events for this coroutine
+        // Return computed timeline with durations
+        return CoroutineTimeline(
+            coroutineId = coroutineId,
+            name = node.name,
+            state = node.state,
+            totalDuration = node.completedAtNanos?.let { it - node.createdAtNanos },
+            // ... more computed fields ...
+        )
+    }
+
+    /**
+     * Get all active children of a coroutine
+     */
+    fun getActiveChildren(coroutineId: String): List<HierarchyNode> {
+        val parent = coroutines[coroutineId] ?: return emptyList()
+        return parent.children.mapNotNull { childId ->
+            coroutines[childId]?.takeIf {
+                it.state in listOf("ACTIVE", "RUNNING", "SUSPENDED")
+            }
+        }
+    }
+
+    /**
+     * Check if coroutine is waiting for children
+     */
+    fun isWaitingForChildren(coroutineId: String): Boolean {
+        val node = coroutines[coroutineId] ?: return false
+        return node.state == "WAITING_FOR_CHILDREN" ||
+            (node.state == "BODY_COMPLETED" && getActiveChildren(coroutineId).isNotEmpty())
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/SessionManager.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/SessionManager.kt
@@ -1,0 +1,95 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.models.SessionInfo
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Manages active visualization sessions.
+ *
+ * Sessions are stored in memory and can be accessed across multiple API calls.
+ * This allows clients to:
+ * - Create a session
+ * - Run scenarios in that session
+ * - Stream events from that session via SSE
+ * - Query the session snapshot
+ */
+object SessionManager {
+    private val logger = LoggerFactory.getLogger(SessionManager::class.java)
+    private val sessions = ConcurrentHashMap<String, VizSession>()
+
+    private var maxEventsPerSession: Int = 100_000
+
+    /** Callback invoked when a new session is created. */
+    var onSessionCreated: ((VizSession) -> Unit)? = null
+
+    /** Callback invoked when a session is closed, with the session ID. */
+    var onSessionClosed: ((String) -> Unit)? = null
+
+    /**
+     * Configure session defaults. Call before creating sessions.
+     */
+    fun configure(maxEventsPerSession: Int = 100_000) {
+        this.maxEventsPerSession = maxEventsPerSession
+        logger.info("SessionManager configured: maxEventsPerSession=$maxEventsPerSession")
+    }
+
+    /**
+     * Create a new visualization session.
+     */
+    fun createSession(name: String? = null): VizSession {
+        val sessionId =
+            name?.let { "$it-${System.currentTimeMillis()}" }
+                ?: "session-${System.currentTimeMillis()}"
+
+        val session = VizSession(sessionId, maxEvents = maxEventsPerSession)
+        sessions[sessionId] = session
+
+        logger.info("Created session: $sessionId")
+        onSessionCreated?.invoke(session)
+        return session
+    }
+
+    /**
+     * Get an existing session by ID.
+     */
+    fun getSession(sessionId: String): VizSession? {
+        return sessions[sessionId]
+    }
+
+    /**
+     * List all active sessions.
+     */
+    fun listSessions(): List<SessionInfo> {
+        return sessions.values.map { session ->
+            SessionInfo(
+                sessionId = session.sessionId,
+                coroutineCount = session.snapshot.coroutines.size,
+                eventCount = session.store.all().size,
+            )
+        }
+    }
+
+    /**
+     * Close and remove a session.
+     */
+    fun closeSession(sessionId: String): Boolean {
+        val removed = sessions.remove(sessionId)
+        if (removed != null) {
+            removed.close() // Clean up session resources
+            logger.info("Closed session: $sessionId")
+            onSessionClosed?.invoke(sessionId)
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Clear all sessions (useful for testing).
+     */
+    fun clearAll() {
+        val count = sessions.size
+        sessions.clear()
+        logger.info("Cleared all sessions: $count removed")
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/VizSession.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/session/VizSession.kt
@@ -1,0 +1,263 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.job.JobStateChanged
+import com.jh.proj.coroutineviz.models.RuntimeSnapshot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Central container for a visualization session.
+ *
+ * A VizSession holds all the state and infrastructure needed to track coroutine
+ * execution within a single visualization context. Each session maintains:
+ * - An [EventBus] for real-time event distribution to subscribers
+ * - An [EventStore] for persistent storage of all events
+ * - A [RuntimeSnapshot] reflecting current coroutine states
+ * - A [ProjectionService] for computing derived views (timelines, hierarchies)
+ *
+ * Events flow through the session in the following order:
+ * 1. Event is appended to [store] (persistent log)
+ * 2. Event is applied to [snapshot] via [EventApplier] (state update)
+ * 3. Event is broadcast via [eventBus] (real-time notifications)
+ *
+ * @property sessionId Unique identifier for this session
+ */
+class VizSession(
+    val sessionId: String,
+    maxEvents: Int = 100_000,
+) {
+    // Session-scoped coroutine scope for async operations
+    val sessionScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    val eventBus = EventBus()
+    val bus = eventBus // Alias for backwards compatibility
+    val store = EventStore(maxEvents)
+    val snapshot = RuntimeSnapshot()
+    val jobMonitor = JobStatusMonitor(session = this, 100)
+
+    private val applier = EventApplier(snapshot)
+    private var monitoringEnabled = false
+
+    // Sequence generator to keep events globally ordered in this session
+    private val seqGenerator = AtomicLong(0)
+
+    val projectionService = ProjectionService(this)
+
+    /**
+     * Allocate next sequence number.
+     */
+    fun nextSeq(): Long = seqGenerator.incrementAndGet()
+
+    /**
+     * Non-suspending event send - PREFERRED for most use cases.
+     * Synchronously emits event to bus, stores it, and updates snapshot.
+     */
+    fun send(event: VizEvent) {
+        store.append(event)
+        applier.apply(event)
+        eventBus.send(event)
+    }
+
+    /**
+     * Async event send - for non-coroutine contexts.
+     * Launches on session scope to emit event asynchronously.
+     */
+    fun sendAsync(event: VizEvent) {
+        sessionScope.launch {
+            send(event)
+        }
+    }
+
+    /**
+     * Suspending version - for backwards compatibility.
+     * Delegates to synchronous send() since bus.send() doesn't suspend.
+     */
+    fun sent(event: VizEvent) {
+        send(event)
+    }
+
+    fun enableJobMonitoring() {
+        if (!monitoringEnabled) {
+            jobMonitor.start()
+            monitoringEnabled = true
+        }
+    }
+
+    /**
+     * Clean up session resources.
+     * Call this when session is closed.
+     */
+    fun close() {
+        jobMonitor.stop()
+        sessionScope.cancel()
+    }
+
+    fun coroutineLifecycleFlow(): Flow<CoroutineEvent> {
+        return eventBus.stream()
+            .filterIsInstance<CoroutineEvent>()
+            .filter { event ->
+                event.kind in
+                    setOf(
+                        "CoroutineCreated",
+                        "CoroutineStarted",
+                        "CoroutineSuspended",
+                        "CoroutineResumed",
+                        "CoroutineCompleted",
+                        "CoroutineCancelled",
+                        "CoroutineFailed",
+                        "CoroutineBodyCompleted",
+                    )
+            }
+    }
+
+    fun jobStateFlow(): Flow<JobStateChanged> {
+        return eventBus.stream().filterIsInstance<JobStateChanged>()
+    }
+
+    fun mergeTimeFlow(): Flow<VizEvent> {
+        return merge(coroutineLifecycleFlow(), jobStateFlow())
+    }
+
+    /**
+     * Get merged flow of coroutine lifecycle + job state events,
+     * sorted by timestamp (newest first)
+     */
+    fun mergedTimelineFlow(newestFirst: Boolean = true): Flow<VizEvent> {
+        return merge(
+            coroutineLifecycleFlow(),
+            jobStateFlow(),
+        ).let { flow ->
+            if (newestFirst) {
+                // For real-time streams, events are already time-ordered
+                // But we can buffer and sort if needed
+                flow
+            } else {
+                flow
+            }
+        }
+    }
+
+    /**
+     * Get paired flow that correlates coroutine events with job state changes
+     * Events are paired if they share the same jobId/coroutineId
+     */
+    fun correlatedFlow(): Flow<CorrelatedEventPair> {
+        val coroutineFlow = coroutineLifecycleFlow()
+        val jobFlow = jobStateFlow()
+
+        return combine(coroutineFlow, jobFlow) { coroutineEvent, jobEvent ->
+            // Correlate by jobId
+            if (coroutineEvent.jobId == jobEvent.jobId) {
+                CorrelatedEventPair(
+                    coroutineEvent = coroutineEvent,
+                    jobEvent = jobEvent,
+                    timeDelta = coroutineEvent.tsNanos - jobEvent.tsNanos,
+                )
+            } else {
+                null
+            }
+        }.filterNotNull()
+    }
+
+    /**
+     * Get timeline for specific coroutine, with both lifecycle and job events
+     * Returns list sorted by timestamp (newest first by default)
+     */
+    fun getCoroutineTimeline(
+        coroutineId: String,
+        newestFirst: Boolean = true,
+    ): List<VizEvent> {
+        val allEvents = store.all()
+
+        val filtered =
+            allEvents.filter { event ->
+                when (event) {
+                    is CoroutineEvent -> event.coroutineId == coroutineId
+                    is JobStateChanged -> {
+                        // Find if this job belongs to our coroutine
+                        snapshot.coroutines[coroutineId]?.jobId == event.jobId
+                    }
+                    else -> false
+                }
+            }
+
+        return if (newestFirst) {
+            filtered.sortedByDescending { it.tsNanos }
+        } else {
+            filtered.sortedBy { it.tsNanos }
+        }
+    }
+
+    /**
+     * Get split timeline (two separate lists)
+     */
+    fun getSplitTimeline(
+        coroutineId: String,
+        newestFirst: Boolean = true,
+    ): SplitTimeline {
+        val allEvents = store.all()
+
+        val coroutineEvents =
+            allEvents
+                .filterIsInstance<CoroutineEvent>()
+                .filter { it.coroutineId == coroutineId }
+
+        val jobId = snapshot.coroutines[coroutineId]?.jobId
+        val jobEvents =
+            if (jobId != null) {
+                allEvents
+                    .filterIsInstance<JobStateChanged>()
+                    .filter { it.jobId == jobId }
+            } else {
+                emptyList()
+            }
+
+        return SplitTimeline(
+            coroutineEvents =
+                if (newestFirst) {
+                    coroutineEvents.sortedByDescending { it.tsNanos }
+                } else {
+                    coroutineEvents.sortedBy { it.tsNanos }
+                },
+            jobEvents =
+                if (newestFirst) {
+                    jobEvents.sortedByDescending { it.tsNanos }
+                } else {
+                    jobEvents.sortedBy { it.tsNanos }
+                },
+            merged =
+                if (newestFirst) {
+                    (coroutineEvents + jobEvents).sortedByDescending { it.tsNanos }
+                } else {
+                    (coroutineEvents + jobEvents).sortedBy { it.tsNanos }
+                },
+        )
+    }
+}
+
+// Data classes for the new types
+data class CorrelatedEventPair(
+    val coroutineEvent: CoroutineEvent,
+    val jobEvent: JobStateChanged,
+    // coroutineEvent.tsNanos - jobEvent.tsNanos
+    val timeDelta: Long,
+)
+
+data class SplitTimeline(
+    val coroutineEvents: List<CoroutineEvent>,
+    val jobEvents: List<JobStateChanged>,
+    // Both types merged and sorted
+    val merged: List<VizEvent>,
+)

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/sync/DeadlockDetector.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/sync/DeadlockDetector.kt
@@ -1,0 +1,318 @@
+package com.jh.proj.coroutineviz.sync
+
+import com.jh.proj.coroutineviz.events.DeadlockAnalysisResult
+import com.jh.proj.coroutineviz.events.DeadlockDetected
+import com.jh.proj.coroutineviz.events.PotentialDeadlockWarning
+import com.jh.proj.coroutineviz.session.VizSession
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Deadlock detector for coroutine synchronization primitives.
+ *
+ * This detector monitors mutex acquisition patterns and identifies:
+ * 1. Actual deadlocks (circular wait conditions)
+ * 2. Potential deadlock risks (inconsistent lock ordering)
+ *
+ * The detector uses a wait-for graph algorithm to detect cycles.
+ *
+ * Real-world applications:
+ * - Database transaction deadlock prevention
+ * - Resource allocation monitoring
+ * - Multi-threaded application debugging
+ */
+class DeadlockDetector(
+    private val session: VizSession,
+) {
+    // Track what each coroutine is waiting for
+    private val waitingFor = ConcurrentHashMap<String, MutexWait>()
+
+    // Track what mutexes each coroutine holds
+    private val holding = ConcurrentHashMap<String, MutableSet<MutexHold>>()
+
+    // Track mutex ownership
+    private val mutexOwners = ConcurrentHashMap<String, OwnerInfo>()
+
+    data class MutexWait(
+        val coroutineId: String,
+        val coroutineLabel: String?,
+        val mutexId: String,
+        val mutexLabel: String?,
+        val timestamp: Long,
+    )
+
+    data class MutexHold(
+        val mutexId: String,
+        val mutexLabel: String?,
+        val acquiredAt: Long,
+    )
+
+    data class OwnerInfo(
+        val coroutineId: String,
+        val coroutineLabel: String?,
+    )
+
+    /**
+     * Record that a coroutine is waiting for a mutex
+     */
+    fun recordWaiting(
+        coroutineId: String,
+        coroutineLabel: String?,
+        mutexId: String,
+        mutexLabel: String?,
+    ) {
+        waitingFor[coroutineId] =
+            MutexWait(
+                coroutineId, coroutineLabel, mutexId, mutexLabel, System.nanoTime(),
+            )
+
+        // Check for deadlock after recording
+        val result = detectDeadlock()
+        handleDeadlockResult(result)
+    }
+
+    /**
+     * Record that a coroutine has acquired a mutex
+     */
+    fun recordAcquired(
+        coroutineId: String,
+        coroutineLabel: String?,
+        mutexId: String,
+        mutexLabel: String?,
+    ) {
+        // Remove from waiting
+        waitingFor.remove(coroutineId)
+
+        // Add to holding
+        holding.getOrPut(coroutineId) { mutableSetOf() }
+            .add(MutexHold(mutexId, mutexLabel, System.nanoTime()))
+
+        // Update ownership
+        mutexOwners[mutexId] = OwnerInfo(coroutineId, coroutineLabel)
+    }
+
+    /**
+     * Record that a coroutine has released a mutex
+     */
+    fun recordReleased(
+        coroutineId: String,
+        mutexId: String,
+    ) {
+        holding[coroutineId]?.removeIf { it.mutexId == mutexId }
+        mutexOwners.remove(mutexId)
+    }
+
+    /**
+     * Detect deadlock using cycle detection in wait-for graph
+     */
+    fun detectDeadlock(): DeadlockAnalysisResult {
+        // Build the wait-for graph
+        // Node: coroutineId
+        // Edge: coroutineA -> coroutineB means A is waiting for a mutex held by B
+
+        val waitForGraph = mutableMapOf<String, String>()
+
+        for ((waitingCoroutine, waitInfo) in waitingFor) {
+            val owner = mutexOwners[waitInfo.mutexId]
+            if (owner != null && owner.coroutineId != waitingCoroutine) {
+                waitForGraph[waitingCoroutine] = owner.coroutineId
+            }
+        }
+
+        // Detect cycle using DFS
+        val visited = mutableSetOf<String>()
+        val recursionStack = mutableSetOf<String>()
+        val path = mutableListOf<String>()
+
+        for (node in waitForGraph.keys) {
+            val cycle = detectCycleDFS(node, waitForGraph, visited, recursionStack, path)
+            if (cycle != null) {
+                return buildDeadlockResult(cycle)
+            }
+        }
+
+        // Check for potential deadlock patterns (inconsistent lock ordering)
+        return checkPotentialDeadlock()
+    }
+
+    private fun detectCycleDFS(
+        node: String,
+        graph: Map<String, String>,
+        visited: MutableSet<String>,
+        recursionStack: MutableSet<String>,
+        path: MutableList<String>,
+    ): List<String>? {
+        if (recursionStack.contains(node)) {
+            // Found cycle - extract it from path
+            val cycleStart = path.indexOf(node)
+            return if (cycleStart >= 0) {
+                path.subList(cycleStart, path.size) + node
+            } else {
+                listOf(node)
+            }
+        }
+
+        if (visited.contains(node)) {
+            return null
+        }
+
+        visited.add(node)
+        recursionStack.add(node)
+        path.add(node)
+
+        val next = graph[node]
+        if (next != null) {
+            val cycle = detectCycleDFS(next, graph, visited, recursionStack, path)
+            if (cycle != null) {
+                return cycle
+            }
+        }
+
+        recursionStack.remove(node)
+        path.removeAt(path.size - 1)
+        return null
+    }
+
+    private fun buildDeadlockResult(cycle: List<String>): DeadlockAnalysisResult.DeadlockFound {
+        val cycleLabels =
+            cycle.map { coroutineId ->
+                waitingFor[coroutineId]?.coroutineLabel
+                    ?: holding[coroutineId]?.firstOrNull()?.mutexLabel
+            }
+
+        val involvedMutexes = mutableSetOf<String>()
+        val mutexLabels = mutableListOf<String?>()
+
+        for (coroutineId in cycle) {
+            waitingFor[coroutineId]?.let {
+                involvedMutexes.add(it.mutexId)
+                mutexLabels.add(it.mutexLabel)
+            }
+            holding[coroutineId]?.forEach {
+                involvedMutexes.add(it.mutexId)
+                mutexLabels.add(it.mutexLabel)
+            }
+        }
+
+        return DeadlockAnalysisResult.DeadlockFound(
+            cycle = cycle,
+            cycleLabels = cycleLabels,
+            involvedMutexes = involvedMutexes.toList(),
+            mutexLabels = mutexLabels.distinct(),
+        )
+    }
+
+    private fun checkPotentialDeadlock(): DeadlockAnalysisResult {
+        // Check for lock ordering violations
+        // If a coroutine holds mutex A and requests mutex B,
+        // and another coroutine ever held B then A (in that order),
+        // we have a potential deadlock risk
+
+        for ((coroutineId, waitInfo) in waitingFor) {
+            val heldMutexes = holding[coroutineId] ?: continue
+
+            for (held in heldMutexes) {
+                // Check if any other coroutine has acquired these in opposite order
+                for ((otherId, otherHeld) in holding) {
+                    if (otherId == coroutineId) continue
+
+                    val holdsRequestedMutex = otherHeld.any { it.mutexId == waitInfo.mutexId }
+                    val otherWaiting = waitingFor[otherId]
+                    val waitingForHeldMutex = otherWaiting?.mutexId == held.mutexId
+
+                    if (holdsRequestedMutex && waitingForHeldMutex) {
+                        return DeadlockAnalysisResult.PotentialDeadlock(
+                            coroutineId = coroutineId,
+                            holdingMutex = held.mutexId,
+                            requestingMutex = waitInfo.mutexId,
+                            reason =
+                                "Lock ordering violation: $coroutineId holds ${held.mutexId} and requests ${waitInfo.mutexId}, " +
+                                    "but $otherId holds ${waitInfo.mutexId} and requests ${held.mutexId}",
+                        )
+                    }
+                }
+            }
+        }
+
+        return DeadlockAnalysisResult.NoDeadlock
+    }
+
+    private fun handleDeadlockResult(result: DeadlockAnalysisResult) {
+        when (result) {
+            is DeadlockAnalysisResult.DeadlockFound -> {
+                // Build wait and hold graphs for the event
+                val waitGraph = mutableMapOf<String, String>()
+                val holdGraph = mutableMapOf<String, String>()
+
+                for (coroutineId in result.cycle) {
+                    waitingFor[coroutineId]?.let {
+                        waitGraph[coroutineId] = it.mutexId
+                    }
+                    holding[coroutineId]?.forEach { held ->
+                        holdGraph[held.mutexId] = coroutineId
+                    }
+                }
+
+                session.send(
+                    DeadlockDetected(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        involvedCoroutines = result.cycle,
+                        involvedCoroutineLabels = result.cycleLabels,
+                        involvedMutexes = result.involvedMutexes,
+                        involvedMutexLabels = result.mutexLabels,
+                        waitGraph = waitGraph,
+                        holdGraph = holdGraph,
+                        cycleDescription = buildCycleDescription(result),
+                    ),
+                )
+            }
+
+            is DeadlockAnalysisResult.PotentialDeadlock -> {
+                val waitInfo = waitingFor[result.coroutineId]
+                val holdInfo = holding[result.coroutineId]?.find { it.mutexId == result.holdingMutex }
+
+                session.send(
+                    PotentialDeadlockWarning(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        coroutineId = result.coroutineId,
+                        coroutineLabel = waitInfo?.coroutineLabel,
+                        holdingMutex = result.holdingMutex,
+                        holdingMutexLabel = holdInfo?.mutexLabel,
+                        requestingMutex = result.requestingMutex,
+                        requestingMutexLabel = waitInfo?.mutexLabel,
+                        recommendation = "Consider acquiring locks in a consistent order (e.g., alphabetically by mutex label)",
+                    ),
+                )
+            }
+
+            DeadlockAnalysisResult.NoDeadlock -> {
+                // No action needed
+            }
+        }
+    }
+
+    private fun buildCycleDescription(result: DeadlockAnalysisResult.DeadlockFound): String {
+        val parts = mutableListOf<String>()
+        for (i in result.cycle.indices) {
+            val coroutine = result.cycle[i]
+            val label = result.cycleLabels.getOrNull(i) ?: coroutine
+            val waitInfo = waitingFor[coroutine]
+            val heldMutexes = holding[coroutine]?.map { it.mutexId } ?: emptyList()
+
+            parts.add("$label holds [${heldMutexes.joinToString()}] and waits for [${waitInfo?.mutexId ?: "?"}]")
+        }
+        return parts.joinToString(" → ")
+    }
+
+    /**
+     * Clear all tracking data
+     */
+    fun reset() {
+        waitingFor.clear()
+        holding.clear()
+        mutexOwners.clear()
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/RealTimeValidator.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/RealTimeValidator.kt
@@ -1,0 +1,87 @@
+package com.jh.proj.coroutineviz.validation
+
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+
+/**
+ * Subscribes to the EventBus and runs validation rules on debounced event batches.
+ * Findings are emitted as ValidationFindingEmitted events via VizSession.send()
+ * (which assigns proper seq numbers).
+ *
+ * IMPORTANT: Filters out ValidationFindingEmitted events from the input stream
+ * to avoid an infinite feedback loop (validator emits finding → finding triggers
+ * validator → validator emits finding → ...).
+ */
+class RealTimeValidator(
+    private val registry: ValidationRuleRegistry,
+    private val session: VizSession,
+    private val scope: CoroutineScope,
+) {
+    private val logger = LoggerFactory.getLogger(RealTimeValidator::class.java)
+    private var job: Job? = null
+
+    // Track previously emitted findings to avoid re-emitting duplicates
+    private val emittedFindingKeys = mutableSetOf<String>()
+
+    /**
+     * Start real-time validation. Runs rules on debounced event batches.
+     */
+    @OptIn(FlowPreview::class)
+    fun start() {
+        if (job?.isActive == true) return
+
+        job =
+            scope.launch {
+                session.eventBus.stream()
+                    // Filter out our own output to prevent infinite loop
+                    .filter { it !is ValidationFindingEmitted }
+                    .debounce(500)
+                    .map { _ ->
+                        val events = session.store.all()
+                        registry.validateAll(events)
+                    }
+                    .collect { findings ->
+                        if (findings.isNotEmpty()) {
+                            // Only emit findings we haven't emitted before
+                            val newFindings =
+                                findings.filter { finding ->
+                                    val key = "${finding.ruleId}:${finding.coroutineId}:${finding.message}"
+                                    emittedFindingKeys.add(key) // returns false if already present
+                                }
+
+                            if (newFindings.isNotEmpty()) {
+                                logger.debug("Real-time validation: ${newFindings.size} new findings for session ${session.sessionId}")
+                                for (finding in newFindings) {
+                                    // Use session.send() to get proper seq assignment
+                                    session.send(
+                                        ValidationFindingEmitted(
+                                            sessionId = session.sessionId,
+                                            seq = session.nextSeq(),
+                                            tsNanos = System.nanoTime(),
+                                            finding = finding,
+                                        ),
+                                    )
+                                }
+                            }
+                        }
+                    }
+            }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+
+    fun reset() {
+        emittedFindingKeys.clear()
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/SuggestionProvider.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/SuggestionProvider.kt
@@ -1,0 +1,165 @@
+package com.jh.proj.coroutineviz.validation
+
+/**
+ * Provides fix recommendations with code snippets for validation findings.
+ */
+object SuggestionProvider {
+    data class Suggestion(
+        val title: String,
+        val description: String,
+        val codeSnippet: String? = null,
+        val documentation: String? = null,
+    )
+
+    fun getSuggestion(finding: RuleFinding): Suggestion {
+        return when {
+            finding.ruleId.startsWith("lifecycle.") -> getLifecycleSuggestion(finding)
+            finding.ruleId.startsWith("hierarchy.") || finding.ruleId.startsWith("structured-concurrency.") ->
+                getStructuredConcurrencySuggestion(
+                    finding,
+                )
+            finding.ruleId.startsWith("performance.") -> getPerformanceSuggestion(finding)
+            finding.ruleId.startsWith("threading.") -> getThreadingSuggestion(finding)
+            finding.ruleId.startsWith("exception.") -> getExceptionSuggestion(finding)
+            finding.ruleId.startsWith("resource.") -> getResourceSuggestion(finding)
+            else -> Suggestion(title = "Review", description = finding.suggestion)
+        }
+    }
+
+    private fun getLifecycleSuggestion(finding: RuleFinding): Suggestion =
+        when (finding.ruleId) {
+            "lifecycle.created-has-started" ->
+                Suggestion(
+                    title = "Ensure coroutine starts",
+                    description = "The coroutine was created but never started. This can happen if the scope is cancelled immediately.",
+                    codeSnippet =
+                        """
+                        // Use coroutineScope to ensure structured startup
+                        coroutineScope {
+                            launch { /* work */ }
+                        }
+                        """.trimIndent(),
+                )
+            "lifecycle.started-has-terminal" ->
+                Suggestion(
+                    title = "Ensure coroutine completes",
+                    description = "The coroutine started but never reached a terminal state. This may indicate a leaked coroutine.",
+                    codeSnippet =
+                        """
+                        // Use withTimeout to prevent infinite running
+                        withTimeout(30_000) {
+                            // work that should complete within 30s
+                        }
+                        """.trimIndent(),
+                )
+            else -> Suggestion(title = "Review lifecycle", description = finding.suggestion)
+        }
+
+    private fun getStructuredConcurrencySuggestion(finding: RuleFinding): Suggestion =
+        Suggestion(
+            title = "Use structured concurrency",
+            description = finding.suggestion,
+            codeSnippet =
+                """
+                // Prefer coroutineScope/supervisorScope over manual Job management
+                coroutineScope {
+                    val result1 = async { fetchData1() }
+                    val result2 = async { fetchData2() }
+                    combine(result1.await(), result2.await())
+                }
+                """.trimIndent(),
+        )
+
+    private fun getPerformanceSuggestion(finding: RuleFinding): Suggestion =
+        when (finding.ruleId) {
+            "performance.main-thread-blocking" ->
+                Suggestion(
+                    title = "Move work off Main dispatcher",
+                    description = finding.suggestion,
+                    codeSnippet =
+                        """
+                        // Use withContext to switch dispatchers
+                        withContext(Dispatchers.IO) {
+                            // blocking I/O work
+                        }
+                        withContext(Dispatchers.Default) {
+                            // CPU-intensive work
+                        }
+                        """.trimIndent(),
+                )
+            "performance.excessive-creation" ->
+                Suggestion(
+                    title = "Limit concurrent coroutines",
+                    description = finding.suggestion,
+                    codeSnippet =
+                        """
+                        // Use a Semaphore to limit concurrency
+                        val semaphore = Semaphore(10)
+                        items.map { item ->
+                            async {
+                                semaphore.withPermit { process(item) }
+                            }
+                        }.awaitAll()
+                        """.trimIndent(),
+                )
+            else -> Suggestion(title = "Optimize performance", description = finding.suggestion)
+        }
+
+    private fun getThreadingSuggestion(finding: RuleFinding): Suggestion =
+        Suggestion(
+            title = "Review threading",
+            description = finding.suggestion,
+            codeSnippet =
+                """
+                // Use Mutex for shared mutable state
+                val mutex = Mutex()
+                var sharedState = 0
+                mutex.withLock { sharedState++ }
+                """.trimIndent(),
+        )
+
+    private fun getExceptionSuggestion(finding: RuleFinding): Suggestion =
+        Suggestion(
+            title = "Handle exceptions properly",
+            description = finding.suggestion,
+            codeSnippet =
+                """
+                // Don't swallow CancellationException
+                try {
+                    suspendingWork()
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    handleError(e)
+                }
+                """.trimIndent(),
+        )
+
+    private fun getResourceSuggestion(finding: RuleFinding): Suggestion =
+        when (finding.ruleId) {
+            "resource.mutex-lock-leak" ->
+                Suggestion(
+                    title = "Use withLock",
+                    description = finding.suggestion,
+                    codeSnippet =
+                        """
+                        // Always prefer withLock over manual lock/unlock
+                        mutex.withLock {
+                            // critical section — automatically unlocked
+                        }
+                        """.trimIndent(),
+                )
+            "resource.unclosed-channel" ->
+                Suggestion(
+                    title = "Close channels",
+                    description = finding.suggestion,
+                    codeSnippet =
+                        """
+                        // Use produce builder for auto-closing
+                        val channel = produce {
+                            for (item in items) send(item)
+                        } // auto-closed when block completes
+                        """.trimIndent(),
+                )
+            else -> Suggestion(title = "Manage resources", description = finding.suggestion)
+        }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/ValidationFindingEmitted.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/ValidationFindingEmitted.kt
@@ -1,0 +1,20 @@
+package com.jh.proj.coroutineviz.validation
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted when real-time validation detects an issue.
+ * Streamed via SSE so the frontend can update the validation dashboard in real-time.
+ */
+@Serializable
+@SerialName("ValidationFindingEmitted")
+data class ValidationFindingEmitted(
+    override val sessionId: String,
+    override val seq: Long,
+    override val tsNanos: Long,
+    val finding: RuleFinding,
+) : VizEvent {
+    override val kind: String get() = "ValidationFindingEmitted"
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/ValidationRule.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/ValidationRule.kt
@@ -1,0 +1,72 @@
+package com.jh.proj.coroutineviz.validation
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Categories for validation rules.
+ */
+enum class ValidationCategory {
+    LIFECYCLE,
+    STRUCTURED_CONCURRENCY,
+    PERFORMANCE,
+    THREADING,
+    EXCEPTION_HANDLING,
+    RESOURCE_MANAGEMENT,
+}
+
+/**
+ * Severity levels for validation findings.
+ */
+enum class ValidationSeverity {
+    ERROR,
+    WARNING,
+    INFO,
+}
+
+/**
+ * A single finding produced by a validation rule.
+ */
+@Serializable
+data class RuleFinding(
+    val ruleId: String,
+    val ruleName: String,
+    // ValidationSeverity name
+    val severity: String,
+    // ValidationCategory name
+    val category: String,
+    val message: String,
+    val suggestion: String,
+    val affectedEntities: List<String> = emptyList(),
+    val eventSeq: Long? = null,
+    val coroutineId: String? = null,
+)
+
+/**
+ * Interface for all validation rules in the correctness engine.
+ *
+ * Each rule inspects the event stream and/or runtime snapshot to detect
+ * issues, anti-patterns, or correctness violations.
+ */
+interface ValidationRule {
+    /** Unique identifier for this rule (e.g., "lifecycle.created-has-started"). */
+    val id: String
+
+    /** Human-readable name. */
+    val name: String
+
+    /** Description of what this rule checks. */
+    val description: String
+
+    /** Category this rule belongs to. */
+    val category: ValidationCategory
+
+    /** Default severity when this rule is violated. */
+    val severity: ValidationSeverity
+
+    /**
+     * Run this rule against the given events.
+     * Returns a list of findings (empty if no issues found).
+     */
+    fun validate(events: List<VizEvent>): List<RuleFinding>
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/ValidationRuleRegistry.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/ValidationRuleRegistry.kt
@@ -1,0 +1,78 @@
+package com.jh.proj.coroutineviz.validation
+
+import com.jh.proj.coroutineviz.events.VizEvent
+
+/**
+ * Registry for all validation rules.
+ * Rules are registered at startup and can be queried by category or id.
+ */
+class ValidationRuleRegistry {
+    private val rules = mutableMapOf<String, ValidationRule>()
+
+    /**
+     * Register a validation rule. Overwrites any existing rule with the same id.
+     */
+    fun register(rule: ValidationRule) {
+        rules[rule.id] = rule
+    }
+
+    /**
+     * Register multiple rules at once.
+     */
+    fun registerAll(vararg rulesToRegister: ValidationRule) {
+        rulesToRegister.forEach { register(it) }
+    }
+
+    /**
+     * Get a rule by its id.
+     */
+    fun get(id: String): ValidationRule? = rules[id]
+
+    /**
+     * Get all registered rules.
+     */
+    fun all(): List<ValidationRule> = rules.values.toList()
+
+    /**
+     * Get rules filtered by category.
+     */
+    fun byCategory(category: ValidationCategory): List<ValidationRule> = rules.values.filter { it.category == category }
+
+    /**
+     * Get rules filtered by severity.
+     */
+    fun bySeverity(severity: ValidationSeverity): List<ValidationRule> = rules.values.filter { it.severity == severity }
+
+    /**
+     * Run all registered rules against the given events.
+     * Returns all findings across all rules.
+     */
+    fun validateAll(events: List<VizEvent>): List<RuleFinding> = rules.values.flatMap { it.validate(events) }
+
+    /**
+     * Run rules in a specific category.
+     */
+    fun validateCategory(
+        category: ValidationCategory,
+        events: List<VizEvent>,
+    ): List<RuleFinding> = byCategory(category).flatMap { it.validate(events) }
+
+    /**
+     * Get a summary of registered rules.
+     */
+    fun summary(): RegistrySummary {
+        val byCat = rules.values.groupBy { it.category }
+        val bySev = rules.values.groupBy { it.severity }
+        return RegistrySummary(
+            totalRules = rules.size,
+            byCategory = byCat.mapValues { it.value.size },
+            bySeverity = bySev.mapValues { it.value.size },
+        )
+    }
+}
+
+data class RegistrySummary(
+    val totalRules: Int,
+    val byCategory: Map<ValidationCategory, Int>,
+    val bySeverity: Map<ValidationSeverity, Int>,
+)

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/ExceptionHandlingRules.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/ExceptionHandlingRules.kt
@@ -1,0 +1,105 @@
+package com.jh.proj.coroutineviz.validation.rules
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineFailed
+import com.jh.proj.coroutineviz.validation.RuleFinding
+import com.jh.proj.coroutineviz.validation.ValidationCategory
+import com.jh.proj.coroutineviz.validation.ValidationRule
+import com.jh.proj.coroutineviz.validation.ValidationSeverity
+
+/**
+ * Detect coroutines that swallow CancellationException (cancel then complete instead of cancel).
+ */
+class SwallowedCancellationRule : ValidationRule {
+    override val id = "exception.swallowed-cancellation"
+    override val name = "Swallowed Cancellation"
+    override val description = "Detect coroutines that may be swallowing CancellationException"
+    override val category = ValidationCategory.EXCEPTION_HANDLING
+    override val severity = ValidationSeverity.WARNING
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+
+        // Find coroutines where cancellation was requested but coroutine completed normally
+        val cancellationRequested =
+            events
+                .filter { it.kind == "JobCancellationRequested" }
+                .filterIsInstance<CoroutineEvent>()
+                .map { it.coroutineId }
+                .toSet()
+
+        for (coroutineId in cancellationRequested) {
+            val cEvents = byCoroutine[coroutineId] ?: continue
+            val completed = cEvents.any { it.kind == "CoroutineCompleted" }
+            val cancelled = cEvents.any { it is CoroutineCancelled }
+
+            if (completed && !cancelled) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Coroutine $coroutineId had cancellation requested but completed normally",
+                        suggestion =
+                            "Avoid catching CancellationException without rethrowing. " +
+                                "Use try { } catch (e: Exception) { if (e is CancellationException) throw e }.",
+                        coroutineId = coroutineId,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Detect unhandled exceptions in launch coroutines (no CoroutineExceptionHandler).
+ */
+class UncaughtExceptionInLaunchRule : ValidationRule {
+    override val id = "exception.uncaught-in-launch"
+    override val name = "Uncaught Exception in Launch"
+    override val description = "Detect launch coroutines that fail without exception handling"
+    override val category = ValidationCategory.EXCEPTION_HANDLING
+    override val severity = ValidationSeverity.WARNING
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+        val createEvents = events.filterIsInstance<CoroutineCreated>()
+
+        for (created in createEvents) {
+            val cEvents = byCoroutine[created.coroutineId] ?: continue
+            val failed = cEvents.filterIsInstance<CoroutineFailed>().firstOrNull() ?: continue
+
+            // If this is a root coroutine (no parent) that failed, it likely crashed
+            if (created.parentCoroutineId == null) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message =
+                            "Root coroutine '${created.label ?: created.coroutineId}' failed with " +
+                                "${failed.exceptionType ?: "unknown exception"}: ${failed.message ?: "no message"}",
+                        suggestion =
+                            "Add a CoroutineExceptionHandler to the scope or use supervisorScope to prevent " +
+                                "unhandled exceptions from crashing the application.",
+                        coroutineId = created.coroutineId,
+                        eventSeq = failed.seq,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/HierarchyRules.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/HierarchyRules.kt
@@ -1,0 +1,119 @@
+package com.jh.proj.coroutineviz.validation.rules
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.validation.RuleFinding
+import com.jh.proj.coroutineviz.validation.ValidationCategory
+import com.jh.proj.coroutineviz.validation.ValidationRule
+import com.jh.proj.coroutineviz.validation.ValidationSeverity
+
+private val TERMINAL_KINDS = setOf("CoroutineCompleted", "CoroutineCancelled", "CoroutineFailed")
+
+/**
+ * Children must be created after their parent is created.
+ */
+class ChildCreatedAfterParentRule : ValidationRule {
+    override val id = "hierarchy.child-created-after-parent"
+    override val name = "Child Created After Parent"
+    override val description = "Children must be created after their parent coroutine"
+    override val category = ValidationCategory.STRUCTURED_CONCURRENCY
+    override val severity = ValidationSeverity.ERROR
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+        val createEvents = coroutineEvents.filterIsInstance<CoroutineCreated>()
+        val findings = mutableListOf<RuleFinding>()
+
+        for (childCreated in createEvents) {
+            val parentId = childCreated.parentCoroutineId ?: continue
+            val parentEvents = byCoroutine[parentId]
+
+            if (parentEvents == null) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Child ${childCreated.coroutineId} references non-existent parent $parentId",
+                        suggestion = "Verify parent coroutine exists and is properly instrumented.",
+                        coroutineId = childCreated.coroutineId,
+                        eventSeq = childCreated.seq,
+                    ),
+                )
+                continue
+            }
+
+            val parentCreated = parentEvents.filterIsInstance<CoroutineCreated>().firstOrNull()
+            if (parentCreated != null && childCreated.seq <= parentCreated.seq) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message =
+                            "Child ${childCreated.coroutineId} created (seq=${childCreated.seq}) " +
+                                "before parent $parentId (seq=${parentCreated.seq})",
+                        suggestion = "This indicates incorrect parent-child relationship or event ordering.",
+                        coroutineId = childCreated.coroutineId,
+                        eventSeq = childCreated.seq,
+                        affectedEntities = listOf(parentId),
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Parent must not complete before all children have terminated.
+ */
+class ParentWaitsForChildrenRule : ValidationRule {
+    override val id = "hierarchy.parent-waits-for-children"
+    override val name = "Parent Waits For Children"
+    override val description = "Parent must not complete before all children (structured concurrency)"
+    override val category = ValidationCategory.STRUCTURED_CONCURRENCY
+    override val severity = ValidationSeverity.ERROR
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+        val createEvents = coroutineEvents.filterIsInstance<CoroutineCreated>()
+        val findings = mutableListOf<RuleFinding>()
+
+        for (childCreated in createEvents) {
+            val parentId = childCreated.parentCoroutineId ?: continue
+            val parentEvents = byCoroutine[parentId] ?: continue
+            val childEvents = byCoroutine[childCreated.coroutineId] ?: continue
+
+            val parentCompleted = parentEvents.firstOrNull { it is CoroutineCompleted } ?: continue
+            val childTerminal = childEvents.firstOrNull { it.kind in TERMINAL_KINDS }
+
+            if (childTerminal == null || parentCompleted.seq < childTerminal.seq) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message =
+                            "Parent $parentId completed (seq=${parentCompleted.seq}) before child ${childCreated.coroutineId}" +
+                                if (childTerminal != null) " terminated (seq=${childTerminal.seq})" else " terminated",
+                        suggestion = "Use structured concurrency (coroutineScope, supervisorScope) to ensure parent waits for children.",
+                        coroutineId = childCreated.coroutineId,
+                        eventSeq = parentCompleted.seq,
+                        affectedEntities = listOf(parentId),
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/LifecycleRules.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/LifecycleRules.kt
@@ -1,0 +1,128 @@
+package com.jh.proj.coroutineviz.validation.rules
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.validation.RuleFinding
+import com.jh.proj.coroutineviz.validation.ValidationCategory
+import com.jh.proj.coroutineviz.validation.ValidationRule
+import com.jh.proj.coroutineviz.validation.ValidationSeverity
+
+private val TERMINAL_KINDS = setOf("CoroutineCompleted", "CoroutineCancelled", "CoroutineFailed")
+
+/**
+ * Every CoroutineCreated must have a matching CoroutineStarted.
+ */
+class CreatedHasStartedRule : ValidationRule {
+    override val id = "lifecycle.created-has-started"
+    override val name = "Created Has Started"
+    override val description = "Every CoroutineCreated must have a matching CoroutineStarted"
+    override val category = ValidationCategory.LIFECYCLE
+    override val severity = ValidationSeverity.ERROR
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val byCoroutine = events.filterIsInstance<CoroutineEvent>().groupBy { it.coroutineId }
+        val findings = mutableListOf<RuleFinding>()
+
+        for ((coroutineId, coroutineEvents) in byCoroutine) {
+            val hasCreated = coroutineEvents.any { it is CoroutineCreated }
+            val hasStarted = coroutineEvents.any { it is CoroutineStarted }
+
+            if (hasCreated && !hasStarted) {
+                val createSeq = coroutineEvents.first { it is CoroutineCreated }.seq
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Coroutine $coroutineId was created but never started",
+                        suggestion = "Ensure the coroutine scope is not cancelled before the coroutine can start.",
+                        coroutineId = coroutineId,
+                        eventSeq = createSeq,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Every started coroutine must reach a terminal state.
+ */
+class StartedHasTerminalRule : ValidationRule {
+    override val id = "lifecycle.started-has-terminal"
+    override val name = "Started Has Terminal"
+    override val description = "Every started coroutine must reach Completed, Cancelled, or Failed"
+    override val category = ValidationCategory.LIFECYCLE
+    override val severity = ValidationSeverity.WARNING
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val byCoroutine = events.filterIsInstance<CoroutineEvent>().groupBy { it.coroutineId }
+        val findings = mutableListOf<RuleFinding>()
+
+        for ((coroutineId, coroutineEvents) in byCoroutine) {
+            val hasStarted = coroutineEvents.any { it is CoroutineStarted }
+            val hasTerminal = coroutineEvents.any { it.kind in TERMINAL_KINDS }
+
+            if (hasStarted && !hasTerminal) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Coroutine $coroutineId was started but never terminated",
+                        suggestion = "This may indicate a leaked coroutine. Ensure structured concurrency or explicit cancellation.",
+                        coroutineId = coroutineId,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * No events should appear for a coroutine after its terminal event.
+ */
+class NoEventsAfterTerminalRule : ValidationRule {
+    override val id = "lifecycle.no-events-after-terminal"
+    override val name = "No Events After Terminal"
+    override val description = "No lifecycle events should appear after a coroutine's terminal event"
+    override val category = ValidationCategory.LIFECYCLE
+    override val severity = ValidationSeverity.ERROR
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val byCoroutine = events.filterIsInstance<CoroutineEvent>().groupBy { it.coroutineId }
+        val findings = mutableListOf<RuleFinding>()
+
+        for ((coroutineId, coroutineEvents) in byCoroutine) {
+            val sorted = coroutineEvents.sortedBy { it.seq }
+            val terminalEvent = sorted.firstOrNull { it.kind in TERMINAL_KINDS } ?: continue
+            val eventsAfter = sorted.filter { it.seq > terminalEvent.seq }
+
+            if (eventsAfter.isNotEmpty()) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Coroutine $coroutineId has ${eventsAfter.size} event(s) after terminal state (${terminalEvent.kind})",
+                        suggestion = "This indicates a bug in event ordering or duplicate event emission.",
+                        coroutineId = coroutineId,
+                        eventSeq = terminalEvent.seq,
+                        affectedEntities = eventsAfter.map { "${it.kind}@seq=${it.seq}" },
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/PerformanceRules.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/PerformanceRules.kt
@@ -1,0 +1,153 @@
+package com.jh.proj.coroutineviz.validation.rules
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import com.jh.proj.coroutineviz.events.dispatcher.DispatcherSelected
+import com.jh.proj.coroutineviz.validation.RuleFinding
+import com.jh.proj.coroutineviz.validation.ValidationCategory
+import com.jh.proj.coroutineviz.validation.ValidationRule
+import com.jh.proj.coroutineviz.validation.ValidationSeverity
+
+/**
+ * Detect long-running work on the Main dispatcher without suspension.
+ */
+class MainThreadBlockingRule : ValidationRule {
+    override val id = "performance.main-thread-blocking"
+    override val name = "Main Thread Blocking"
+    override val description = "Detect coroutines that block the Main dispatcher for too long"
+    override val category = ValidationCategory.PERFORMANCE
+    override val severity = ValidationSeverity.ERROR
+
+    companion object {
+        const val THRESHOLD_NANOS = 50_000_000L // 50ms
+    }
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val dispatchers = events.filterIsInstance<DispatcherSelected>()
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+
+        val mainCoroutines =
+            dispatchers
+                .filter { it.dispatcherName.contains("Main", ignoreCase = true) }
+                .map { it.coroutineId }
+                .toSet()
+
+        for (coroutineId in mainCoroutines) {
+            val cEvents = byCoroutine[coroutineId] ?: continue
+            val started = cEvents.filterIsInstance<CoroutineStarted>().firstOrNull() ?: continue
+            val suspensions = cEvents.filterIsInstance<CoroutineSuspended>()
+            val terminal = cEvents.firstOrNull { it.kind in setOf("CoroutineCompleted", "CoroutineCancelled", "CoroutineFailed") }
+
+            if (terminal != null && suspensions.isEmpty()) {
+                val duration = terminal.tsNanos - started.tsNanos
+                if (duration > THRESHOLD_NANOS) {
+                    findings.add(
+                        RuleFinding(
+                            ruleId = id,
+                            ruleName = name,
+                            severity = severity.name,
+                            category = category.name,
+                            message = "Coroutine $coroutineId ran ${duration / 1_000_000}ms on Main without suspending",
+                            suggestion = "Move CPU-intensive or blocking work to Dispatchers.IO or Dispatchers.Default.",
+                            coroutineId = coroutineId,
+                            eventSeq = started.seq,
+                        ),
+                    )
+                }
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Detect excessive coroutine creation (coroutine explosion).
+ */
+class ExcessiveCoroutineCreationRule : ValidationRule {
+    override val id = "performance.excessive-creation"
+    override val name = "Excessive Coroutine Creation"
+    override val description = "Detect creation of too many coroutines in a short time window"
+    override val category = ValidationCategory.PERFORMANCE
+    override val severity = ValidationSeverity.WARNING
+
+    companion object {
+        const val THRESHOLD = 100
+        const val WINDOW_NANOS = 1_000_000_000L // 1 second
+    }
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val created = events.filterIsInstance<CoroutineCreated>().sortedBy { it.tsNanos }
+
+        if (created.size < THRESHOLD) return findings
+
+        var start = 0
+        for (end in created.indices) {
+            while (created[end].tsNanos - created[start].tsNanos > WINDOW_NANOS) start++
+            val count = end - start + 1
+            if (count >= THRESHOLD) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "$count coroutines created within 1 second",
+                        suggestion = "Use bounded concurrency (Semaphore, Channel, or flatMapMerge) to limit parallel coroutines.",
+                        eventSeq = created[end].seq,
+                        affectedEntities = created.subList(start, end + 1).map { it.coroutineId },
+                    ),
+                )
+                break
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Detect suspensions that take unusually long.
+ */
+class SlowSuspensionRule : ValidationRule {
+    override val id = "performance.slow-suspension"
+    override val name = "Slow Suspension"
+    override val description = "Detect coroutine suspensions that take unusually long"
+    override val category = ValidationCategory.PERFORMANCE
+    override val severity = ValidationSeverity.INFO
+
+    companion object {
+        const val THRESHOLD_NANOS = 10_000_000_000L // 10 seconds
+    }
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val suspensions = events.filterIsInstance<CoroutineSuspended>()
+
+        for (suspension in suspensions) {
+            val duration = suspension.durationMillis
+            if (duration != null && duration * 1_000_000 > THRESHOLD_NANOS) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Coroutine ${suspension.coroutineId} suspended for ${duration}ms (reason: ${suspension.reason})",
+                        suggestion = "Long suspensions may indicate deadlocks, slow I/O, or forgotten delays. Verify this is intentional.",
+                        coroutineId = suspension.coroutineId,
+                        eventSeq = suspension.seq,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/ResourceManagementRules.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/ResourceManagementRules.kt
@@ -1,0 +1,159 @@
+package com.jh.proj.coroutineviz.validation.rules
+
+import com.jh.proj.coroutineviz.events.MutexLockAcquired
+import com.jh.proj.coroutineviz.events.MutexUnlocked
+import com.jh.proj.coroutineviz.events.SemaphorePermitAcquired
+import com.jh.proj.coroutineviz.events.SemaphorePermitReleased
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.channel.ChannelClosed
+import com.jh.proj.coroutineviz.events.channel.ChannelCreated
+import com.jh.proj.coroutineviz.validation.RuleFinding
+import com.jh.proj.coroutineviz.validation.ValidationCategory
+import com.jh.proj.coroutineviz.validation.ValidationRule
+import com.jh.proj.coroutineviz.validation.ValidationSeverity
+
+/**
+ * Detect channels that are created but never closed.
+ */
+class UnclosedChannelRule : ValidationRule {
+    override val id = "resource.unclosed-channel"
+    override val name = "Unclosed Channel"
+    override val description = "Detect channels that are created but never closed"
+    override val category = ValidationCategory.RESOURCE_MANAGEMENT
+    override val severity = ValidationSeverity.WARNING
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val created = events.filterIsInstance<ChannelCreated>().map { it.channelId }.toSet()
+        val closed = events.filterIsInstance<ChannelClosed>().map { it.channelId }.toSet()
+
+        val unclosed = created - closed
+        for (channelId in unclosed) {
+            findings.add(
+                RuleFinding(
+                    ruleId = id,
+                    ruleName = name,
+                    severity = severity.name,
+                    category = category.name,
+                    message = "Channel $channelId was created but never closed",
+                    suggestion = "Always close channels when done. Use channel.close() or the produce { } builder which auto-closes.",
+                    affectedEntities = listOf(channelId),
+                ),
+            )
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Detect mutex locks that are acquired but never released.
+ */
+class MutexLockLeakRule : ValidationRule {
+    override val id = "resource.mutex-lock-leak"
+    override val name = "Mutex Lock Leak"
+    override val description = "Detect mutex locks that are acquired but never released"
+    override val category = ValidationCategory.RESOURCE_MANAGEMENT
+    override val severity = ValidationSeverity.ERROR
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+
+        val acquires = events.filterIsInstance<MutexLockAcquired>().groupBy { it.mutexId }
+        val releases = events.filterIsInstance<MutexUnlocked>().groupBy { it.mutexId }
+
+        for ((mutexId, acqs) in acquires) {
+            val rels = releases[mutexId] ?: emptyList()
+            if (acqs.size > rels.size) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Mutex $mutexId has ${acqs.size} acquires but only ${rels.size} releases",
+                        suggestion = "Always use mutex.withLock { } instead of manual lock/unlock to prevent leaks from exceptions.",
+                        affectedEntities = listOf(mutexId),
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Detect semaphore permits that are acquired but never released.
+ */
+class SemaphorePermitLeakRule : ValidationRule {
+    override val id = "resource.semaphore-permit-leak"
+    override val name = "Semaphore Permit Leak"
+    override val description = "Detect semaphore permits that are acquired but never released"
+    override val category = ValidationCategory.RESOURCE_MANAGEMENT
+    override val severity = ValidationSeverity.ERROR
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+
+        val acquires = events.filterIsInstance<SemaphorePermitAcquired>().groupBy { it.semaphoreId }
+        val releases = events.filterIsInstance<SemaphorePermitReleased>().groupBy { it.semaphoreId }
+
+        for ((semaphoreId, acqs) in acquires) {
+            val rels = releases[semaphoreId] ?: emptyList()
+            if (acqs.size > rels.size) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Semaphore $semaphoreId has ${acqs.size} acquires but only ${rels.size} releases",
+                        suggestion =
+                            "Always use semaphore.withPermit { } instead of manual acquire/release " +
+                                "to prevent leaks from exceptions.",
+                        affectedEntities = listOf(semaphoreId),
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Detect buffer overflow events indicating silent data loss.
+ */
+class BufferOverflowSilentRule : ValidationRule {
+    override val id = "resource.buffer-overflow-silent"
+    override val name = "Silent Buffer Overflow"
+    override val description = "Detect Flow buffer overflows that silently drop values"
+    override val category = ValidationCategory.RESOURCE_MANAGEMENT
+    override val severity = ValidationSeverity.WARNING
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val overflows = events.filter { it.kind == "FlowBufferOverflow" }
+
+        if (overflows.isNotEmpty()) {
+            val byFlow = overflows.groupBy { (it as? com.jh.proj.coroutineviz.events.flow.FlowBufferOverflow)?.flowId ?: "unknown" }
+            for ((flowId, flowOverflows) in byFlow) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Flow $flowId had ${flowOverflows.size} buffer overflow(s) — values may have been silently dropped",
+                        suggestion = "Increase buffer size, use a different overflow strategy, or slow down the producer.",
+                        affectedEntities = listOf(flowId),
+                        eventSeq = flowOverflows.first().seq,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/SequenceRules.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/SequenceRules.kt
@@ -1,0 +1,82 @@
+package com.jh.proj.coroutineviz.validation.rules
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.validation.RuleFinding
+import com.jh.proj.coroutineviz.validation.ValidationCategory
+import com.jh.proj.coroutineviz.validation.ValidationRule
+import com.jh.proj.coroutineviz.validation.ValidationSeverity
+
+/**
+ * No two events should share the same sequence number.
+ */
+class NoDuplicateSequenceNumbersRule : ValidationRule {
+    override val id = "sequence.no-duplicates"
+    override val name = "No Duplicate Sequence Numbers"
+    override val description = "No two events should share the same sequence number"
+    override val category = ValidationCategory.LIFECYCLE
+    override val severity = ValidationSeverity.ERROR
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val seenSeqs = mutableMapOf<Long, VizEvent>()
+
+        for (event in events) {
+            val existing = seenSeqs[event.seq]
+            if (existing != null) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Duplicate sequence number ${event.seq}: ${existing.kind} and ${event.kind}",
+                        suggestion = "Ensure the sequence generator is thread-safe (AtomicLong). This may indicate a concurrency bug.",
+                        eventSeq = event.seq,
+                    ),
+                )
+            } else {
+                seenSeqs[event.seq] = event
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Events should have monotonically increasing timestamps within a session.
+ */
+class MonotonicTimestampsRule : ValidationRule {
+    override val id = "sequence.monotonic-timestamps"
+    override val name = "Monotonic Timestamps"
+    override val description = "Event timestamps should be monotonically increasing"
+    override val category = ValidationCategory.LIFECYCLE
+    override val severity = ValidationSeverity.WARNING
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val findings = mutableListOf<RuleFinding>()
+        val sorted = events.sortedBy { it.seq }
+
+        for (i in 1 until sorted.size) {
+            if (sorted[i].tsNanos < sorted[i - 1].tsNanos) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message =
+                            "Event seq=${sorted[i].seq} (${sorted[i].kind}) has earlier timestamp " +
+                                "than seq=${sorted[i - 1].seq} (${sorted[i - 1].kind})",
+                        suggestion =
+                            "Timestamps should increase with sequence numbers. This may indicate events " +
+                                "were processed out of order.",
+                        eventSeq = sorted[i].seq,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/StructuredConcurrencyRules.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/StructuredConcurrencyRules.kt
@@ -1,0 +1,127 @@
+package com.jh.proj.coroutineviz.validation.rules
+
+import com.jh.proj.coroutineviz.events.CoroutineEvent
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineFailed
+import com.jh.proj.coroutineviz.validation.RuleFinding
+import com.jh.proj.coroutineviz.validation.ValidationCategory
+import com.jh.proj.coroutineviz.validation.ValidationRule
+import com.jh.proj.coroutineviz.validation.ValidationSeverity
+
+/**
+ * Parent cancellation should propagate to children.
+ */
+class CancellationPropagationRule : ValidationRule {
+    override val id = "structured-concurrency.cancellation-propagation"
+    override val name = "Cancellation Propagation"
+    override val description = "Parent cancellation should cause children to be cancelled"
+    override val category = ValidationCategory.STRUCTURED_CONCURRENCY
+    override val severity = ValidationSeverity.WARNING
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+        val createEvents = coroutineEvents.filterIsInstance<CoroutineCreated>()
+        val findings = mutableListOf<RuleFinding>()
+
+        // Find cancelled parents
+        val cancelledParents =
+            coroutineEvents
+                .filterIsInstance<CoroutineCancelled>()
+                .map { it.coroutineId }
+                .toSet()
+
+        // Build parent -> children map
+        val childrenOf = mutableMapOf<String, MutableList<String>>()
+        for (created in createEvents) {
+            val parentId = created.parentCoroutineId ?: continue
+            childrenOf.getOrPut(parentId) { mutableListOf() }.add(created.coroutineId)
+        }
+
+        for (parentId in cancelledParents) {
+            val children = childrenOf[parentId] ?: continue
+            for (childId in children) {
+                val childEvents = byCoroutine[childId] ?: continue
+                val childCancelled = childEvents.any { it is CoroutineCancelled }
+                val childFailed = childEvents.any { it is CoroutineFailed }
+
+                if (!childCancelled && !childFailed) {
+                    findings.add(
+                        RuleFinding(
+                            ruleId = id,
+                            ruleName = name,
+                            severity = severity.name,
+                            category = category.name,
+                            message = "Parent $parentId was cancelled but child $childId was not cancelled",
+                            suggestion =
+                                "Ensure children respect cancellation. This may indicate the child is running " +
+                                    "in a non-cooperative way (e.g., blocking without checking isActive).",
+                            coroutineId = childId,
+                            affectedEntities = listOf(parentId, childId),
+                        ),
+                    )
+                }
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Child failure should propagate to parent (unless SupervisorJob).
+ */
+class ChildFailurePropagationRule : ValidationRule {
+    override val id = "structured-concurrency.child-failure-propagation"
+    override val name = "Child Failure Propagation"
+    override val description = "Child failure should propagate to parent (unless SupervisorJob)"
+    override val category = ValidationCategory.STRUCTURED_CONCURRENCY
+    override val severity = ValidationSeverity.INFO
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        val coroutineEvents = events.filterIsInstance<CoroutineEvent>()
+        val byCoroutine = coroutineEvents.groupBy { it.coroutineId }
+        val createEvents = coroutineEvents.filterIsInstance<CoroutineCreated>()
+        val findings = mutableListOf<RuleFinding>()
+
+        // Find failed children
+        val failedChildren =
+            coroutineEvents
+                .filterIsInstance<CoroutineFailed>()
+                .map { it.coroutineId }
+                .toSet()
+
+        for (created in createEvents) {
+            if (created.coroutineId !in failedChildren) continue
+            val parentId = created.parentCoroutineId ?: continue
+            val parentEvents = byCoroutine[parentId] ?: continue
+
+            val parentFailed = parentEvents.any { it is CoroutineFailed }
+            val parentCancelled = parentEvents.any { it is CoroutineCancelled }
+
+            // If parent didn't fail or get cancelled, it might be using SupervisorJob
+            if (!parentFailed && !parentCancelled) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message =
+                            "Child ${created.coroutineId} failed but parent $parentId was not affected. " +
+                                "Parent may be using SupervisorJob.",
+                        suggestion =
+                            "If this is intentional (SupervisorJob), this is expected. Otherwise, ensure " +
+                                "exception propagation is working correctly.",
+                        coroutineId = created.coroutineId,
+                        affectedEntities = listOf(parentId, created.coroutineId),
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/ThreadingRules.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/validation/rules/ThreadingRules.kt
@@ -1,0 +1,94 @@
+package com.jh.proj.coroutineviz.validation.rules
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.dispatcher.DispatcherSelected
+import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
+import com.jh.proj.coroutineviz.validation.RuleFinding
+import com.jh.proj.coroutineviz.validation.ValidationCategory
+import com.jh.proj.coroutineviz.validation.ValidationRule
+import com.jh.proj.coroutineviz.validation.ValidationSeverity
+
+/**
+ * Detect coroutines that may be running on an inappropriate dispatcher.
+ * E.g., I/O work on Default, or CPU work on IO.
+ */
+class WrongDispatcherRule : ValidationRule {
+    override val id = "threading.wrong-dispatcher"
+    override val name = "Wrong Dispatcher"
+    override val description = "Detect coroutines that may be on an inappropriate dispatcher"
+    override val category = ValidationCategory.THREADING
+    override val severity = ValidationSeverity.INFO
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        // This rule needs semantic information about what the coroutine does,
+        // which we don't have from events alone. We can flag heuristics:
+        // - Multiple dispatcher switches for a single coroutine (unnecessary withContext)
+        val findings = mutableListOf<RuleFinding>()
+        val dispatchers = events.filterIsInstance<DispatcherSelected>()
+        val byCoroutine = dispatchers.groupBy { it.coroutineId }
+
+        for ((coroutineId, dispatcherEvents) in byCoroutine) {
+            val uniqueDispatchers = dispatcherEvents.map { it.dispatcherName }.distinct()
+            if (uniqueDispatchers.size > 3) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message =
+                            "Coroutine $coroutineId switched between ${uniqueDispatchers.size} " +
+                                "dispatchers: ${uniqueDispatchers.joinToString()}",
+                        suggestion = "Frequent dispatcher switching adds overhead. Consider consolidating work on fewer dispatchers.",
+                        coroutineId = coroutineId,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}
+
+/**
+ * Detect potential shared mutable state access from multiple dispatchers.
+ */
+class SharedMutableStateRule : ValidationRule {
+    override val id = "threading.shared-mutable-state"
+    override val name = "Shared Mutable State Risk"
+    override val description = "Detect coroutines accessing shared state from different threads"
+    override val category = ValidationCategory.THREADING
+    override val severity = ValidationSeverity.WARNING
+
+    override fun validate(events: List<VizEvent>): List<RuleFinding> {
+        // Heuristic: if multiple coroutines share the same scope but run on different threads,
+        // they may have shared state issues
+        val findings = mutableListOf<RuleFinding>()
+        val threadAssignments = events.filterIsInstance<ThreadAssigned>()
+        val byScopeId = threadAssignments.groupBy { it.scopeId }
+
+        for ((scopeId, assignments) in byScopeId) {
+            val uniqueThreads = assignments.map { it.threadId }.distinct()
+            val uniqueCoroutines = assignments.map { it.coroutineId }.distinct()
+
+            if (uniqueThreads.size > 1 && uniqueCoroutines.size > 2) {
+                findings.add(
+                    RuleFinding(
+                        ruleId = id,
+                        ruleName = name,
+                        severity = severity.name,
+                        category = category.name,
+                        message = "Scope $scopeId has ${uniqueCoroutines.size} coroutines across ${uniqueThreads.size} threads",
+                        suggestion =
+                            "If coroutines in this scope share mutable state, consider using Mutex, atomic " +
+                                "operations, or confining state to a single thread " +
+                                "(Dispatchers.Main or newSingleThreadContext).",
+                        affectedEntities = uniqueCoroutines,
+                    ),
+                )
+            }
+        }
+
+        return findings
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedChannel.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedChannel.kt
@@ -1,0 +1,259 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.DelicateCoroutinesApi::class)
+
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.channel.ChannelReceiveCompleted
+import com.jh.proj.coroutineviz.session.ChannelEventContext
+import com.jh.proj.coroutineviz.session.VizSession
+import com.jh.proj.coroutineviz.session.channelBufferStateChanged
+import com.jh.proj.coroutineviz.session.channelClosed
+import com.jh.proj.coroutineviz.session.channelCreated
+import com.jh.proj.coroutineviz.session.channelReceiveCompleted
+import com.jh.proj.coroutineviz.session.channelReceiveStarted
+import com.jh.proj.coroutineviz.session.channelSendCompleted
+import com.jh.proj.coroutineviz.session.channelSendStarted
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ChannelIterator
+import kotlinx.coroutines.channels.ChannelResult
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.selects.SelectClause1
+import kotlinx.coroutines.selects.SelectClause2
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * InstrumentedChannel wraps a kotlinx.coroutines Channel to emit visualization events.
+ *
+ * Features:
+ * - Tracks all send operations with suspension detection
+ * - Tracks all receive operations with suspension detection
+ * - Monitors buffer state changes
+ * - Tracks channel close
+ *
+ * @param T The type of values transmitted through the channel
+ * @param delegate The underlying Channel
+ * @param session The VizSession for event tracking
+ * @param channelId Unique identifier for this Channel
+ * @param name Optional human-readable name
+ * @param capacity The buffer capacity of the channel
+ * @param channelType Type string: RENDEZVOUS, BUFFERED, CONFLATED, UNLIMITED
+ */
+class InstrumentedChannel<T>(
+    private val delegate: Channel<T>,
+    private val session: VizSession,
+    val channelId: String,
+    val name: String? = null,
+    private val capacity: Int,
+    private val channelType: String,
+) : Channel<T> {
+    private val bufferCount = AtomicInteger(0)
+
+    private val ctx: ChannelEventContext by lazy {
+        ChannelEventContext(
+            session = session,
+            channelId = channelId,
+            name = name,
+            capacity = capacity,
+            channelType = channelType,
+        )
+    }
+
+    init {
+        session.send(
+            ctx.channelCreated(),
+        )
+        logger.debug("Channel created: channelId=$channelId, type=$channelType, capacity=$capacity")
+    }
+
+    // ========================================================================
+    // SendChannel implementation
+    // ========================================================================
+
+    override val isClosedForSend: Boolean
+        get() = delegate.isClosedForSend
+
+    override suspend fun send(element: T) {
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val valueDesc = element?.toString()?.take(200) ?: "null"
+
+        session.send(ctx.channelSendStarted(coroutineId, valueDesc))
+
+        delegate.send(element)
+
+        val currentSize = bufferCount.incrementAndGet()
+        session.send(ctx.channelBufferStateChanged(currentSize))
+        session.send(ctx.channelSendCompleted(coroutineId, valueDesc))
+
+        logger.trace("Channel send completed: channelId=$channelId, value=$valueDesc")
+    }
+
+    override fun trySend(element: T): ChannelResult<Unit> {
+        val result = delegate.trySend(element)
+        if (result.isSuccess) {
+            val currentSize = bufferCount.incrementAndGet()
+            val coroutineId =
+                runCatching {
+                    kotlinx.coroutines.runBlocking {
+                        currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                    }
+                }.getOrNull() ?: "unknown"
+            val valueDesc = element?.toString()?.take(200) ?: "null"
+
+            session.send(ctx.channelSendStarted(coroutineId, valueDesc))
+            session.send(ctx.channelBufferStateChanged(currentSize))
+            session.send(ctx.channelSendCompleted(coroutineId, valueDesc))
+        }
+        return result
+    }
+
+    override fun close(cause: Throwable?): Boolean {
+        val result = delegate.close(cause)
+        if (result) {
+            session.send(ctx.channelClosed(cause?.message))
+            logger.debug("Channel closed: channelId=$channelId, cause=${cause?.message}")
+        }
+        return result
+    }
+
+    override fun invokeOnClose(handler: (cause: Throwable?) -> Unit) {
+        delegate.invokeOnClose(handler)
+    }
+
+    override val onSend: SelectClause2<T, SendChannel<T>>
+        get() = delegate.onSend
+
+    // ========================================================================
+    // ReceiveChannel implementation
+    // ========================================================================
+
+    override val isClosedForReceive: Boolean
+        get() = delegate.isClosedForReceive
+
+    override val isEmpty: Boolean
+        get() = delegate.isEmpty
+
+    override suspend fun receive(): T {
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+
+        session.send(ctx.channelReceiveStarted(coroutineId))
+
+        val value = delegate.receive()
+
+        val currentSize = bufferCount.decrementAndGet().coerceAtLeast(0)
+        session.send(ctx.channelBufferStateChanged(currentSize))
+
+        val valueDesc = value?.toString()?.take(200) ?: "null"
+        session.send(ctx.channelReceiveCompleted(coroutineId, valueDesc))
+
+        logger.trace("Channel receive completed: channelId=$channelId, value=$valueDesc")
+        return value
+    }
+
+    override fun tryReceive(): ChannelResult<T> {
+        val result = delegate.tryReceive()
+        if (result.isSuccess) {
+            val currentSize = bufferCount.decrementAndGet().coerceAtLeast(0)
+            val coroutineId =
+                runCatching {
+                    kotlinx.coroutines.runBlocking {
+                        currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                    }
+                }.getOrNull() ?: "unknown"
+
+            session.send(ctx.channelReceiveStarted(coroutineId))
+            session.send(ctx.channelBufferStateChanged(currentSize))
+            val valueDesc = result.getOrNull()?.toString()?.take(200) ?: "null"
+            session.send(ctx.channelReceiveCompleted(coroutineId, valueDesc))
+        }
+        return result
+    }
+
+    override fun cancel(cause: CancellationException?) {
+        delegate.cancel(cause)
+        session.send(ctx.channelClosed(cause?.message ?: "Cancelled"))
+        logger.debug("Channel cancelled: channelId=$channelId, cause=${cause?.message}")
+    }
+
+    @Deprecated("Deprecated in ReceiveChannel", replaceWith = ReplaceWith("cancel(CancellationException(cause))"))
+    override fun cancel(cause: Throwable?): Boolean {
+        val cancellationException =
+            when (cause) {
+                null -> null
+                is CancellationException -> cause
+                else -> CancellationException(cause.message, cause)
+            }
+        delegate.cancel(cancellationException)
+        session.send(ctx.channelClosed(cause?.message ?: "Cancelled"))
+        logger.debug("Channel cancelled (deprecated): channelId=$channelId, cause=${cause?.message}")
+        return true
+    }
+
+    override val onReceive: SelectClause1<T>
+        get() = delegate.onReceive
+
+    override val onReceiveCatching: SelectClause1<ChannelResult<T>>
+        get() = delegate.onReceiveCatching
+
+    override fun iterator(): ChannelIterator<T> {
+        val delegateIterator = delegate.iterator()
+        return object : ChannelIterator<T> {
+            override suspend fun hasNext(): Boolean {
+                return delegateIterator.hasNext()
+            }
+
+            override fun next(): T {
+                val value = delegateIterator.next()
+                val currentSize = bufferCount.decrementAndGet().coerceAtLeast(0)
+                session.send(ctx.channelBufferStateChanged(currentSize))
+                val valueDesc = value?.toString()?.take(200) ?: "null"
+                session.send(
+                    ChannelReceiveCompleted(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        channelId = channelId,
+                        coroutineId = "iterator",
+                        valueDescription = valueDesc,
+                    ),
+                )
+                return value
+            }
+        }
+    }
+
+    override suspend fun receiveCatching(): ChannelResult<T> {
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        session.send(ctx.channelReceiveStarted(coroutineId))
+
+        val result = delegate.receiveCatching()
+
+        if (result.isSuccess) {
+            val currentSize = bufferCount.decrementAndGet().coerceAtLeast(0)
+            session.send(ctx.channelBufferStateChanged(currentSize))
+            val valueDesc = result.getOrNull()?.toString()?.take(200) ?: "null"
+            session.send(ctx.channelReceiveCompleted(coroutineId, valueDesc))
+        } else if (result.isClosed) {
+            session.send(ctx.channelClosed(result.exceptionOrNull()?.message))
+        }
+
+        return result
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(InstrumentedChannel::class.java)
+    }
+}
+
+/**
+ * Determine the channel type string from the capacity constant.
+ */
+fun channelTypeFromCapacity(capacity: Int): String =
+    when (capacity) {
+        Channel.RENDEZVOUS -> "RENDEZVOUS"
+        Channel.CONFLATED -> "CONFLATED"
+        Channel.UNLIMITED -> "UNLIMITED"
+        Channel.BUFFERED -> "BUFFERED"
+        else -> "BUFFERED"
+    }

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedDeferred.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedDeferred.kt
@@ -1,0 +1,137 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.SuspensionPoint
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineResumed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import com.jh.proj.coroutineviz.events.deferred.DeferredAwaitCompleted
+import com.jh.proj.coroutineviz.events.deferred.DeferredAwaitStarted
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.InternalForInheritanceCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
+
+/**
+ * Deferred wrapper that emits await lifecycle events for visualization.
+ *
+ * InstrumentedDeferred wraps a standard [Deferred] and emits events when
+ * [await] is called, enabling visualization of async/await patterns and
+ * the suspension/resumption of awaiting coroutines.
+ *
+ * Events emitted:
+ * - [DeferredAwaitStarted] when await() is called
+ * - [CoroutineSuspended] when the awaiting coroutine suspends
+ * - [CoroutineResumed] when the awaiting coroutine resumes
+ * - [DeferredAwaitCompleted] when await() returns
+ *
+ * Created automatically by [VizScope.vizAsync] - you typically don't
+ * instantiate this directly.
+ *
+ * @param T The type of value this Deferred produces
+ * @property delegate The underlying Deferred to delegate operations to
+ * @property session The visualization session for emitting events
+ * @property deferredId Unique identifier for this Deferred instance
+ * @property coroutineId ID of the coroutine that owns this Deferred
+ * @property jobId ID of the associated Job
+ * @property parentCoroutineId ID of the parent coroutine, if any
+ * @property scopeId ID of the owning VizScope
+ * @property label Optional human-readable label
+ *
+ * Deferred wrapper that emits await lifecycle events and the awaiter's
+ * suspension/resumption for visualization.
+ */
+@OptIn(InternalForInheritanceCoroutinesApi::class)
+class InstrumentedDeferred<T>(
+    private val delegate: Deferred<T>,
+    private val session: VizSession,
+    private val deferredId: String,
+    private val coroutineId: String,
+    private val jobId: String,
+    private val parentCoroutineId: String?,
+    private val scopeId: String,
+    private val label: String?,
+) : Deferred<T> by delegate {
+    /**
+     * Await the deferred value with visualization tracking.
+     *
+     * This override emits events to track the await lifecycle:
+     * 1. [DeferredAwaitStarted] - when await begins
+     * 2. [CoroutineSuspended] - when the caller suspends (if not immediately available)
+     * 3. [CoroutineResumed] - when the caller resumes with the value
+     * 4. [DeferredAwaitCompleted] - when await returns
+     *
+     * @return The computed value
+     * @throws CancellationException if the deferred was cancelled
+     */
+    override suspend fun await(): T {
+        val awaiterId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+        // Emit DeferredAwaitStarted event
+        session.sent(
+            DeferredAwaitStarted(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                deferredId = deferredId,
+                coroutineId = coroutineId,
+                awaiterId = awaiterId,
+                scopeId = scopeId,
+                label = label,
+            ),
+        )
+
+        // Emit suspension point (only if awaiter exists)
+        if (awaiterId != null) {
+            val suspensionPoint = SuspensionPoint.capture("await")
+            session.sent(
+                CoroutineSuspended(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    coroutineId = awaiterId,
+                    jobId = currentCoroutineContext()[VizCoroutineElement]?.jobId ?: "unknown",
+                    parentCoroutineId = currentCoroutineContext()[VizCoroutineElement]?.parentCoroutineId,
+                    scopeId = scopeId,
+                    label = currentCoroutineContext()[VizCoroutineElement]?.label,
+                    reason = "await",
+                    durationMillis = null,
+                    suspensionPoint = suspensionPoint,
+                ),
+            )
+        }
+
+        // Actually await the result
+        val result = delegate.await()
+
+        // Emit resumption (only if awaiter exists)
+        if (awaiterId != null) {
+            session.sent(
+                CoroutineResumed(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    coroutineId = awaiterId,
+                    jobId = currentCoroutineContext()[VizCoroutineElement]?.jobId ?: "unknown",
+                    parentCoroutineId = currentCoroutineContext()[VizCoroutineElement]?.parentCoroutineId,
+                    scopeId = scopeId,
+                    label = currentCoroutineContext()[VizCoroutineElement]?.label,
+                ),
+            )
+        }
+
+        // Emit DeferredAwaitCompleted
+        session.sent(
+            DeferredAwaitCompleted(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                deferredId = deferredId,
+                coroutineId = coroutineId,
+                awaiterId = awaiterId,
+                scopeId = scopeId,
+                label = label,
+            ),
+        )
+
+        return result
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedDispatcher.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedDispatcher.kt
@@ -1,0 +1,107 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.dispatcher.DispatcherSelected
+import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * CoroutineDispatcher wrapper that emits tracking events for visualization.
+ *
+ * InstrumentedDispatcher wraps a real [CoroutineDispatcher] and emits events
+ * when coroutines are dispatched and assigned to threads. This enables
+ * visualization of dispatcher behavior and thread assignment patterns.
+ *
+ * Events emitted:
+ * - [DispatcherSelected] when dispatch() is called (dispatcher chosen)
+ * - [ThreadAssigned] when the coroutine actually starts running on a thread
+ *
+ * Usage:
+ * ```kotlin
+ * val instrumentedDefault = InstrumentedDispatcher(
+ *     delegate = Dispatchers.Default,
+ *     session = session,
+ *     dispatcherId = "default",
+ *     dispatcherName = "Dispatchers.Default"
+ * )
+ *
+ * // Use in coroutine context
+ * scope.vizLaunch(context = instrumentedDefault) {
+ *     // Runs with dispatcher tracking
+ * }
+ * ```
+ *
+ * @property delegate The underlying dispatcher to delegate execution to
+ * @property session The visualization session for emitting events
+ * @property dispatcherId Unique identifier for this dispatcher instance
+ * @property dispatcherName Human-readable name for display in events
+ *
+ * @see VizDispatchers For convenient access to pre-configured instrumented dispatchers
+ */
+class InstrumentedDispatcher(
+    private val delegate: CoroutineDispatcher,
+    private val session: VizSession,
+    val dispatcherId: String,
+    val dispatcherName: String,
+) : CoroutineDispatcher() {
+    override fun dispatch(
+        context: CoroutineContext,
+        block: Runnable,
+    ) {
+        // Get coroutine info from context
+        val vizElement = context[VizCoroutineElement]
+
+        // Note: dispatch() is not a suspend function, so we use send() (non-suspend)
+        if (vizElement != null) {
+            // Emit DispatcherSelected event
+            session.send(
+                DispatcherSelected(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    coroutineId = vizElement.coroutineId,
+                    jobId = vizElement.jobId,
+                    parentCoroutineId = vizElement.parentCoroutineId,
+                    scopeId = vizElement.scopeId,
+                    label = vizElement.label,
+                    dispatcherId = dispatcherId,
+                    dispatcherName = dispatcherName,
+                ),
+            )
+        }
+
+        // Wrap the Runnable to capture thread assignment
+        val instrumentedBlock =
+            Runnable {
+                if (vizElement != null) {
+                    // Emit ThreadAssigned when actually running on thread
+                    session.send(
+                        ThreadAssigned(
+                            sessionId = session.sessionId,
+                            seq = session.nextSeq(),
+                            tsNanos = System.nanoTime(),
+                            coroutineId = vizElement.coroutineId,
+                            jobId = vizElement.jobId,
+                            parentCoroutineId = vizElement.parentCoroutineId,
+                            scopeId = vizElement.scopeId,
+                            label = vizElement.label,
+                            threadId = Thread.currentThread().threadId(),
+                            threadName = Thread.currentThread().name,
+                            dispatcherName = dispatcherName,
+                        ),
+                    )
+                }
+
+                // Execute the actual block
+                block.run()
+            }
+
+        // Dispatch to real dispatcher
+        delegate.dispatch(context, instrumentedBlock)
+    }
+
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+        return delegate.isDispatchNeeded(context)
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedFlow.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedFlow.kt
@@ -1,0 +1,1333 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.flow.FlowCreated
+import com.jh.proj.coroutineviz.events.flow.FlowOperatorApplied
+import com.jh.proj.coroutineviz.events.flow.FlowValueFiltered
+import com.jh.proj.coroutineviz.events.flow.FlowValueTransformed
+import com.jh.proj.coroutineviz.session.FlowEventContext
+import com.jh.proj.coroutineviz.session.VizSession
+import com.jh.proj.coroutineviz.session.flowCollectionCancelled
+import com.jh.proj.coroutineviz.session.flowCollectionCompleted
+import com.jh.proj.coroutineviz.session.flowCollectionStarted
+import com.jh.proj.coroutineviz.session.flowOperatorApplied
+import com.jh.proj.coroutineviz.session.flowValueEmitted
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.reduce
+import kotlinx.coroutines.flow.retry
+import kotlinx.coroutines.flow.sample
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.toSet
+import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+
+/**
+ * InstrumentedFlow wraps a Flow to emit visualization events for all operations.
+ *
+ * Features:
+ * - Tracks flow creation, collection, and completion
+ * - Monitors value emissions with sequence numbers
+ * - Detects backpressure and buffer overflows
+ * - Tracks operator chains (map, filter, transform, etc.)
+ * - Supports multiple collectors
+ *
+ * @param T The type of values emitted by the flow
+ * @param delegate The underlying Flow to wrap
+ * @param session The VizSession for event tracking
+ * @param flowId Unique identifier for this flow
+ * @param flowType "Cold", "Hot", "StateFlow", "SharedFlow"
+ * @param label Optional human-readable label
+ * @param sourceFlowId ID of the upstream flow (for operator chains)
+ * @param operatorIndex Position in the operator chain
+ */
+class InstrumentedFlow<T>(
+    private val delegate: Flow<T>,
+    private val session: VizSession,
+    val flowId: String,
+    val flowType: String = "Cold",
+    val label: String? = null,
+    private val sourceFlowId: String? = null,
+    private val operatorIndex: Int = 0,
+) : Flow<T> {
+    private val ctx: FlowEventContext by lazy {
+        FlowEventContext(
+            session = session,
+            flowId = flowId,
+            flowType = flowType,
+            label = label,
+            sourceFlowId = sourceFlowId,
+            operatorIndex = operatorIndex,
+        )
+    }
+
+    override suspend fun collect(collector: FlowCollector<T>) {
+        val collectorId = "collector-${session.nextSeq()}"
+        val coroutineContext = currentCoroutineContext()
+        val coroutineId = coroutineContext[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val startTime = System.nanoTime()
+
+        // Update context with coroutine info
+        val collectionCtx = ctx.copy(coroutineId = coroutineId)
+
+        logger.debug("Flow collection started: flowId=$flowId, collectorId=$collectorId, coroutineId=$coroutineId")
+
+        // Emit collection started event
+        session.send(collectionCtx.flowCollectionStarted(collectorId))
+
+        var emissionCount = 0
+
+        try {
+            // Wrap the collector to intercept emissions
+            delegate.collect { value ->
+                // Emit value event BEFORE passing to collector
+                session.send(collectionCtx.flowValueEmitted(collectorId, emissionCount, value))
+
+                emissionCount++
+
+                // Pass value to the actual collector
+                collector.emit(value)
+
+                logger.trace("Flow value emitted: flowId=$flowId, seq=$emissionCount, value=$value")
+            }
+
+            // Successful completion
+            val endTime = System.nanoTime()
+            val duration = endTime - startTime
+
+            logger.debug("Flow collection completed: flowId=$flowId, emissions=$emissionCount, duration=${duration}ns")
+
+            session.send(
+                collectionCtx.flowCollectionCompleted(
+                    collectorId = collectorId,
+                    totalEmissions = emissionCount,
+                    durationNanos = duration,
+                ),
+            )
+        } catch (e: CancellationException) {
+            // Collection cancelled
+            logger.debug("Flow collection cancelled: flowId=$flowId, reason=${e.message}, emissions=$emissionCount")
+
+            session.send(
+                collectionCtx.flowCollectionCancelled(
+                    collectorId = collectorId,
+                    reason = e.message ?: "CancellationException",
+                    emittedCount = emissionCount,
+                ),
+            )
+            throw e
+        } catch (e: Exception) {
+            // Collection failed
+            logger.debug("Flow collection failed: flowId=$flowId, reason=${e.message}, emissions=$emissionCount")
+
+            session.send(
+                collectionCtx.flowCollectionCancelled(
+                    collectorId = collectorId,
+                    reason = e.message ?: e.javaClass.simpleName,
+                    emittedCount = emissionCount,
+                ),
+            )
+            throw e
+        }
+    }
+
+    // ========================================================================
+    // Transform Operators
+    // ========================================================================
+
+    /**
+     * Instrumented map operator - tracks each transformation.
+     */
+    fun <R> vizMap(transform: suspend (T) -> R): InstrumentedFlow<R> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "map"
+        val newIndex = operatorIndex + 1
+
+        // Emit operator applied event
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var sequenceNumber = 0
+
+        val transformedFlow =
+            delegate.map { value ->
+                val result = transform(value)
+
+                // Emit transformation event
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                session.send(
+                    FlowValueTransformed(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        flowId = newFlowId,
+                        operatorName = operatorName,
+                        inputValuePreview = value?.toString()?.take(200) ?: "null",
+                        outputValuePreview = result?.toString()?.take(200) ?: "null",
+                        inputType = value?.javaClass?.simpleName ?: "null",
+                        outputType = result?.javaClass?.simpleName ?: "null",
+                        sequenceNumber = sequenceNumber++,
+                        coroutineId = coroutineId,
+                    ),
+                )
+
+                result
+            }
+
+        return InstrumentedFlow(
+            delegate = transformedFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.map" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented mapNotNull operator - tracks transformations that may filter.
+     */
+    fun <R : Any> vizMapNotNull(transform: suspend (T) -> R?): InstrumentedFlow<R> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "mapNotNull"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var sequenceNumber = 0
+
+        val transformedFlow =
+            delegate.mapNotNull { value ->
+                val result = transform(value)
+
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+                if (result != null) {
+                    session.send(
+                        FlowValueTransformed(
+                            sessionId = session.sessionId,
+                            seq = session.nextSeq(),
+                            tsNanos = System.nanoTime(),
+                            flowId = newFlowId,
+                            operatorName = operatorName,
+                            inputValuePreview = value?.toString()?.take(200) ?: "null",
+                            outputValuePreview = result.toString().take(200),
+                            inputType = value?.javaClass?.simpleName ?: "null",
+                            outputType = result.javaClass.simpleName,
+                            sequenceNumber = sequenceNumber++,
+                            coroutineId = coroutineId,
+                        ),
+                    )
+                } else {
+                    session.send(
+                        FlowValueFiltered(
+                            sessionId = session.sessionId,
+                            seq = session.nextSeq(),
+                            tsNanos = System.nanoTime(),
+                            flowId = newFlowId,
+                            operatorName = operatorName,
+                            valuePreview = value?.toString()?.take(200) ?: "null",
+                            valueType = value?.javaClass?.simpleName ?: "null",
+                            passed = false,
+                            sequenceNumber = sequenceNumber++,
+                            coroutineId = coroutineId,
+                        ),
+                    )
+                }
+
+                result
+            }
+
+        return InstrumentedFlow(
+            delegate = transformedFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.mapNotNull" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented transform operator - for complex transformations.
+     */
+    fun <R> vizTransform(transform: suspend FlowCollector<R>.(value: T) -> Unit): InstrumentedFlow<R> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "transform"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var inputSequence = 0
+        var outputSequence = 0
+
+        val transformedFlow =
+            delegate.transform { inputValue ->
+                val inputSeq = inputSequence++
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+                // Wrap the collector to track outputs
+                val wrappedCollector =
+                    object : FlowCollector<R> {
+                        override suspend fun emit(value: R) {
+                            session.send(
+                                FlowValueTransformed(
+                                    sessionId = session.sessionId,
+                                    seq = session.nextSeq(),
+                                    tsNanos = System.nanoTime(),
+                                    flowId = newFlowId,
+                                    operatorName = operatorName,
+                                    inputValuePreview = inputValue?.toString()?.take(200) ?: "null",
+                                    outputValuePreview = value?.toString()?.take(200) ?: "null",
+                                    inputType = inputValue?.javaClass?.simpleName ?: "null",
+                                    outputType = value?.javaClass?.simpleName ?: "null",
+                                    sequenceNumber = outputSequence++,
+                                    coroutineId = coroutineId,
+                                ),
+                            )
+                            this@transform.emit(value)
+                        }
+                    }
+
+                transform(wrappedCollector, inputValue)
+            }
+
+        return InstrumentedFlow(
+            delegate = transformedFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.transform" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    // ========================================================================
+    // Filter Operators
+    // ========================================================================
+
+    /**
+     * Instrumented filter operator - tracks which values pass.
+     */
+    fun vizFilter(predicate: suspend (T) -> Boolean): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "filter"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var sequenceNumber = 0
+
+        val filteredFlow =
+            delegate.filter { value ->
+                val passed = predicate(value)
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+                session.send(
+                    FlowValueFiltered(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        flowId = newFlowId,
+                        operatorName = operatorName,
+                        valuePreview = value?.toString()?.take(200) ?: "null",
+                        valueType = value?.javaClass?.simpleName ?: "null",
+                        passed = passed,
+                        sequenceNumber = sequenceNumber++,
+                        coroutineId = coroutineId,
+                    ),
+                )
+
+                passed
+            }
+
+        return InstrumentedFlow(
+            delegate = filteredFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.filter" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented filterNot operator.
+     */
+    fun vizFilterNot(predicate: suspend (T) -> Boolean): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "filterNot"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var sequenceNumber = 0
+
+        val filteredFlow =
+            delegate.filterNot { value ->
+                val matches = predicate(value)
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+                session.send(
+                    FlowValueFiltered(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        flowId = newFlowId,
+                        operatorName = operatorName,
+                        valuePreview = value?.toString()?.take(200) ?: "null",
+                        valueType = value?.javaClass?.simpleName ?: "null",
+                        // Passes if predicate is false
+                        passed = !matches,
+                        sequenceNumber = sequenceNumber++,
+                        coroutineId = coroutineId,
+                    ),
+                )
+
+                matches
+            }
+
+        return InstrumentedFlow(
+            delegate = filteredFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.filterNot" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented filterIsInstance operator.
+     * Note: Due to Kotlin inline restrictions, use the extension function version for reified types.
+     */
+    fun <R : Any> vizFilterIsInstance(clazz: Class<R>): InstrumentedFlow<R> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "filterIsInstance<${clazz.simpleName}>"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var sequenceNumber = 0
+
+        val filteredFlow =
+            delegate.transform { value ->
+                val isInstance = clazz.isInstance(value)
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+                session.send(
+                    FlowValueFiltered(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        flowId = newFlowId,
+                        operatorName = operatorName,
+                        valuePreview = value?.toString()?.take(200) ?: "null",
+                        valueType = value?.javaClass?.simpleName ?: "null",
+                        passed = isInstance,
+                        sequenceNumber = sequenceNumber++,
+                        coroutineId = coroutineId,
+                    ),
+                )
+
+                if (isInstance) {
+                    @Suppress("UNCHECKED_CAST")
+                    emit(value as R)
+                }
+            }
+
+        return InstrumentedFlow(
+            delegate = filteredFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.filterIsInstance" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented distinctUntilChanged operator.
+     */
+    fun vizDistinctUntilChanged(): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "distinctUntilChanged"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var sequenceNumber = 0
+        var previousValue: Any? = UNSET
+
+        val filteredFlow =
+            delegate.transform { value ->
+                val isDifferent = previousValue === UNSET || previousValue != value
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+                session.send(
+                    FlowValueFiltered(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        flowId = newFlowId,
+                        operatorName = operatorName,
+                        valuePreview = value?.toString()?.take(200) ?: "null",
+                        valueType = value?.javaClass?.simpleName ?: "null",
+                        passed = isDifferent,
+                        sequenceNumber = sequenceNumber++,
+                        coroutineId = coroutineId,
+                    ),
+                )
+
+                if (isDifferent) {
+                    previousValue = value
+                    emit(value)
+                }
+            }
+
+        return InstrumentedFlow(
+            delegate = filteredFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.distinctUntilChanged" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    // ========================================================================
+    // Take/Drop Operators
+    // ========================================================================
+
+    /**
+     * Instrumented take operator.
+     */
+    fun vizTake(count: Int): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "take($count)"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.take(count),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.take($count)" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented takeWhile operator.
+     */
+    fun vizTakeWhile(predicate: suspend (T) -> Boolean): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "takeWhile"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var sequenceNumber = 0
+
+        val takenFlow =
+            delegate.takeWhile { value ->
+                val take = predicate(value)
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+                session.send(
+                    FlowValueFiltered(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        flowId = newFlowId,
+                        operatorName = operatorName,
+                        valuePreview = value?.toString()?.take(200) ?: "null",
+                        valueType = value?.javaClass?.simpleName ?: "null",
+                        passed = take,
+                        sequenceNumber = sequenceNumber++,
+                        coroutineId = coroutineId,
+                    ),
+                )
+
+                take
+            }
+
+        return InstrumentedFlow(
+            delegate = takenFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.takeWhile" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented drop operator.
+     */
+    fun vizDrop(count: Int): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "drop($count)"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.drop(count),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.drop($count)" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented dropWhile operator.
+     */
+    fun vizDropWhile(predicate: suspend (T) -> Boolean): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "dropWhile"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.dropWhile(predicate),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.dropWhile" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    // ========================================================================
+    // Side Effect Operators
+    // ========================================================================
+
+    /**
+     * Instrumented onEach operator - tracks side effects.
+     */
+    fun vizOnEach(action: suspend (T) -> Unit): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "onEach"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        var sequenceNumber = 0
+
+        val sideEffectFlow =
+            delegate.onEach { value ->
+                val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+                session.send(
+                    FlowValueTransformed(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        flowId = newFlowId,
+                        operatorName = operatorName,
+                        inputValuePreview = value?.toString()?.take(200) ?: "null",
+                        outputValuePreview = value?.toString()?.take(200) ?: "null",
+                        inputType = value?.javaClass?.simpleName ?: "null",
+                        outputType = value?.javaClass?.simpleName ?: "null",
+                        sequenceNumber = sequenceNumber++,
+                        coroutineId = coroutineId,
+                    ),
+                )
+
+                action(value)
+            }
+
+        return InstrumentedFlow(
+            delegate = sideEffectFlow,
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.onEach" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented onStart operator.
+     */
+    fun vizOnStart(action: suspend FlowCollector<T>.() -> Unit): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "onStart"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.onStart(action),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.onStart" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented onCompletion operator.
+     */
+    fun vizOnCompletion(action: suspend FlowCollector<T>.(cause: Throwable?) -> Unit): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "onCompletion"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.onCompletion(action),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.onCompletion" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    // ========================================================================
+    // Buffer Operators (Backpressure)
+    // ========================================================================
+
+    /**
+     * Instrumented buffer operator - tracks backpressure behavior.
+     */
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    fun vizBuffer(
+        capacity: Int = 64,
+        onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
+    ): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "buffer($capacity, $onBufferOverflow)"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.buffer(capacity, onBufferOverflow),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.buffer($capacity)" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented conflate operator - drops intermediate values.
+     */
+    fun vizConflate(): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "conflate"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.conflate(),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.conflate" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    // ========================================================================
+    // Timing Operators
+    // ========================================================================
+
+    /**
+     * Instrumented debounce operator.
+     */
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    fun vizDebounce(timeoutMillis: Long): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "debounce(${timeoutMillis}ms)"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.debounce(timeoutMillis),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.debounce(${timeoutMillis}ms)" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented sample operator.
+     */
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    fun vizSample(periodMillis: Long): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "sample(${periodMillis}ms)"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.sample(periodMillis),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.sample(${periodMillis}ms)" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    // ========================================================================
+    // Error Handling Operators
+    // ========================================================================
+
+    /**
+     * Instrumented catch operator.
+     */
+    fun vizCatch(action: suspend FlowCollector<T>.(cause: Throwable) -> Unit): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "catch"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.catch(action),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.catch" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented retry operator.
+     */
+    fun vizRetry(
+        retries: Long = Long.MAX_VALUE,
+        predicate: suspend (cause: Throwable) -> Boolean = { true },
+    ): InstrumentedFlow<T> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = if (retries == Long.MAX_VALUE) "retry" else "retry($retries)"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.retry(retries, predicate),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.$operatorName" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    // ========================================================================
+    // Flattening Operators
+    // ========================================================================
+
+    /**
+     * Instrumented flatMapConcat operator.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    fun <R> vizFlatMapConcat(transform: suspend (T) -> Flow<R>): InstrumentedFlow<R> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "flatMapConcat"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.flatMapConcat(transform),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.flatMapConcat" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented flatMapMerge operator.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    fun <R> vizFlatMapMerge(
+        concurrency: Int = DEFAULT_CONCURRENCY,
+        transform: suspend (T) -> Flow<R>,
+    ): InstrumentedFlow<R> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "flatMapMerge($concurrency)"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.flatMapMerge(concurrency, transform),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.flatMapMerge($concurrency)" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    /**
+     * Instrumented flatMapLatest operator.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    fun <R> vizFlatMapLatest(transform: suspend (T) -> Flow<R>): InstrumentedFlow<R> {
+        val newFlowId = "flow-${session.nextSeq()}"
+        val operatorName = "flatMapLatest"
+        val newIndex = operatorIndex + 1
+
+        session.send(ctx.forOperator(newFlowId, operatorName, newIndex).flowOperatorApplied(operatorName))
+
+        return InstrumentedFlow(
+            delegate = delegate.flatMapLatest(transform),
+            session = session,
+            flowId = newFlowId,
+            flowType = flowType,
+            label = label?.let { "$it.flatMapLatest" },
+            sourceFlowId = flowId,
+            operatorIndex = newIndex,
+        )
+    }
+
+    // ========================================================================
+    // Async Collection Operations
+    // ========================================================================
+
+    /**
+     * Launch collection of this flow in the given scope.
+     *
+     * This is the equivalent of `launchIn` but with visualization tracking.
+     * The collection runs in a new coroutine and emits events for:
+     * - Coroutine launch
+     * - Collection start/complete/cancel
+     * - All value emissions
+     *
+     * @param scope The CoroutineScope to launch in
+     * @param onEach Optional action for each emitted value
+     * @return Job handle for the collection coroutine
+     */
+    fun vizLaunchIn(
+        scope: CoroutineScope,
+        onEach: (suspend (T) -> Unit)? = null,
+    ): Job {
+        val coroutineId = "flow-collector-${session.nextSeq()}"
+
+        session.send(
+            FlowOperatorApplied(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                flowId = flowId,
+                sourceFlowId = sourceFlowId ?: flowId,
+                operatorName = "launchIn",
+                operatorIndex = operatorIndex + 1,
+                label = label,
+                coroutineId = coroutineId,
+            ),
+        )
+
+        return scope.launch {
+            if (onEach != null) {
+                collect { value -> onEach(value) }
+            } else {
+                collect { }
+            }
+        }
+    }
+
+    /**
+     * Convert this cold flow to a hot SharedFlow.
+     *
+     * @param scope The CoroutineScope for the sharing coroutine
+     * @param started The sharing start strategy
+     * @param replay Number of values to replay to new subscribers
+     * @return An InstrumentedSharedFlow
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    fun vizShareIn(
+        scope: CoroutineScope,
+        started: SharingStarted,
+        replay: Int = 0,
+    ): SharedFlow<T> {
+        val sharedFlowId = "sharedflow-from-$flowId-${session.nextSeq()}"
+
+        session.send(
+            FlowOperatorApplied(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                flowId = sharedFlowId,
+                sourceFlowId = flowId,
+                operatorName = "shareIn(replay=$replay)",
+                operatorIndex = operatorIndex + 1,
+                label = label,
+                coroutineId = null,
+            ),
+        )
+
+        // Create the shared flow
+        val sharedFlow = delegate.shareIn(scope, started, replay)
+
+        // Emit FlowCreated for the new SharedFlow
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = "unknown",
+                flowId = sharedFlowId,
+                flowType = "SharedFlow",
+                label = label?.let { "$it.shareIn" },
+                scopeId = null,
+            ),
+        )
+
+        return sharedFlow
+    }
+
+    /**
+     * Convert this cold flow to a hot StateFlow.
+     *
+     * @param scope The CoroutineScope for the state coroutine
+     * @param started The sharing start strategy
+     * @param initialValue The initial value of the StateFlow
+     * @return A StateFlow
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    fun vizStateIn(
+        scope: CoroutineScope,
+        started: SharingStarted,
+        initialValue: T,
+    ): StateFlow<T> {
+        val stateFlowId = "stateflow-from-$flowId-${session.nextSeq()}"
+
+        session.send(
+            FlowOperatorApplied(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                flowId = stateFlowId,
+                sourceFlowId = flowId,
+                operatorName = "stateIn(initial=$initialValue)",
+                operatorIndex = operatorIndex + 1,
+                label = label,
+                coroutineId = null,
+            ),
+        )
+
+        // Create the state flow
+        val stateFlow = delegate.stateIn(scope, started, initialValue)
+
+        // Emit FlowCreated for the new StateFlow
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = "unknown",
+                flowId = stateFlowId,
+                flowType = "StateFlow",
+                label = label?.let { "$it.stateIn" },
+                scopeId = null,
+            ),
+        )
+
+        return stateFlow
+    }
+
+    // ========================================================================
+    // Terminal Operators with Tracking
+    // ========================================================================
+
+    /**
+     * Collect the first value and return it.
+     */
+    suspend fun vizFirst(): T {
+        val collectorId = "first-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        val result = delegate.first()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, 0, result))
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, 1, 0))
+
+        return result
+    }
+
+    /**
+     * Collect the first value matching the predicate.
+     */
+    suspend fun vizFirst(predicate: suspend (T) -> Boolean): T {
+        val collectorId = "first-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        val result = delegate.first(predicate)
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, 0, result))
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, 1, 0))
+
+        return result
+    }
+
+    /**
+     * Collect the first value or null if empty.
+     */
+    suspend fun vizFirstOrNull(): T? {
+        val collectorId = "firstOrNull-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        val result = delegate.firstOrNull()
+
+        if (result != null) {
+            session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, 0, result))
+            session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, 1, 0))
+        } else {
+            session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, 0, 0))
+        }
+
+        return result
+    }
+
+    /**
+     * Collect the last value.
+     */
+    suspend fun vizLast(): T {
+        val collectorId = "last-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val startTime = System.nanoTime()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        var count = 0
+        val result = delegate.onEach { count++ }.last()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, count - 1, result))
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, count, System.nanoTime() - startTime))
+
+        return result
+    }
+
+    /**
+     * Collect all values into a list.
+     */
+    suspend fun vizToList(): List<T> {
+        val collectorId = "toList-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val startTime = System.nanoTime()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        var count = 0
+        val result =
+            delegate.onEach {
+                session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, count++, it))
+            }.toList()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, count, System.nanoTime() - startTime))
+
+        return result
+    }
+
+    /**
+     * Collect all values into a set.
+     */
+    suspend fun vizToSet(): Set<T> {
+        val collectorId = "toSet-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val startTime = System.nanoTime()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        var count = 0
+        val result =
+            delegate.onEach {
+                session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, count++, it))
+            }.toSet()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, count, System.nanoTime() - startTime))
+
+        return result
+    }
+
+    /**
+     * Count the number of elements.
+     */
+    suspend fun vizCount(): Int {
+        val collectorId = "count-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val startTime = System.nanoTime()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        val result = delegate.count()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, result, System.nanoTime() - startTime))
+
+        return result
+    }
+
+    /**
+     * Reduce values using the given operation.
+     */
+    suspend fun vizReduce(operation: suspend (accumulator: T, value: T) -> T): T {
+        val collectorId = "reduce-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val startTime = System.nanoTime()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        var count = 0
+        val result = delegate.onEach { count++ }.reduce(operation)
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, count - 1, result))
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, count, System.nanoTime() - startTime))
+
+        return result
+    }
+
+    /**
+     * Fold values using the given operation.
+     */
+    suspend fun <R> vizFold(
+        initial: R,
+        operation: suspend (accumulator: R, value: T) -> R,
+    ): R {
+        val collectorId = "fold-${session.nextSeq()}"
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId ?: "unknown"
+        val startTime = System.nanoTime()
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        var count = 0
+        val result = delegate.onEach { count++ }.fold(initial, operation)
+
+        session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, count, result))
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionCompleted(collectorId, count, System.nanoTime() - startTime))
+
+        return result
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(InstrumentedFlow::class.java)
+        private val UNSET = Any()
+        private const val DEFAULT_CONCURRENCY = 16
+    }
+}
+
+// ============================================================================
+// Extension Functions
+// ============================================================================
+
+/**
+ * Extension function to wrap any Flow with instrumentation.
+ */
+fun <T> Flow<T>.instrumented(
+    session: VizSession,
+    flowId: String,
+    flowType: String = "Cold",
+    label: String? = null,
+): InstrumentedFlow<T> {
+    // Emit FlowCreated when wrapping
+    session.send(
+        FlowCreated(
+            sessionId = session.sessionId,
+            seq = session.nextSeq(),
+            tsNanos = System.nanoTime(),
+            coroutineId = "unknown",
+            flowId = flowId,
+            flowType = flowType,
+            label = label,
+            scopeId = null,
+        ),
+    )
+
+    return InstrumentedFlow(this, session, flowId, flowType, label)
+}
+
+/**
+ * Extension function to wrap any Flow with auto-generated ID.
+ */
+fun <T> Flow<T>.vizInstrumented(
+    session: VizSession,
+    flowType: String = "Cold",
+    label: String? = null,
+): InstrumentedFlow<T> {
+    val flowId = "flow-${session.nextSeq()}"
+    return this.instrumented(session, flowId, flowType, label)
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedSharedFlow.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedSharedFlow.kt
@@ -1,0 +1,273 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.flow.FlowBufferOverflow
+import com.jh.proj.coroutineviz.events.flow.FlowCreated
+import com.jh.proj.coroutineviz.events.flow.SharedFlowEmission
+import com.jh.proj.coroutineviz.events.flow.SharedFlowSubscription
+import com.jh.proj.coroutineviz.session.FlowEventContext
+import com.jh.proj.coroutineviz.session.VizSession
+import com.jh.proj.coroutineviz.session.flowCollectionCancelled
+import com.jh.proj.coroutineviz.session.flowCollectionStarted
+import com.jh.proj.coroutineviz.session.flowValueEmitted
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * InstrumentedSharedFlow wraps a MutableSharedFlow to emit visualization events.
+ *
+ * Features:
+ * - Tracks all emissions with subscriber count
+ * - Monitors subscriber lifecycle (subscribe/unsubscribe)
+ * - Tracks replay cache state
+ * - Handles buffer overflow scenarios
+ *
+ * @param T The type of values emitted
+ * @param delegate The underlying MutableSharedFlow
+ * @param session The VizSession for event tracking
+ * @param flowId Unique identifier for this SharedFlow
+ * @param label Optional human-readable label
+ * @param extraBufferCapacity The extra buffer capacity of the flow
+ */
+class InstrumentedSharedFlow<T>(
+    private val delegate: MutableSharedFlow<T>,
+    private val session: VizSession,
+    val flowId: String,
+    val label: String? = null,
+    private val extraBufferCapacity: Int = 0,
+) : MutableSharedFlow<T> {
+    private val subscriberCount = AtomicInteger(0)
+
+    private val ctx: FlowEventContext by lazy {
+        FlowEventContext(
+            session = session,
+            flowId = flowId,
+            flowType = "SharedFlow",
+            label = label,
+        )
+    }
+
+    init {
+        // Emit FlowCreated for SharedFlow
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = "unknown",
+                flowId = flowId,
+                flowType = "SharedFlow",
+                label = label,
+                scopeId = null,
+            ),
+        )
+        logger.debug("SharedFlow created: flowId=$flowId, replay=${delegate.replayCache.size}, extraBuffer=$extraBufferCapacity")
+    }
+
+    // ========================================================================
+    // SharedFlow Properties
+    // ========================================================================
+
+    override val replayCache: List<T>
+        get() = delegate.replayCache
+
+    override val subscriptionCount: StateFlow<Int>
+        get() = delegate.subscriptionCount
+
+    // ========================================================================
+    // MutableSharedFlow - Emission
+    // ========================================================================
+
+    override suspend fun emit(value: T) {
+        val coroutineId = currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+
+        delegate.emit(value)
+
+        session.send(
+            SharedFlowEmission(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                flowId = flowId,
+                valuePreview = value?.toString()?.take(200) ?: "null",
+                valueType = value?.javaClass?.simpleName ?: "null",
+                subscriberCount = subscriberCount.get(),
+                replayCache = delegate.replayCache.size,
+                extraBufferCapacity = extraBufferCapacity,
+                coroutineId = coroutineId,
+                label = label,
+            ),
+        )
+
+        logger.trace("SharedFlow emission: flowId=$flowId, value=$value, subscribers=${subscriberCount.get()}")
+    }
+
+    override fun tryEmit(value: T): Boolean {
+        val result = delegate.tryEmit(value)
+
+        if (result) {
+            val coroutineId =
+                runCatching {
+                    kotlinx.coroutines.runBlocking {
+                        currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                    }
+                }.getOrNull()
+
+            session.send(
+                SharedFlowEmission(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    flowId = flowId,
+                    valuePreview = value?.toString()?.take(200) ?: "null",
+                    valueType = value?.javaClass?.simpleName ?: "null",
+                    subscriberCount = subscriberCount.get(),
+                    replayCache = delegate.replayCache.size,
+                    extraBufferCapacity = extraBufferCapacity,
+                    coroutineId = coroutineId,
+                    label = label,
+                ),
+            )
+        } else {
+            // Buffer overflow - could not emit
+            session.send(
+                FlowBufferOverflow(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    coroutineId = "unknown",
+                    flowId = flowId,
+                    droppedValue = value?.toString()?.take(100),
+                    bufferSize = delegate.replayCache.size + extraBufferCapacity,
+                    overflowStrategy = "tryEmit_failed",
+                ),
+            )
+        }
+
+        return result
+    }
+
+    override fun resetReplayCache() {
+        delegate.resetReplayCache()
+        logger.debug("SharedFlow replay cache reset: flowId=$flowId")
+    }
+
+    // ========================================================================
+    // Flow Collection
+    // ========================================================================
+
+    override suspend fun collect(collector: FlowCollector<T>): Nothing {
+        val collectorId = "collector-${session.nextSeq()}"
+        val coroutineContext = currentCoroutineContext()
+        val coroutineId = coroutineContext[VizCoroutineElement]?.coroutineId ?: "unknown"
+
+        // Track subscription
+        val currentSubscribers = subscriberCount.incrementAndGet()
+
+        session.send(
+            SharedFlowSubscription(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                flowId = flowId,
+                collectorId = collectorId,
+                action = "subscribed",
+                subscriberCount = currentSubscribers,
+                coroutineId = coroutineId,
+                label = label,
+            ),
+        )
+
+        // Emit collection started
+        session.send(ctx.copy(coroutineId = coroutineId).flowCollectionStarted(collectorId))
+
+        logger.debug("SharedFlow collector subscribed: flowId=$flowId, collectorId=$collectorId, subscribers=$currentSubscribers")
+
+        var emissionCount = 0
+
+        try {
+            delegate.collect { value ->
+                // Emit value event
+                session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, emissionCount, value))
+                emissionCount++
+                collector.emit(value)
+            }
+        } catch (e: CancellationException) {
+            session.send(
+                ctx.copy(coroutineId = coroutineId).flowCollectionCancelled(
+                    collectorId = collectorId,
+                    reason = e.message ?: "CancellationException",
+                    emittedCount = emissionCount,
+                ),
+            )
+            throw e
+        } finally {
+            // Track unsubscription
+            val remainingSubscribers = subscriberCount.decrementAndGet()
+
+            session.send(
+                SharedFlowSubscription(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    flowId = flowId,
+                    collectorId = collectorId,
+                    action = "unsubscribed",
+                    subscriberCount = remainingSubscribers,
+                    coroutineId = coroutineId,
+                    label = label,
+                ),
+            )
+
+            logger.debug("SharedFlow collector unsubscribed: flowId=$flowId, collectorId=$collectorId, subscribers=$remainingSubscribers")
+        }
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(InstrumentedSharedFlow::class.java)
+    }
+}
+
+/**
+ * Create an instrumented MutableSharedFlow.
+ */
+fun <T> VizSession.vizSharedFlow(
+    replay: Int = 0,
+    extraBufferCapacity: Int = 0,
+    onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
+    label: String? = null,
+): InstrumentedSharedFlow<T> {
+    val flowId = "sharedflow-${nextSeq()}"
+    return InstrumentedSharedFlow(
+        delegate = MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow),
+        session = this,
+        flowId = flowId,
+        label = label,
+        extraBufferCapacity = extraBufferCapacity,
+    )
+}
+
+/**
+ * Wrap an existing MutableSharedFlow with instrumentation.
+ */
+fun <T> MutableSharedFlow<T>.instrumented(
+    session: VizSession,
+    label: String? = null,
+    extraBufferCapacity: Int = 0,
+): InstrumentedSharedFlow<T> {
+    val flowId = "sharedflow-${session.nextSeq()}"
+    return InstrumentedSharedFlow(
+        delegate = this,
+        session = session,
+        flowId = flowId,
+        label = label,
+        extraBufferCapacity = extraBufferCapacity,
+    )
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedStateFlow.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedStateFlow.kt
@@ -1,0 +1,264 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.flow.FlowCreated
+import com.jh.proj.coroutineviz.events.flow.SharedFlowSubscription
+import com.jh.proj.coroutineviz.events.flow.StateFlowValueChanged
+import com.jh.proj.coroutineviz.session.FlowEventContext
+import com.jh.proj.coroutineviz.session.VizSession
+import com.jh.proj.coroutineviz.session.flowCollectionCancelled
+import com.jh.proj.coroutineviz.session.flowValueEmitted
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * InstrumentedStateFlow wraps a MutableStateFlow to emit visualization events.
+ *
+ * Features:
+ * - Tracks value changes with old/new value comparison
+ * - Monitors subscriber count
+ * - Tracks all state updates
+ * - Thread-safe subscriber tracking
+ *
+ * @param T The type of state values
+ * @param delegate The underlying MutableStateFlow
+ * @param session The VizSession for event tracking
+ * @param flowId Unique identifier for this StateFlow
+ * @param label Optional human-readable label
+ */
+class InstrumentedStateFlow<T>(
+    private val delegate: MutableStateFlow<T>,
+    private val session: VizSession,
+    val flowId: String,
+    val label: String? = null,
+) : MutableStateFlow<T> {
+    private val subscriberCount = AtomicInteger(0)
+
+    private val ctx: FlowEventContext by lazy {
+        FlowEventContext(
+            session = session,
+            flowId = flowId,
+            flowType = "StateFlow",
+            label = label,
+        )
+    }
+
+    init {
+        // Emit FlowCreated for StateFlow
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = "unknown",
+                flowId = flowId,
+                flowType = "StateFlow",
+                label = label,
+                scopeId = null,
+            ),
+        )
+        logger.debug("StateFlow created: flowId=$flowId, initialValue=${delegate.value}")
+    }
+
+    // ========================================================================
+    // StateFlow Properties
+    // ========================================================================
+
+    override val replayCache: List<T>
+        get() = delegate.replayCache
+
+    override val subscriptionCount: StateFlow<Int>
+        get() = MutableStateFlow(subscriberCount.get())
+
+    // ========================================================================
+    // MutableStateFlow - Value Updates
+    // ========================================================================
+
+    override fun compareAndSet(
+        expect: T,
+        update: T,
+    ): Boolean {
+        val oldValue = delegate.value
+        val result = delegate.compareAndSet(expect, update)
+
+        if (result) {
+            emitValueChanged(oldValue, update)
+        }
+
+        return result
+    }
+
+    override var value: T
+        get() = delegate.value
+        set(newValue) {
+            val oldValue = delegate.value
+            delegate.value = newValue
+
+            if (oldValue != newValue) {
+                emitValueChanged(oldValue, newValue)
+            }
+        }
+
+    override suspend fun emit(value: T) {
+        val oldValue = delegate.value
+        delegate.emit(value)
+
+        if (oldValue != value) {
+            emitValueChanged(oldValue, value)
+        }
+    }
+
+    override fun tryEmit(value: T): Boolean {
+        val oldValue = delegate.value
+        val result = delegate.tryEmit(value)
+
+        if (result && oldValue != value) {
+            emitValueChanged(oldValue, value)
+        }
+
+        return result
+    }
+
+    override fun resetReplayCache() {
+        delegate.resetReplayCache()
+    }
+
+    private fun emitValueChanged(
+        oldValue: T,
+        newValue: T,
+    ) {
+        val coroutineId =
+            runCatching {
+                kotlinx.coroutines.runBlocking {
+                    currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                }
+            }.getOrNull()
+
+        session.send(
+            StateFlowValueChanged(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                flowId = flowId,
+                oldValuePreview = oldValue?.toString()?.take(200) ?: "null",
+                newValuePreview = newValue?.toString()?.take(200) ?: "null",
+                valueType = newValue?.javaClass?.simpleName ?: "null",
+                subscriberCount = subscriberCount.get(),
+                coroutineId = coroutineId,
+                label = label,
+            ),
+        )
+
+        logger.debug("StateFlow value changed: flowId=$flowId, old=$oldValue, new=$newValue, subscribers=${subscriberCount.get()}")
+    }
+
+    // ========================================================================
+    // Flow Collection
+    // ========================================================================
+
+    override suspend fun collect(collector: FlowCollector<T>): Nothing {
+        val collectorId = "collector-${session.nextSeq()}"
+        val coroutineContext = currentCoroutineContext()
+        val coroutineId = coroutineContext[VizCoroutineElement]?.coroutineId ?: "unknown"
+
+        // Track subscription
+        val currentSubscribers = subscriberCount.incrementAndGet()
+
+        session.send(
+            SharedFlowSubscription(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                flowId = flowId,
+                collectorId = collectorId,
+                action = "subscribed",
+                subscriberCount = currentSubscribers,
+                coroutineId = coroutineId,
+                label = label,
+            ),
+        )
+
+        logger.debug("StateFlow collector subscribed: flowId=$flowId, collectorId=$collectorId, subscribers=$currentSubscribers")
+
+        var emissionCount = 0
+
+        try {
+            delegate.collect { value ->
+                // Emit value event
+                session.send(ctx.copy(coroutineId = coroutineId).flowValueEmitted(collectorId, emissionCount, value))
+                emissionCount++
+                collector.emit(value)
+            }
+        } catch (e: CancellationException) {
+            session.send(
+                ctx.copy(coroutineId = coroutineId).flowCollectionCancelled(
+                    collectorId = collectorId,
+                    reason = e.message ?: "CancellationException",
+                    emittedCount = emissionCount,
+                ),
+            )
+            throw e
+        } finally {
+            // Track unsubscription
+            val remainingSubscribers = subscriberCount.decrementAndGet()
+
+            session.send(
+                SharedFlowSubscription(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    flowId = flowId,
+                    collectorId = collectorId,
+                    action = "unsubscribed",
+                    subscriberCount = remainingSubscribers,
+                    coroutineId = coroutineId,
+                    label = label,
+                ),
+            )
+
+            logger.debug("StateFlow collector unsubscribed: flowId=$flowId, collectorId=$collectorId, subscribers=$remainingSubscribers")
+        }
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(InstrumentedStateFlow::class.java)
+    }
+}
+
+/**
+ * Create an instrumented MutableStateFlow.
+ */
+fun <T> VizSession.vizStateFlow(
+    initialValue: T,
+    label: String? = null,
+): InstrumentedStateFlow<T> {
+    val flowId = "stateflow-${nextSeq()}"
+    return InstrumentedStateFlow(
+        delegate = MutableStateFlow(initialValue),
+        session = this,
+        flowId = flowId,
+        label = label,
+    )
+}
+
+/**
+ * Wrap an existing MutableStateFlow with instrumentation.
+ */
+fun <T> MutableStateFlow<T>.instrumented(
+    session: VizSession,
+    label: String? = null,
+): InstrumentedStateFlow<T> {
+    val flowId = "stateflow-${session.nextSeq()}"
+    return InstrumentedStateFlow(
+        delegate = this,
+        session = session,
+        flowId = flowId,
+        label = label,
+    )
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizActor.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizActor.kt
@@ -1,0 +1,439 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.ActorClosed
+import com.jh.proj.coroutineviz.events.ActorCreated
+import com.jh.proj.coroutineviz.events.ActorMailboxChanged
+import com.jh.proj.coroutineviz.events.ActorMessageProcessed
+import com.jh.proj.coroutineviz.events.ActorMessageProcessing
+import com.jh.proj.coroutineviz.events.ActorMessageSent
+import com.jh.proj.coroutineviz.events.ActorStateChanged
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Instrumented actor implementation that emits visualization events.
+ *
+ * Implements the actor pattern using a coroutine + channel combination, with full
+ * event tracking for the visualization system. The actor:
+ * - Receives messages through a [Channel]-backed mailbox
+ * - Processes them sequentially in a dedicated coroutine
+ * - Emits events for creation, message send/processing, state changes, and closure
+ *
+ * Lifecycle events:
+ * 1. [ActorCreated] — when the actor is constructed and its processing loop starts
+ * 2. [ActorMessageSent] — when a message is enqueued to the mailbox
+ * 3. [ActorMessageProcessing] — when a message is dequeued and begins processing
+ * 4. [ActorMessageProcessed] — when message processing completes (success or failure)
+ * 5. [ActorMailboxChanged] — when the mailbox size changes
+ * 6. [ActorStateChanged] — when the actor's state is explicitly updated
+ * 7. [ActorClosed] — when the actor is shut down
+ *
+ * Usage via VizScope extension:
+ * ```kotlin
+ * val actor = scope.vizActor<String>(name = "printer") { message ->
+ *     println("Received: $message")
+ * }
+ * actor.send("Hello")
+ * actor.send("World")
+ * actor.close()
+ * ```
+ *
+ * @param M The message type accepted by this actor
+ * @param session The visualization session for emitting events
+ * @param scope The coroutine scope in which the actor's processing loop runs
+ * @param name Optional human-readable name for the actor
+ * @param capacity Mailbox channel capacity (defaults to [Channel.BUFFERED])
+ * @param handler The suspend function invoked for each received message
+ */
+class VizActor<M>(
+    private val session: VizSession,
+    private val scope: CoroutineScope,
+    val name: String? = null,
+    capacity: Int = Channel.BUFFERED,
+    private val handler: suspend (M) -> Unit,
+) {
+    val actorId: String = "actor-${session.nextSeq()}"
+
+    private val channel = Channel<TimestampedMessage<M>>(capacity)
+    private val mailboxSize = AtomicInteger(0)
+    private val messagesProcessed = AtomicLong(0L)
+    private val resolvedCapacity = resolveCapacity(capacity)
+
+    @Volatile
+    private var closed = false
+
+    private val job: Job
+
+    /**
+     * Internal wrapper that pairs a message with its enqueue timestamp,
+     * allowing queue wait time to be measured.
+     */
+    internal data class TimestampedMessage<M>(
+        val message: M,
+        val enqueuedAtNanos: Long,
+    )
+
+    init {
+        // Determine coroutine ID if running inside a viz context
+        val coroutineId =
+            runCatching {
+                kotlinx.coroutines.runBlocking {
+                    currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                }
+            }.getOrNull() ?: "actor-loop-$actorId"
+
+        // Emit ActorCreated
+        session.send(
+            ActorCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                actorId = actorId,
+                coroutineId = coroutineId,
+                name = name,
+                mailboxCapacity = resolvedCapacity,
+            ),
+        )
+
+        // Launch the processing loop
+        job =
+            scope.launch {
+                try {
+                    for (timestamped in channel) {
+                        val msg = timestamped.message
+                        val queueWaitNanos = System.nanoTime() - timestamped.enqueuedAtNanos
+                        val currentSize = mailboxSize.decrementAndGet().coerceAtLeast(0)
+
+                        val messageType = msg?.let { it::class.simpleName } ?: "null"
+                        val messagePreview = msg?.toString()?.take(200) ?: "null"
+
+                        // Emit mailbox changed (message dequeued)
+                        session.send(
+                            ActorMailboxChanged(
+                                sessionId = session.sessionId,
+                                seq = session.nextSeq(),
+                                tsNanos = System.nanoTime(),
+                                actorId = actorId,
+                                currentSize = currentSize,
+                                capacity = resolvedCapacity,
+                                pendingSenders = 0,
+                            ),
+                        )
+
+                        // Emit processing start
+                        session.send(
+                            ActorMessageProcessing(
+                                sessionId = session.sessionId,
+                                seq = session.nextSeq(),
+                                tsNanos = System.nanoTime(),
+                                actorId = actorId,
+                                messageType = messageType,
+                                messagePreview = messagePreview,
+                                queueWaitNanos = queueWaitNanos,
+                            ),
+                        )
+
+                        // Process the message
+                        val processingStart = System.nanoTime()
+                        var success = true
+                        try {
+                            handler(msg)
+                        } catch (e: CancellationException) {
+                            throw e // Don't swallow cancellation
+                        } catch (e: Exception) {
+                            success = false
+                            logger.warn(
+                                "Actor '$name' ($actorId) failed to process message: ${e.message}",
+                                e,
+                            )
+                        }
+                        val processingDuration = System.nanoTime() - processingStart
+
+                        messagesProcessed.incrementAndGet()
+
+                        // Emit processing completed
+                        session.send(
+                            ActorMessageProcessed(
+                                sessionId = session.sessionId,
+                                seq = session.nextSeq(),
+                                tsNanos = System.nanoTime(),
+                                actorId = actorId,
+                                messageType = messageType,
+                                processingDurationNanos = processingDuration,
+                                success = success,
+                            ),
+                        )
+                    }
+                } catch (e: CancellationException) {
+                    // Actor loop cancelled - normal shutdown
+                    logger.debug("Actor '$name' ($actorId) processing loop cancelled")
+                } finally {
+                    if (!closed) {
+                        emitClosed("Processing loop ended")
+                    }
+                }
+            }
+
+        logger.debug(
+            "Actor created: actorId=$actorId, name=$name, capacity=$resolvedCapacity",
+        )
+    }
+
+    /**
+     * Send a message to the actor's mailbox.
+     *
+     * Suspends if the mailbox is full (depending on capacity). Emits [ActorMessageSent]
+     * and [ActorMailboxChanged] events.
+     *
+     * @param message The message to send
+     * @throws IllegalStateException if the actor has been closed
+     */
+    suspend fun send(message: M) {
+        check(!closed) { "Actor '$name' ($actorId) is closed" }
+
+        val senderElement = currentCoroutineContext()[VizCoroutineElement]
+        val senderId = senderElement?.coroutineId ?: "unknown-${System.nanoTime()}"
+
+        val messageType = message?.let { it::class.simpleName } ?: "null"
+        val messagePreview = message?.toString()?.take(200) ?: "null"
+
+        // Enqueue the message
+        val timestamped = TimestampedMessage(message, System.nanoTime())
+        channel.send(timestamped)
+
+        val currentSize = mailboxSize.incrementAndGet()
+
+        // Emit message sent
+        session.send(
+            ActorMessageSent(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                actorId = actorId,
+                senderId = senderId,
+                messageType = messageType,
+                messagePreview = messagePreview,
+                mailboxSize = currentSize,
+            ),
+        )
+
+        // Emit mailbox changed (message enqueued)
+        session.send(
+            ActorMailboxChanged(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                actorId = actorId,
+                currentSize = currentSize,
+                capacity = resolvedCapacity,
+                pendingSenders = 0,
+            ),
+        )
+
+        logger.trace("Message sent to actor '$name' ($actorId): $messagePreview")
+    }
+
+    /**
+     * Try to send a message without suspending.
+     *
+     * @param message The message to send
+     * @return true if the message was enqueued, false if the mailbox is full
+     */
+    fun trySend(message: M): Boolean {
+        if (closed) return false
+
+        val timestamped = TimestampedMessage(message, System.nanoTime())
+        val result = channel.trySend(timestamped)
+
+        if (result.isSuccess) {
+            val currentSize = mailboxSize.incrementAndGet()
+            val messageType = message?.let { it::class.simpleName } ?: "null"
+            val messagePreview = message?.toString()?.take(200) ?: "null"
+
+            session.send(
+                ActorMessageSent(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    actorId = actorId,
+                    senderId = "trySend",
+                    messageType = messageType,
+                    messagePreview = messagePreview,
+                    mailboxSize = currentSize,
+                ),
+            )
+
+            session.send(
+                ActorMailboxChanged(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    actorId = actorId,
+                    currentSize = currentSize,
+                    capacity = resolvedCapacity,
+                    pendingSenders = 0,
+                ),
+            )
+        }
+
+        return result.isSuccess
+    }
+
+    /**
+     * Report a state change in the actor.
+     *
+     * Call this from within the handler to track internal state transitions.
+     *
+     * @param oldState Preview of the previous state
+     * @param newState Preview of the new state
+     * @param stateType Type/class name of the state object
+     */
+    fun reportStateChange(
+        oldState: String,
+        newState: String,
+        stateType: String,
+    ) {
+        session.send(
+            ActorStateChanged(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                actorId = actorId,
+                oldStatePreview = oldState,
+                newStatePreview = newState,
+                stateType = stateType,
+            ),
+        )
+    }
+
+    /**
+     * Close the actor and stop processing messages.
+     *
+     * Any messages already in the mailbox will be processed before the actor stops.
+     * Emits an [ActorClosed] event.
+     *
+     * @param reason Optional reason for closing the actor
+     */
+    fun close(reason: String? = null) {
+        if (closed) return
+        closed = true
+        channel.close()
+        emitClosed(reason)
+        logger.debug("Actor '$name' ($actorId) closed: reason=$reason")
+    }
+
+    /**
+     * Cancel the actor immediately, discarding any pending messages.
+     *
+     * @param reason Optional reason for cancellation
+     */
+    fun cancel(reason: String? = null) {
+        if (closed) return
+        closed = true
+        channel.cancel(CancellationException(reason ?: "Actor cancelled"))
+        job.cancel(CancellationException(reason ?: "Actor cancelled"))
+        emitClosed(reason ?: "Cancelled")
+        logger.debug("Actor '$name' ($actorId) cancelled: reason=$reason")
+    }
+
+    /**
+     * Whether this actor has been closed or cancelled.
+     */
+    val isClosed: Boolean get() = closed
+
+    /**
+     * The total number of messages processed by this actor.
+     */
+    val totalMessagesProcessed: Long get() = messagesProcessed.get()
+
+    /**
+     * The current mailbox size (approximate).
+     */
+    val currentMailboxSize: Int get() = mailboxSize.get().coerceAtLeast(0)
+
+    /**
+     * The Job backing this actor's processing loop.
+     */
+    val processingJob: Job get() = job
+
+    private fun emitClosed(reason: String?) {
+        session.send(
+            ActorClosed(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                actorId = actorId,
+                reason = reason,
+                totalMessagesProcessed = messagesProcessed.get(),
+            ),
+        )
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(VizActor::class.java)
+
+        /**
+         * Resolve the effective capacity for display purposes.
+         * Channel constants (BUFFERED, RENDEZVOUS, etc.) are negative sentinel values.
+         */
+        private fun resolveCapacity(capacity: Int): Int =
+            when (capacity) {
+                Channel.BUFFERED -> 64 // Default buffered capacity in kotlinx.coroutines
+                Channel.RENDEZVOUS -> 0
+                Channel.CONFLATED -> 1
+                Channel.UNLIMITED -> Int.MAX_VALUE
+                else -> capacity
+            }
+    }
+}
+
+// ============================================================================
+// Extension function for creating VizActor in VizScope
+// ============================================================================
+
+/**
+ * Create a new instrumented actor within this VizScope.
+ *
+ * The actor runs a dedicated coroutine that sequentially processes messages
+ * received through its mailbox channel, emitting visualization events
+ * for each lifecycle step.
+ *
+ * Example:
+ * ```kotlin
+ * val counter = scope.vizActor<Int>(name = "counter", capacity = Channel.BUFFERED) { delta ->
+ *     total += delta
+ *     reportStateChange("${total - delta}", "$total", "Int")
+ * }
+ *
+ * counter.send(1)
+ * counter.send(5)
+ * counter.close()
+ * ```
+ *
+ * @param M The message type accepted by the actor
+ * @param name Optional human-readable name for the actor
+ * @param capacity Mailbox channel capacity (defaults to [Channel.BUFFERED])
+ * @param handler The suspend function invoked for each received message
+ * @return A [VizActor] that can receive messages and be closed
+ */
+fun <M> VizScope.vizActor(
+    name: String? = null,
+    capacity: Int = Channel.BUFFERED,
+    handler: suspend (M) -> Unit,
+): VizActor<M> {
+    return VizActor(
+        session = session,
+        scope = this,
+        name = name,
+        capacity = capacity,
+        handler = handler,
+    )
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizCoroutineElement.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizCoroutineElement.kt
@@ -1,0 +1,36 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * CoroutineContext element that carries visualization metadata through the coroutine hierarchy.
+ *
+ * VizCoroutineElement is automatically added to the coroutine context by [VizScope.vizLaunch]
+ * and [VizScope.vizAsync]. It enables:
+ * - Parent-child relationship tracking (via [parentCoroutineId])
+ * - Event attribution to the correct coroutine
+ * - Scope membership tracking
+ *
+ * Access the current element from any coroutine context:
+ * ```kotlin
+ * val element = currentCoroutineContext()[VizCoroutineElement]
+ * println("Current coroutine: ${element?.coroutineId}")
+ * ```
+ *
+ * @property coroutineId Unique identifier for this coroutine
+ * @property jobId ID of the associated Job
+ * @property parentCoroutineId ID of the parent coroutine, null for root coroutines
+ * @property scopeId ID of the owning VizScope
+ * @property label Optional human-readable label for this coroutine
+ */
+data class VizCoroutineElement(
+    val coroutineId: String,
+    val jobId: String,
+    val parentCoroutineId: String?,
+    val scopeId: String,
+    val label: String?,
+) : CoroutineContext.Element {
+    companion object Key : CoroutineContext.Key<VizCoroutineElement>
+
+    override val key: CoroutineContext.Key<*> = Key
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizDispatchers.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizDispatchers.kt
@@ -1,0 +1,113 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Container for instrumented dispatchers used in visualization scenarios.
+ *
+ * This class creates and holds instrumented versions of common dispatchers
+ * that automatically emit DispatcherSelected and ThreadAssigned events.
+ *
+ * Usage:
+ * ```
+ * val dispatchers = VizDispatchers(session)
+ *
+ * // Use in VizScope via context
+ * val scope = VizScope(session, context = dispatchers.default)
+ *
+ * // Or pass to individual launches
+ * scope.vizLaunch(context = dispatchers.io) {
+ *     // Runs on IO dispatcher with tracking
+ * }
+ * ```
+ */
+class VizDispatchers(
+    private val session: VizSession,
+    private val scopeId: String = "dispatchers",
+) {
+    /**
+     * Instrumented version of Dispatchers.Default.
+     * Use for CPU-intensive operations.
+     */
+    val default: InstrumentedDispatcher =
+        InstrumentedDispatcher(
+            delegate = Dispatchers.Default,
+            session = session,
+            dispatcherId = "dispatcher-default-$scopeId",
+            dispatcherName = "Dispatchers.Default",
+        )
+
+    /**
+     * Instrumented version of Dispatchers.IO.
+     * Use for I/O operations (file, network, database).
+     */
+    val io: InstrumentedDispatcher =
+        InstrumentedDispatcher(
+            delegate = Dispatchers.IO,
+            session = session,
+            dispatcherId = "dispatcher-io-$scopeId",
+            dispatcherName = "Dispatchers.IO",
+        )
+
+    /**
+     * Instrumented version of Dispatchers.Unconfined.
+     * Use with caution - coroutine resumes in whatever thread the suspending function uses.
+     */
+    val unconfined: InstrumentedDispatcher =
+        InstrumentedDispatcher(
+            delegate = Dispatchers.Unconfined,
+            session = session,
+            dispatcherId = "dispatcher-unconfined-$scopeId",
+            dispatcherName = "Dispatchers.Unconfined",
+        )
+
+    /**
+     * Wrap any custom dispatcher with instrumentation.
+     *
+     * @param dispatcher The dispatcher to wrap
+     * @param name Human-readable name for the dispatcher (shown in events)
+     * @return Instrumented dispatcher that emits tracking events
+     *
+     * @example
+     * ```
+     * val myThreadPool = Executors.newFixedThreadPool(4).asCoroutineDispatcher()
+     * val instrumented = dispatchers.instrument(myThreadPool, "MyThreadPool")
+     *
+     * scope.vizLaunch(context = instrumented) {
+     *     // Tracked on your custom dispatcher
+     * }
+     * ```
+     */
+    fun instrument(
+        dispatcher: CoroutineDispatcher,
+        name: String? = null,
+    ): InstrumentedDispatcher {
+        // If already instrumented, return as-is
+        if (dispatcher is InstrumentedDispatcher) {
+            return dispatcher
+        }
+
+        // Wrap with instrumentation
+        return InstrumentedDispatcher(
+            delegate = dispatcher,
+            session = session,
+            dispatcherId = "dispatcher-custom-${dispatcher.hashCode()}-$scopeId",
+            dispatcherName = name ?: dispatcher.toString(),
+        )
+    }
+
+    companion object {
+        /**
+         * Create VizDispatchers for a session with a specific scope ID.
+         * Useful when you want multiple dispatcher sets in the same session.
+         */
+        fun create(
+            session: VizSession,
+            scopeId: String = "dispatchers",
+        ): VizDispatchers {
+            return VizDispatchers(session, scopeId)
+        }
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizMutex.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizMutex.kt
@@ -1,0 +1,291 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.MutexCreated
+import com.jh.proj.coroutineviz.events.MutexLockAcquired
+import com.jh.proj.coroutineviz.events.MutexLockRequested
+import com.jh.proj.coroutineviz.events.MutexQueueChanged
+import com.jh.proj.coroutineviz.events.MutexTryLockFailed
+import com.jh.proj.coroutineviz.events.MutexUnlocked
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.sync.Mutex
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * Instrumented Mutex wrapper that emits visualization events.
+ *
+ * This wrapper provides full transparency into mutex behavior:
+ * - Lock acquisition and release timing
+ * - Wait queue management
+ * - Contention detection
+ * - Potential deadlock warnings
+ *
+ * Real-world use cases:
+ * - Database connection serialization
+ * - Shared resource protection
+ * - Thread-safe counter updates
+ * - Critical section protection
+ *
+ * @param session The visualization session for emitting events
+ * @param label Human-readable label for the mutex
+ */
+class VizMutex(
+    private val session: VizSession,
+    val label: String? = null,
+) {
+    val mutexId: String = "mutex-${session.nextSeq()}"
+    private val delegate = Mutex()
+
+    // Wait queue tracking
+    private val waitQueue = ConcurrentLinkedQueue<WaiterInfo>()
+    private val holdStartTimes = ConcurrentHashMap<String, Long>()
+
+    // Current owner tracking
+    @Volatile
+    private var currentOwnerId: String? = null
+
+    @Volatile
+    private var currentOwnerLabel: String? = null
+
+    data class WaiterInfo(
+        val coroutineId: String,
+        val label: String?,
+        val requestTime: Long,
+    )
+
+    init {
+        session.send(
+            MutexCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                mutexId = mutexId,
+                mutexLabel = label,
+                ownerCoroutineId = null,
+            ),
+        )
+    }
+
+    /**
+     * Check if the mutex is currently locked
+     */
+    val isLocked: Boolean get() = delegate.isLocked
+
+    /**
+     * Get the current owner coroutine ID (if any)
+     */
+    fun getOwnerId(): String? = currentOwnerId
+
+    /**
+     * Get the number of coroutines waiting for this mutex
+     */
+    fun getWaitQueueSize(): Int = waitQueue.size
+
+    /**
+     * Acquire the mutex lock (suspends if already held)
+     */
+    suspend fun lock(owner: Any? = null) {
+        val coroutineElement = currentCoroutineContext()[VizCoroutineElement]
+        val coroutineId = coroutineElement?.coroutineId ?: "unknown-${System.nanoTime()}"
+        val coroutineLabel = coroutineElement?.label
+
+        val wasLocked = delegate.isLocked
+        val position = if (wasLocked) waitQueue.size + 1 else 0
+
+        // Emit lock requested
+        session.send(
+            MutexLockRequested(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                mutexId = mutexId,
+                mutexLabel = label,
+                requesterId = coroutineId,
+                requesterLabel = coroutineLabel,
+                isLocked = wasLocked,
+                queuePosition = position,
+            ),
+        )
+
+        // Add to wait queue if locked
+        val waiterInfo = WaiterInfo(coroutineId, coroutineLabel, System.nanoTime())
+        if (wasLocked) {
+            waitQueue.add(waiterInfo)
+            emitQueueChanged()
+        }
+
+        // Actually acquire the lock (may suspend)
+        val startWait = System.nanoTime()
+        delegate.lock(owner)
+        val waitDuration = System.nanoTime() - startWait
+
+        // Remove from wait queue and update owner
+        waitQueue.remove(waiterInfo)
+        currentOwnerId = coroutineId
+        currentOwnerLabel = coroutineLabel
+        holdStartTimes[coroutineId] = System.nanoTime()
+
+        // Emit lock acquired
+        session.send(
+            MutexLockAcquired(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                mutexId = mutexId,
+                mutexLabel = label,
+                acquirerId = coroutineId,
+                acquirerLabel = coroutineLabel,
+                waitDurationNanos = waitDuration,
+            ),
+        )
+
+        if (wasLocked) {
+            emitQueueChanged()
+        }
+    }
+
+    /**
+     * Release the mutex lock
+     */
+    fun unlock(owner: Any? = null) {
+        val coroutineElement =
+            try {
+                // This might fail if called from non-coroutine context
+                kotlinx.coroutines.runBlocking { currentCoroutineContext()[VizCoroutineElement] }
+            } catch (_: Exception) {
+                null
+            }
+
+        val coroutineId = coroutineElement?.coroutineId ?: currentOwnerId ?: "unknown"
+        val coroutineLabel = coroutineElement?.label ?: currentOwnerLabel
+
+        val holdStart = holdStartTimes.remove(coroutineId)
+        val holdDuration = if (holdStart != null) System.nanoTime() - holdStart else 0L
+
+        val nextWaiter = waitQueue.peek()
+
+        // Clear owner before unlocking
+        currentOwnerId = null
+        currentOwnerLabel = null
+
+        delegate.unlock(owner)
+
+        // Emit unlocked
+        session.send(
+            MutexUnlocked(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                mutexId = mutexId,
+                mutexLabel = label,
+                releaserId = coroutineId,
+                releaserLabel = coroutineLabel,
+                nextWaiterId = nextWaiter?.coroutineId,
+                holdDurationNanos = holdDuration,
+            ),
+        )
+    }
+
+    /**
+     * Try to acquire the lock without suspending
+     *
+     * @return true if lock was acquired, false if already held
+     */
+    fun tryLock(owner: Any? = null): Boolean {
+        val coroutineElement =
+            try {
+                kotlinx.coroutines.runBlocking { currentCoroutineContext()[VizCoroutineElement] }
+            } catch (_: Exception) {
+                null
+            }
+
+        val coroutineId = coroutineElement?.coroutineId ?: "unknown-${System.nanoTime()}"
+        val coroutineLabel = coroutineElement?.label
+
+        val acquired = delegate.tryLock(owner)
+
+        if (acquired) {
+            currentOwnerId = coroutineId
+            currentOwnerLabel = coroutineLabel
+            holdStartTimes[coroutineId] = System.nanoTime()
+
+            session.send(
+                MutexLockAcquired(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    mutexId = mutexId,
+                    mutexLabel = label,
+                    acquirerId = coroutineId,
+                    acquirerLabel = coroutineLabel,
+                    waitDurationNanos = 0,
+                ),
+            )
+        } else {
+            session.send(
+                MutexTryLockFailed(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    mutexId = mutexId,
+                    mutexLabel = label,
+                    requesterId = coroutineId,
+                    requesterLabel = coroutineLabel,
+                    currentOwnerId = currentOwnerId,
+                ),
+            )
+        }
+
+        return acquired
+    }
+
+    /**
+     * Execute block while holding the mutex lock
+     */
+    suspend fun <T> withLock(
+        owner: Any? = null,
+        action: suspend () -> T,
+    ): T {
+        lock(owner)
+        try {
+            return action()
+        } finally {
+            unlock(owner)
+        }
+    }
+
+    private fun emitQueueChanged() {
+        val waiters = waitQueue.toList()
+        session.send(
+            MutexQueueChanged(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                mutexId = mutexId,
+                mutexLabel = label,
+                waitingCoroutineIds = waiters.map { it.coroutineId },
+                waitingLabels = waiters.map { it.label },
+            ),
+        )
+    }
+}
+
+// ============================================================================
+// Extension function for creating VizMutex in VizScope
+// ============================================================================
+
+/**
+ * Create a new instrumented Mutex within this VizScope
+ *
+ * Example:
+ * ```kotlin
+ * val mutex = vizMutex("database-lock")
+ * mutex.withLock {
+ *     // Critical section
+ * }
+ * ```
+ */
+fun VizScope.vizMutex(label: String? = null): VizMutex {
+    return VizMutex(session, label)
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizScope.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizScope.kt
@@ -1,0 +1,804 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.SuspensionPoint
+import com.jh.proj.coroutineviz.events.deferred.DeferredValueAvailable
+import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
+import com.jh.proj.coroutineviz.events.flow.FlowCreated
+import com.jh.proj.coroutineviz.session.EventContext
+import com.jh.proj.coroutineviz.session.VizSession
+import com.jh.proj.coroutineviz.session.coroutineBodyCompleted
+import com.jh.proj.coroutineviz.session.coroutineCancelled
+import com.jh.proj.coroutineviz.session.coroutineCompleted
+import com.jh.proj.coroutineviz.session.coroutineCreated
+import com.jh.proj.coroutineviz.session.coroutineFailed
+import com.jh.proj.coroutineviz.session.coroutineResumed
+import com.jh.proj.coroutineviz.session.coroutineStarted
+import com.jh.proj.coroutineviz.session.coroutineSuspended
+import com.jh.proj.coroutineviz.session.jobStateChanged
+import com.jh.proj.coroutineviz.session.waitingForChildren
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * VizScope creates an independent coroutine hierarchy for visualization.
+ *
+ * It maintains structured concurrency within its own scope, independent of the caller's scope.
+ * This allows multiple visualization sessions to run concurrently without interfering with each other.
+ *
+ * With the default Job (not SupervisorJob), child failures will cancel parent and siblings,
+ * demonstrating proper structured concurrency behavior. Use SupervisorJob if you want
+ * children to fail independently.
+ *
+ * @param session The visualization session for tracking events
+ * @param context Optional coroutine context (dispatcher, job, etc.) for customization
+ * @param scopeId Unique identifier for this scope
+ */
+class VizScope(
+    internal val session: VizSession,
+    context: CoroutineContext = EmptyCoroutineContext,
+    val scopeId: String = "scope-${session.nextSeq()}",
+) : CoroutineScope {
+    override val coroutineContext: CoroutineContext = context + CoroutineName("VizScope-$scopeId")
+
+    /**
+     * Launch a coroutine with visualization tracking while maintaining structured concurrency.
+     *
+     * This function:
+     * - Launches on the VizScope's independent coroutine scope
+     * - Tracks parent-child relationships through VizCoroutineElement in context
+     * - Ensures parents wait for all children to complete (structured concurrency)
+     * - Emits events in the correct order (children complete before parents)
+     *
+     * @param label Optional label for the coroutine
+     * @param context Additional coroutine context to merge
+     * @param block The coroutine body to execute
+     * @return VizJob handle for the launched coroutine with event tracking
+     */
+    suspend fun vizLaunch(
+        label: String? = null,
+        context: CoroutineContext = EmptyCoroutineContext,
+        block: suspend VizScope.() -> Unit,
+    ): Job {
+        // Check if we're already inside a vizLaunch (nested call)
+        // Use currentCoroutineContext() to get the CURRENT coroutine's context, not VizScope's
+        val parentElement = currentCoroutineContext()[VizCoroutineElement]
+        val parentCoroutineId = parentElement?.coroutineId
+
+        val coroutineId = "coroutine-${session.nextSeq()}"
+        val jobId = "job-$coroutineId"
+
+        val vizElement =
+            VizCoroutineElement(
+                coroutineId = coroutineId,
+                label = label,
+                parentCoroutineId = parentCoroutineId,
+                scopeId = scopeId,
+                jobId = jobId,
+            )
+
+        // ✅ Create EventContext once for this coroutine
+        val ctx =
+            EventContext(
+                session = session,
+                coroutineId = coroutineId,
+                jobId = jobId,
+                parentCoroutineId = parentCoroutineId,
+                scopeId = scopeId,
+                label = label,
+            )
+
+        // Check if we're in a nested context (inside another vizLaunch/vizAsync)
+        // If so, use current scope; otherwise use VizScope
+        val targetScope =
+            currentCoroutineContext()[VizCoroutineElement]?.let {
+                CoroutineScope(currentCoroutineContext())
+            } ?: this
+
+        // Merge VizScope's own context (which may contain a specific dispatcher)
+        // so that e.g. ioScope.vizLaunch() uses the IO dispatcher even when nested
+        val scopeDispatcher = this.coroutineContext[ContinuationInterceptor]
+
+        // Launch with the viz element in context
+        // scopeDispatcher is applied first, then overridden by explicit context if provided
+        val mergedContext = (scopeDispatcher ?: EmptyCoroutineContext) + context + vizElement
+        val job =
+            targetScope.launch(mergedContext) {
+                val currentJob = coroutineContext[Job] ?: throw IllegalArgumentException("Missing job")
+                // ✨ NEW: Register job for tracking
+                session.snapshot.registerJob(currentJob, coroutineId)
+
+                // ✨ NEW: Optionally track with monitor
+                session.jobMonitor.track(currentJob, jobId, coroutineId)
+
+                // register currentJob with coroutineId
+                session.snapshot.registerJob(currentJob, coroutineId)
+                // ✅ EMIT: CoroutineCreated
+                session.send(ctx.coroutineCreated())
+
+                // ✅ EMIT: CoroutineStarted
+                session.send(ctx.coroutineStarted())
+
+                // EMIT: ThreadAssigned
+                session.sent(
+                    ThreadAssigned(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        coroutineId = coroutineId,
+                        jobId = jobId,
+                        parentCoroutineId = parentCoroutineId,
+                        scopeId = scopeId,
+                        label = label,
+                        threadId = Thread.currentThread().threadId(),
+                        threadName = Thread.currentThread().name,
+                        dispatcherName = coroutineContext[ContinuationInterceptor]?.toString() ?: "Unknown",
+                    ),
+                )
+
+                block()
+
+                checkAndSendJobStateEvent(currentJob, ctx)
+
+                // Emit CoroutineBodyCompleted - the coroutine's own code has finished
+                // AND all children have completed (due to coroutineScope above)
+                session.sent(ctx.coroutineBodyCompleted())
+            }
+
+        // Register completion handler - this fires AFTER the job and all children complete
+        // This is crucial for detecting the FINAL state of the Job:
+        // 1. cause == null -> Normal completion
+        // 2. cause is CancellationException -> Cancelled (child failed, explicit cancellation, etc.)
+        // 3. cause is other Throwable -> Failed (but in practice, this is rare for jobs)
+        job.invokeOnCompletion { cause ->
+            // invokeOnCompletion is NOT a suspend function, but session.send() is also NOT suspend!
+            // We can call it directly without launching a coroutine
+            // Only emit terminal event if we haven't already emitted one
+            when {
+                cause == null -> {
+                    // Normal completion - body finished and all children completed successfully
+                    session.send(
+                        ctx.coroutineCompleted(),
+                    )
+                }
+
+                cause !is CancellationException && cause.message?.contains(ctx.label ?: "unknown") == true -> {
+                    // Failure - own code threw an exception
+                    // Note: In practice, this rarely happens because coroutineScope
+                    // converts exceptions to CancellationException
+                    session.send(ctx.coroutineFailed(cause::class.simpleName, cause.message))
+                    session.send(
+                        ctx.jobStateChanged(
+                            isActive = false,
+                            isCompleted = false,
+                            isCancelled = true,
+                            childrenCount = coroutineContext[Job]?.children?.count() ?: 0,
+                        ),
+                    )
+                }
+
+                cause is CancellationException || job.isCancelled -> {
+                    // Cancellation - could be:
+                    // - Child failed (structured concurrency cancellation)
+                    // - Explicit cancellation
+                    // - Parent cancelled
+                    session.send(ctx.coroutineCancelled(cause.message ?: "CancellationException"))
+                    session.send(
+                        ctx.jobStateChanged(
+                            isActive = false,
+                            isCompleted = false,
+                            isCancelled = true,
+                            childrenCount = coroutineContext[Job]?.children?.count() ?: 0,
+                        ),
+                    )
+                }
+
+                else -> {
+                    // Failure - own code threw an exception
+                    // Note: In practice, this rarely happens because coroutineScope
+                    // converts exceptions to CancellationException
+                    throw IllegalArgumentException("It is not correct state")
+                }
+            }
+        }
+        return job
+    }
+
+    /**
+     * Async counterpart to vizLaunch that emits lifecycle events and returns an InstrumentedDeferred
+     * so awaiters are tracked (await start/completion and awaiter suspension/resume).
+     */
+    suspend fun <T> vizAsync(
+        label: String? = null,
+        context: CoroutineContext = EmptyCoroutineContext,
+        block: suspend VizScope.() -> T,
+    ): InstrumentedDeferred<T> {
+        val parentElement = currentCoroutineContext()[VizCoroutineElement]
+        val parentCoroutineId = parentElement?.coroutineId
+
+        val coroutineId = "coroutine-${session.nextSeq()}"
+        val jobId = "job-$coroutineId"
+        val deferredId = "deferred-$coroutineId"
+
+        val vizElement =
+            VizCoroutineElement(
+                coroutineId = coroutineId,
+                label = label,
+                parentCoroutineId = parentCoroutineId,
+                scopeId = scopeId,
+                jobId = jobId,
+            )
+
+        val ctx =
+            EventContext(
+                session = session,
+                coroutineId = coroutineId,
+                jobId = jobId,
+                parentCoroutineId = parentCoroutineId,
+                scopeId = scopeId,
+                label = label,
+            )
+
+        // Check if we're in a nested context (inside another vizLaunch/vizAsync)
+        // If so, use current scope; otherwise use VizScope
+        val targetScope =
+            currentCoroutineContext()[VizCoroutineElement]?.let {
+                CoroutineScope(currentCoroutineContext())
+            } ?: this
+
+        // Merge VizScope's own context (which may contain a specific dispatcher)
+        val scopeDispatcher = this.coroutineContext[ContinuationInterceptor]
+        val mergedContext = (scopeDispatcher ?: EmptyCoroutineContext) + context + vizElement
+
+        // Use async{} instead of launch{}
+        val deferred =
+            targetScope.async(mergedContext) {
+                val currentJob = coroutineContext[Job] ?: throw IllegalArgumentException("Missing job")
+
+                // ✨ Register job for tracking (must happen inside async where Job exists)
+                session.snapshot.registerJob(currentJob, coroutineId)
+                session.jobMonitor.track(currentJob, jobId, coroutineId)
+
+                // Emit lifecycle events (similar to vizLaunch)
+                session.send(ctx.coroutineCreated())
+                session.send(ctx.coroutineStarted())
+
+                session.sent(
+                    ThreadAssigned(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        coroutineId = coroutineId,
+                        jobId = jobId,
+                        parentCoroutineId = parentCoroutineId,
+                        scopeId = scopeId,
+                        label = label,
+                        threadId = Thread.currentThread().threadId(),
+                        threadName = Thread.currentThread().name,
+                        dispatcherName = coroutineContext[ContinuationInterceptor]?.toString() ?: "Unknown",
+                    ),
+                )
+                // Execute block
+                val result = block()
+
+                checkAndSendJobStateEvent(currentJob, ctx)
+
+                // Emit body completed
+                session.sent(
+                    ctx.coroutineBodyCompleted(),
+                )
+
+                // Emit deferred value available
+                session.sent(
+                    DeferredValueAvailable(
+                        sessionId = session.sessionId,
+                        seq = session.nextSeq(),
+                        tsNanos = System.nanoTime(),
+                        coroutineId = coroutineId,
+                        jobId = jobId,
+                        parentCoroutineId = parentCoroutineId,
+                        scopeId = scopeId,
+                        label = label,
+                        deferredId = deferredId,
+                    ),
+                )
+
+                result
+            }
+
+        // Register completion handler (same logic as vizLaunch)
+        // session.send() is NOT suspend, so we can call it directly
+        deferred.invokeOnCompletion { cause ->
+            // invokeOnCompletion is NOT a suspend function, but session.send() is also NOT suspend!
+            // We can call it directly without launching a coroutine
+            // Only emit terminal event if we haven't already emitted one
+            when {
+                cause == null -> {
+                    // Normal completion - body finished and all children completed successfully
+                    session.send(
+                        ctx.coroutineCompleted(),
+                    )
+                }
+
+                cause !is CancellationException && cause.message?.contains(ctx.label ?: "unknown") == true -> {
+                    // Failure - own code threw an exception
+                    // Note: In practice, this rarely happens because coroutineScope
+                    // converts exceptions to CancellationException
+                    session.send(ctx.coroutineFailed(cause::class.simpleName, cause.message))
+                }
+
+                cause is CancellationException || deferred.isCancelled -> {
+                    // Cancellation - could be:
+                    // - Child failed (structured concurrency cancellation)
+                    // - Explicit cancellation
+                    // - Parent cancelled
+                    session.send(ctx.coroutineCancelled(cause.message ?: "CancellationException"))
+                }
+
+                else -> {
+                    // Failure - own code threw an exception
+                    // Note: In practice, this rarely happens because coroutineScope
+                    // converts exceptions to CancellationException
+                    throw IllegalArgumentException("It is not correct state")
+                }
+            }
+        }
+
+        // Return wrapped deferred
+        return InstrumentedDeferred(
+            delegate = deferred,
+            session = session,
+            deferredId = deferredId,
+            coroutineId = coroutineId,
+            jobId = jobId,
+            parentCoroutineId = parentCoroutineId,
+            scopeId = scopeId,
+            label = label,
+        )
+    }
+
+    /**
+     * Suspend with delay while emitting suspension/resume events when running inside a viz instrumented coroutine.
+     */
+    suspend fun vizDelay(timeMillis: Long) {
+        val coroutineElement = currentCoroutineContext()[VizCoroutineElement]
+
+        if (coroutineElement != null) {
+            // Create EventContext for this coroutine
+            val ctx =
+                EventContext(
+                    session = session,
+                    coroutineId = coroutineElement.coroutineId,
+                    jobId = coroutineElement.jobId,
+                    parentCoroutineId = coroutineElement.parentCoroutineId,
+                    scopeId = coroutineElement.scopeId,
+                    label = coroutineElement.label,
+                )
+
+            // Capture suspension point with stack trace
+            val suspensionPoint = SuspensionPoint.capture("delay", skipFrames = 3)
+
+            // Emit suspension with detailed info
+            session.sent(
+                ctx.coroutineSuspended(reason = "delay", durationMillis = timeMillis, suspensionPoint = suspensionPoint),
+            )
+
+            // Actual suspension
+            delay(timeMillis)
+
+            // Emit resumption
+            session.send(ctx.coroutineResumed())
+        } else {
+            // No instrumentation context, just delay
+            delay(timeMillis)
+        }
+    }
+
+    /**
+     * Cancel all coroutines in this VizScope and wait for them to complete.
+     */
+    suspend fun cancelAndJoin() {
+        coroutineContext[Job]?.cancelAndJoin()
+    }
+
+    /**
+     * Cancel all coroutines in this VizScope.
+     */
+    fun cancel() {
+        coroutineContext[Job]?.cancel()
+    }
+
+    private fun checkAndSendJobStateEvent(
+        job: Job,
+        ctx: EventContext,
+    ) {
+        val hasActiveChildren = job.children.any { it.isActive }
+        if (hasActiveChildren) {
+            val activeChildren = job.children.filter { it.isActive }.map { it.job }.toList()
+            // Get child coroutine IDs from their contexts
+            val activeChildIds =
+                activeChildren.mapNotNull { childJob ->
+                    // Try to extract coroutineId from child job
+                    // This requires tracking job->coroutineId mapping
+                    session.snapshot.getCoroutineIdFromJob(childJob)
+                }
+
+            session.send(
+                ctx.waitingForChildren(
+                    activeChildrenCount = activeChildren.count(),
+                    activeChildrenIds = activeChildIds,
+                ),
+            )
+        }
+    }
+
+    // ========================================================================
+    // Flow Builders
+    // ========================================================================
+
+    /**
+     * Create an instrumented Flow with visualization tracking.
+     *
+     * This function wraps a flow builder to emit events for:
+     * - Flow creation
+     * - Collection start/complete/cancel
+     * - Value emissions with sequence numbers
+     * - Operator applications
+     *
+     * Usage:
+     * ```kotlin
+     * val flow = scope.vizFlow("my-flow") {
+     *     emit(1)
+     *     emit(2)
+     *     emit(3)
+     * }
+     *
+     * flow.collect { println(it) }
+     * ```
+     *
+     * @param label Optional human-readable label for the flow
+     * @param block The flow builder block
+     * @return An InstrumentedFlow that tracks all operations
+     */
+    fun <T> vizFlow(
+        label: String? = null,
+        block: suspend FlowCollector<T>.() -> Unit,
+    ): InstrumentedFlow<T> {
+        val flowId = "flow-${session.nextSeq()}"
+        val coroutineId =
+            runCatching {
+                kotlinx.coroutines.runBlocking {
+                    currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                }
+            }.getOrNull()
+
+        // Emit FlowCreated event
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = coroutineId ?: "unknown",
+                flowId = flowId,
+                flowType = "Cold",
+                label = label,
+                scopeId = scopeId,
+            ),
+        )
+
+        // Create the underlying flow
+        val underlyingFlow = flow(block)
+
+        // Wrap it with instrumentation
+        return InstrumentedFlow(
+            delegate = underlyingFlow,
+            session = session,
+            flowId = flowId,
+            flowType = "Cold",
+            label = label,
+        )
+    }
+
+    /**
+     * Wrap an existing Flow with instrumentation.
+     *
+     * Use this to add visualization tracking to any existing Flow.
+     *
+     * @param existingFlow The Flow to wrap
+     * @param label Optional human-readable label
+     * @return An InstrumentedFlow that tracks all operations
+     */
+    fun <T> vizWrap(
+        existingFlow: Flow<T>,
+        label: String? = null,
+    ): InstrumentedFlow<T> {
+        val flowId = "flow-${session.nextSeq()}"
+        val coroutineId =
+            runCatching {
+                kotlinx.coroutines.runBlocking {
+                    currentCoroutineContext()[VizCoroutineElement]?.coroutineId
+                }
+            }.getOrNull()
+
+        // Emit FlowCreated event
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = coroutineId ?: "unknown",
+                flowId = flowId,
+                flowType = "Cold",
+                label = label,
+                scopeId = scopeId,
+            ),
+        )
+
+        return InstrumentedFlow(
+            delegate = existingFlow,
+            session = session,
+            flowId = flowId,
+            flowType = "Cold",
+            label = label,
+        )
+    }
+
+    /**
+     * Create an instrumented MutableStateFlow.
+     *
+     * StateFlow is a hot Flow that:
+     * - Always has a current value
+     * - Replays the current value to new collectors
+     * - Emits only when value changes (distinctUntilChanged)
+     *
+     * @param initialValue The initial value of the StateFlow
+     * @param label Optional human-readable label
+     * @return An InstrumentedStateFlow with visualization tracking
+     */
+    fun <T> vizStateFlow(
+        initialValue: T,
+        label: String? = null,
+    ): InstrumentedStateFlow<T> {
+        val flowId = "stateflow-${session.nextSeq()}"
+        return InstrumentedStateFlow(
+            delegate = MutableStateFlow(initialValue),
+            session = session,
+            flowId = flowId,
+            label = label,
+        )
+    }
+
+    /**
+     * Create an instrumented MutableSharedFlow.
+     *
+     * SharedFlow is a hot Flow that:
+     * - Can have multiple subscribers
+     * - Supports replay cache for late subscribers
+     * - Can buffer emissions with configurable overflow strategy
+     *
+     * @param replay Number of values to replay to new subscribers
+     * @param extraBufferCapacity Extra buffer capacity beyond replay
+     * @param onBufferOverflow Strategy for handling buffer overflow
+     * @param label Optional human-readable label
+     * @return An InstrumentedSharedFlow with visualization tracking
+     */
+    fun <T> vizSharedFlow(
+        replay: Int = 0,
+        extraBufferCapacity: Int = 0,
+        onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
+        label: String? = null,
+    ): InstrumentedSharedFlow<T> {
+        val flowId = "sharedflow-${session.nextSeq()}"
+        return InstrumentedSharedFlow(
+            delegate = MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow),
+            session = session,
+            flowId = flowId,
+            label = label,
+            extraBufferCapacity = extraBufferCapacity,
+        )
+    }
+
+    /**
+     * Create an instrumented interval Flow that emits values at fixed intervals.
+     *
+     * Useful for testing timing-related Flow behavior.
+     *
+     * @param periodMillis The interval between emissions in milliseconds
+     * @param initialDelayMillis Optional initial delay before first emission
+     * @param label Optional human-readable label
+     * @return An InstrumentedFlow that emits Long values at intervals
+     */
+    fun vizInterval(
+        periodMillis: Long,
+        initialDelayMillis: Long = 0,
+        label: String? = null,
+    ): InstrumentedFlow<Long> {
+        val flowId = "flow-interval-${session.nextSeq()}"
+
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = "unknown",
+                flowId = flowId,
+                flowType = "Interval",
+                label = label ?: "interval(${periodMillis}ms)",
+                scopeId = scopeId,
+            ),
+        )
+
+        val intervalFlow =
+            flow {
+                if (initialDelayMillis > 0) {
+                    delay(initialDelayMillis)
+                }
+                var counter = 0L
+                while (true) {
+                    emit(counter++)
+                    delay(periodMillis)
+                }
+            }
+
+        return InstrumentedFlow(
+            delegate = intervalFlow,
+            session = session,
+            flowId = flowId,
+            flowType = "Interval",
+            label = label ?: "interval(${periodMillis}ms)",
+        )
+    }
+
+    /**
+     * Create an instrumented Flow from a range.
+     *
+     * @param range The range of values to emit
+     * @param delayMillis Optional delay between emissions
+     * @param label Optional human-readable label
+     * @return An InstrumentedFlow that emits values from the range
+     */
+    fun vizRange(
+        range: IntRange,
+        delayMillis: Long = 0,
+        label: String? = null,
+    ): InstrumentedFlow<Int> {
+        val flowId = "flow-range-${session.nextSeq()}"
+
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = "unknown",
+                flowId = flowId,
+                flowType = "Range",
+                label = label ?: "range(${range.first}..${range.last})",
+                scopeId = scopeId,
+            ),
+        )
+
+        val rangeFlow =
+            flow {
+                for (value in range) {
+                    emit(value)
+                    if (delayMillis > 0) {
+                        delay(delayMillis)
+                    }
+                }
+            }
+
+        return InstrumentedFlow(
+            delegate = rangeFlow,
+            session = session,
+            flowId = flowId,
+            flowType = "Range",
+            label = label ?: "range(${range.first}..${range.last})",
+        )
+    }
+
+    /**
+     * Create an instrumented Flow from a list of values.
+     *
+     * @param values The values to emit
+     * @param delayMillis Optional delay between emissions
+     * @param label Optional human-readable label
+     * @return An InstrumentedFlow that emits the values
+     */
+    fun <T> vizFlowOf(
+        vararg values: T,
+        delayMillis: Long = 0,
+        label: String? = null,
+    ): InstrumentedFlow<T> {
+        val flowId = "flow-of-${session.nextSeq()}"
+
+        session.send(
+            FlowCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                coroutineId = "unknown",
+                flowId = flowId,
+                flowType = "FlowOf",
+                label = label ?: "flowOf(${values.size} items)",
+                scopeId = scopeId,
+            ),
+        )
+
+        val listFlow =
+            flow {
+                for (value in values) {
+                    emit(value)
+                    if (delayMillis > 0) {
+                        delay(delayMillis)
+                    }
+                }
+            }
+
+        return InstrumentedFlow(
+            delegate = listFlow,
+            session = session,
+            flowId = flowId,
+            flowType = "FlowOf",
+            label = label ?: "flowOf(${values.size} items)",
+        )
+    }
+
+    // ========================================================================
+    // Channel Builders
+    // ========================================================================
+
+    /**
+     * Create an instrumented Channel with visualization tracking.
+     *
+     * This function wraps a Channel to emit events for:
+     * - Channel creation
+     * - Send start/complete/suspend
+     * - Receive start/complete/suspend
+     * - Buffer state changes
+     * - Channel close
+     *
+     * Usage:
+     * ```kotlin
+     * val channel = scope.vizChannel<Int>(Channel.BUFFERED, "my-channel")
+     * channel.send(42)
+     * val value = channel.receive()
+     * channel.close()
+     * ```
+     *
+     * @param capacity Channel capacity (Channel.RENDEZVOUS, Channel.BUFFERED, Channel.CONFLATED, Channel.UNLIMITED, or a specific int)
+     * @param name Optional human-readable name for the channel
+     * @return An InstrumentedChannel that tracks all operations
+     */
+    fun <T> vizChannel(
+        capacity: Int = Channel.RENDEZVOUS,
+        name: String? = null,
+    ): InstrumentedChannel<T> {
+        val channelId = "channel-${session.nextSeq()}"
+        val channelType = channelTypeFromCapacity(capacity)
+        return InstrumentedChannel(
+            delegate = Channel(capacity),
+            session = session,
+            channelId = channelId,
+            name = name,
+            capacity = capacity,
+            channelType = channelType,
+        )
+    }
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizSelect.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizSelect.kt
@@ -1,0 +1,328 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.SelectClauseRegistered
+import com.jh.proj.coroutineviz.events.SelectClauseWon
+import com.jh.proj.coroutineviz.events.SelectCompleted
+import com.jh.proj.coroutineviz.events.SelectStarted
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.selects.SelectBuilder
+import kotlinx.coroutines.selects.select
+
+/**
+ * Instrumented wrapper for Kotlin's `select` expression that emits visualization events.
+ *
+ * Tracks the lifecycle of a select expression:
+ * 1. [SelectStarted] — when the select begins evaluation
+ * 2. [SelectClauseRegistered] — for each clause registered in the select block
+ * 3. [SelectClauseWon] — when a clause wins the race
+ * 4. [SelectCompleted] — when the select finishes
+ *
+ * Usage via VizScope extension:
+ * ```kotlin
+ * val result = scope.vizSelect<String> {
+ *     channel1.onReceive { value ->
+ *         registerClause("onReceive", channelId = instrumentedChannel.channelId)
+ *         "Got from channel1: $value"
+ *     }
+ *     channel2.onReceive { value ->
+ *         registerClause("onReceive", channelId = instrumentedChannel2.channelId)
+ *         "Got from channel2: $value"
+ *     }
+ * }
+ * ```
+ *
+ * @param session The visualization session for emitting events
+ */
+class VizSelect(private val session: VizSession) {
+    val selectId: String = "select-${session.nextSeq()}"
+
+    /**
+     * Execute an instrumented select expression.
+     *
+     * The [block] receives a [VizSelectBuilder] that wraps the real [SelectBuilder],
+     * allowing clause registration events to be emitted alongside the actual select logic.
+     *
+     * @param coroutineId ID of the coroutine executing the select
+     * @param block The select builder block that registers clauses and returns a result
+     * @return The result of the winning clause
+     */
+    suspend fun <R> vizSelect(
+        coroutineId: String,
+        block: VizSelectBuilder<R>.() -> Unit,
+    ): R {
+        val startNanos = System.nanoTime()
+        val builder = VizSelectBuilder<R>(session, selectId, coroutineId)
+
+        // Emit SelectStarted (clauseCount will be updated after registration)
+        val startedEvent =
+            SelectStarted(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = startNanos,
+                selectId = selectId,
+                coroutineId = coroutineId,
+                clauseCount = 0,
+            )
+        session.send(startedEvent)
+
+        val selectStartNanos = System.nanoTime()
+
+        // Execute the actual kotlinx.coroutines select with the instrumented builder
+        val result =
+            select<R> {
+                builder.selectBuilder = this
+                builder.block()
+            }
+
+        val endNanos = System.nanoTime()
+
+        // Emit SelectClauseWon for the winning clause
+        val winnerInfo = builder.winnerClause
+        if (winnerInfo != null) {
+            session.send(
+                SelectClauseWon(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = endNanos,
+                    selectId = selectId,
+                    coroutineId = coroutineId,
+                    winnerClauseIndex = winnerInfo.index,
+                    winnerClauseType = winnerInfo.type,
+                    waitDurationNanos = endNanos - selectStartNanos,
+                ),
+            )
+        }
+
+        // Emit SelectCompleted
+        session.send(
+            SelectCompleted(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = endNanos,
+                selectId = selectId,
+                coroutineId = coroutineId,
+                totalDurationNanos = endNanos - startNanos,
+            ),
+        )
+
+        return result
+    }
+}
+
+/**
+ * Builder DSL for instrumented select expressions.
+ *
+ * This builder wraps the real [SelectBuilder] and provides a [registerClause] method
+ * to emit [SelectClauseRegistered] events for each clause. The caller is responsible
+ * for calling [registerClause] inside each clause handler to record which clause won.
+ *
+ * @param R The result type of the select expression
+ * @param session The visualization session
+ * @param selectId The unique ID of the select expression
+ * @param coroutineId The coroutine executing the select
+ */
+class VizSelectBuilder<R>(
+    private val session: VizSession,
+    private val selectId: String,
+    private val coroutineId: String,
+) {
+    /**
+     * The underlying kotlinx.coroutines [SelectBuilder].
+     * Use this to register actual select clauses (onReceive, onSend, onAwait, etc.).
+     *
+     * Example:
+     * ```kotlin
+     * select.onReceive(channel) { value -> ... }
+     * ```
+     *
+     * Set internally by [VizSelect.vizSelect] before the block runs.
+     */
+    lateinit var select: SelectBuilder<R>
+        internal set
+
+    // Internal alias used by VizSelect to set the builder
+    internal var selectBuilder: SelectBuilder<R>
+        get() = select
+        set(value) {
+            select = value
+        }
+
+    private val clauses = mutableListOf<ClauseInfo>()
+
+    /**
+     * The clause that won the select race. Set by [registerClause] when called
+     * inside the winning clause's handler.
+     */
+    @Volatile
+    internal var winnerClause: ClauseInfo? = null
+
+    /**
+     * Information about a registered select clause.
+     */
+    data class ClauseInfo(
+        val index: Int,
+        val type: String,
+        val channelId: String?,
+        val deferredId: String?,
+        val timeoutMillis: Long?,
+        val label: String?,
+    )
+
+    /**
+     * Register a clause in the select expression and emit a [SelectClauseRegistered] event.
+     *
+     * Call this inside each clause handler (e.g., inside `onReceive { }`, `onAwait { }`) to
+     * track which clauses are part of the select and which one eventually wins.
+     *
+     * @param type The clause type: "onReceive", "onSend", "onAwait", "onTimeout", "onJoin"
+     * @param channelId Channel ID for onReceive/onSend clauses
+     * @param deferredId Deferred ID for onAwait clauses
+     * @param timeoutMillis Timeout for onTimeout clauses
+     * @param label Optional human-readable label
+     * @return The clause index (0-based)
+     */
+    fun registerClause(
+        type: String,
+        channelId: String? = null,
+        deferredId: String? = null,
+        timeoutMillis: Long? = null,
+        label: String? = null,
+    ): Int {
+        val index = clauses.size
+        val info =
+            ClauseInfo(
+                index = index,
+                type = type,
+                channelId = channelId,
+                deferredId = deferredId,
+                timeoutMillis = timeoutMillis,
+                label = label,
+            )
+        clauses.add(info)
+
+        // Emit clause registration event
+        session.send(
+            SelectClauseRegistered(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                selectId = selectId,
+                coroutineId = coroutineId,
+                clauseIndex = index,
+                clauseType = type,
+                channelId = channelId,
+                deferredId = deferredId,
+                timeoutMillis = timeoutMillis,
+                label = label,
+            ),
+        )
+
+        return index
+    }
+
+    /**
+     * Mark a clause as the winner of the select race.
+     *
+     * Call this from inside a clause handler to record which clause actually executed.
+     * Only the handler of the winning clause runs, so calling this inside the handler
+     * correctly identifies the winner.
+     *
+     * @param clauseIndex The index returned by [registerClause]
+     */
+    fun markWinner(clauseIndex: Int) {
+        if (clauseIndex in clauses.indices) {
+            winnerClause = clauses[clauseIndex]
+        }
+    }
+
+    /**
+     * Convenience: register a clause and immediately mark it as winner.
+     *
+     * Use this inside the clause handler (which only runs for the winning clause)
+     * to both register and mark the clause in a single call.
+     *
+     * @param type The clause type
+     * @param channelId Channel ID for onReceive/onSend clauses
+     * @param deferredId Deferred ID for onAwait clauses
+     * @param timeoutMillis Timeout for onTimeout clauses
+     * @param label Optional human-readable label
+     * @return The clause index
+     */
+    fun clauseWon(
+        type: String,
+        channelId: String? = null,
+        deferredId: String? = null,
+        timeoutMillis: Long? = null,
+        label: String? = null,
+    ): Int {
+        val index = registerClause(type, channelId, deferredId, timeoutMillis, label)
+        markWinner(index)
+        return index
+    }
+
+    /**
+     * Number of clauses registered so far.
+     */
+    val clauseCount: Int get() = clauses.size
+
+    /**
+     * Get a snapshot of all registered clauses.
+     */
+    fun registeredClauses(): List<ClauseInfo> = clauses.toList()
+}
+
+// ============================================================================
+// Extension function for creating instrumented select in VizScope
+// ============================================================================
+
+/**
+ * Execute an instrumented `select` expression within this VizScope.
+ *
+ * Wraps Kotlin's [select] to emit visualization events tracking which clauses
+ * are registered, which one wins, and the overall timing.
+ *
+ * The [block] receives a [VizSelectBuilder] whose [VizSelectBuilder.select] property
+ * gives access to the real [SelectBuilder]. Register clauses on the real builder
+ * and call [VizSelectBuilder.registerClause] to emit tracking events.
+ *
+ * Usage:
+ * ```kotlin
+ * val result = scope.vizSelect<String> {
+ *     val idx0 = registerClause("onReceive", channelId = ch1.channelId)
+ *     select.onReceive(ch1) { value ->
+ *         markWinner(idx0)
+ *         "Received from ch1: $value"
+ *     }
+ *     val idx1 = registerClause("onReceive", channelId = ch2.channelId)
+ *     select.onReceive(ch2) { value ->
+ *         markWinner(idx1)
+ *         "Received from ch2: $value"
+ *     }
+ * }
+ * ```
+ *
+ * Or use the shorthand [VizSelectBuilder.clauseWon] inside the handler:
+ * ```kotlin
+ * val result = scope.vizSelect<String> {
+ *     select.onReceive(ch1) { value ->
+ *         clauseWon("onReceive", channelId = ch1.channelId)
+ *         "Received: $value"
+ *     }
+ * }
+ * ```
+ *
+ * @param label Optional label for this select expression (reserved for future use)
+ * @param block The select builder block
+ * @return The result of the winning clause
+ */
+suspend fun <R> VizScope.vizSelect(
+    label: String? = null,
+    block: VizSelectBuilder<R>.() -> Unit,
+): R {
+    val coroutineElement = currentCoroutineContext()[VizCoroutineElement]
+    val coroutineId = coroutineElement?.coroutineId ?: "unknown-${System.nanoTime()}"
+
+    val vizSelect = VizSelect(session)
+    return vizSelect.vizSelect(coroutineId, block)
+}

--- a/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizSemaphore.kt
+++ b/backend/coroutine-viz-core/src/main/kotlin/com/jh/proj/coroutineviz/wrappers/VizSemaphore.kt
@@ -1,0 +1,310 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.SemaphoreAcquireRequested
+import com.jh.proj.coroutineviz.events.SemaphoreCreated
+import com.jh.proj.coroutineviz.events.SemaphorePermitAcquired
+import com.jh.proj.coroutineviz.events.SemaphorePermitReleased
+import com.jh.proj.coroutineviz.events.SemaphoreStateChanged
+import com.jh.proj.coroutineviz.events.SemaphoreTryAcquireFailed
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.sync.Semaphore
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * Instrumented Semaphore wrapper that emits visualization events.
+ *
+ * This wrapper provides full transparency into semaphore behavior:
+ * - Permit acquisition and release timing
+ * - Active holder tracking
+ * - Wait queue management
+ * - Utilization metrics
+ *
+ * Real-world use cases:
+ * - Connection pool limiting (max N connections)
+ * - Rate limiting (max N concurrent API calls)
+ * - Resource throttling
+ * - Batch processing control
+ *
+ * @param session The visualization session for emitting events
+ * @param permits Number of permits (concurrent access limit)
+ * @param label Human-readable label for the semaphore
+ */
+class VizSemaphore(
+    private val session: VizSession,
+    val permits: Int,
+    val label: String? = null,
+) {
+    val semaphoreId: String = "semaphore-${session.nextSeq()}"
+    private val delegate = Semaphore(permits)
+    private val totalPermits = permits
+
+    // Active holders tracking
+    private val activeHolders = ConcurrentHashMap<String, HolderInfo>()
+
+    // Wait queue tracking
+    private val waitQueue = ConcurrentLinkedQueue<WaiterInfo>()
+
+    data class HolderInfo(
+        val coroutineId: String,
+        val label: String?,
+        val acquireTime: Long,
+    )
+
+    data class WaiterInfo(
+        val coroutineId: String,
+        val label: String?,
+        val requestTime: Long,
+        val permitsRequested: Int,
+    )
+
+    init {
+        session.send(
+            SemaphoreCreated(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                semaphoreId = semaphoreId,
+                semaphoreLabel = label,
+                totalPermits = totalPermits,
+            ),
+        )
+    }
+
+    /**
+     * Get number of available permits
+     */
+    val availablePermits: Int get() = delegate.availablePermits
+
+    /**
+     * Get number of active permit holders
+     */
+    fun getActiveHolderCount(): Int = activeHolders.size
+
+    /**
+     * Get number of coroutines waiting for permits
+     */
+    fun getWaitQueueSize(): Int = waitQueue.size
+
+    /**
+     * Calculate current utilization (0.0 to 1.0)
+     */
+    fun getUtilization(): Double {
+        return (totalPermits - availablePermits).toDouble() / totalPermits
+    }
+
+    /**
+     * Acquire a permit (suspends if none available)
+     */
+    suspend fun acquire() {
+        val coroutineElement = currentCoroutineContext()[VizCoroutineElement]
+        val coroutineId = coroutineElement?.coroutineId ?: "unknown-${System.nanoTime()}"
+        val coroutineLabel = coroutineElement?.label
+
+        val available = delegate.availablePermits
+
+        // Emit acquire requested
+        session.send(
+            SemaphoreAcquireRequested(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                semaphoreId = semaphoreId,
+                semaphoreLabel = label,
+                requesterId = coroutineId,
+                requesterLabel = coroutineLabel,
+                availablePermits = available,
+                permitsRequested = 1,
+            ),
+        )
+
+        // Add to wait queue if no permits available
+        val waiterInfo = WaiterInfo(coroutineId, coroutineLabel, System.nanoTime(), 1)
+        if (available == 0) {
+            waitQueue.add(waiterInfo)
+            emitStateChanged()
+        }
+
+        // Actually acquire the permit (may suspend)
+        val startWait = System.nanoTime()
+        delegate.acquire()
+        val waitDuration = System.nanoTime() - startWait
+
+        // Update tracking
+        waitQueue.remove(waiterInfo)
+        activeHolders[coroutineId] = HolderInfo(coroutineId, coroutineLabel, System.nanoTime())
+
+        // Emit permit acquired
+        session.send(
+            SemaphorePermitAcquired(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                semaphoreId = semaphoreId,
+                semaphoreLabel = label,
+                acquirerId = coroutineId,
+                acquirerLabel = coroutineLabel,
+                remainingPermits = delegate.availablePermits,
+                waitDurationNanos = waitDuration,
+            ),
+        )
+
+        emitStateChanged()
+    }
+
+    /**
+     * Release a permit back to the pool
+     */
+    fun release() {
+        val coroutineElement =
+            try {
+                kotlinx.coroutines.runBlocking { currentCoroutineContext()[VizCoroutineElement] }
+            } catch (_: Exception) {
+                null
+            }
+
+        val coroutineId =
+            coroutineElement?.coroutineId
+                ?: activeHolders.keys.firstOrNull()
+                ?: "unknown"
+        val coroutineLabel = coroutineElement?.label
+
+        val holderInfo = activeHolders.remove(coroutineId)
+        val holdDuration =
+            if (holderInfo != null) {
+                System.nanoTime() - holderInfo.acquireTime
+            } else {
+                0L
+            }
+
+        delegate.release()
+
+        // Emit permit released
+        session.send(
+            SemaphorePermitReleased(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                semaphoreId = semaphoreId,
+                semaphoreLabel = label,
+                releaserId = coroutineId,
+                releaserLabel = coroutineLabel,
+                newAvailablePermits = delegate.availablePermits,
+                holdDurationNanos = holdDuration,
+            ),
+        )
+
+        emitStateChanged()
+    }
+
+    /**
+     * Try to acquire a permit without suspending
+     *
+     * @return true if permit was acquired, false if none available
+     */
+    fun tryAcquire(): Boolean {
+        val coroutineElement =
+            try {
+                kotlinx.coroutines.runBlocking { currentCoroutineContext()[VizCoroutineElement] }
+            } catch (_: Exception) {
+                null
+            }
+
+        val coroutineId = coroutineElement?.coroutineId ?: "unknown-${System.nanoTime()}"
+        val coroutineLabel = coroutineElement?.label
+
+        val acquired = delegate.tryAcquire()
+
+        if (acquired) {
+            activeHolders[coroutineId] = HolderInfo(coroutineId, coroutineLabel, System.nanoTime())
+
+            session.send(
+                SemaphorePermitAcquired(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    semaphoreId = semaphoreId,
+                    semaphoreLabel = label,
+                    acquirerId = coroutineId,
+                    acquirerLabel = coroutineLabel,
+                    remainingPermits = delegate.availablePermits,
+                    waitDurationNanos = 0,
+                ),
+            )
+
+            emitStateChanged()
+        } else {
+            session.send(
+                SemaphoreTryAcquireFailed(
+                    sessionId = session.sessionId,
+                    seq = session.nextSeq(),
+                    tsNanos = System.nanoTime(),
+                    semaphoreId = semaphoreId,
+                    semaphoreLabel = label,
+                    requesterId = coroutineId,
+                    requesterLabel = coroutineLabel,
+                    availablePermits = delegate.availablePermits,
+                    permitsRequested = 1,
+                ),
+            )
+        }
+
+        return acquired
+    }
+
+    /**
+     * Execute block while holding a permit
+     */
+    suspend fun <T> withPermit(action: suspend () -> T): T {
+        acquire()
+        try {
+            return action()
+        } finally {
+            release()
+        }
+    }
+
+    private fun emitStateChanged() {
+        val holders = activeHolders.values.toList()
+        val waiters = waitQueue.toList()
+
+        session.send(
+            SemaphoreStateChanged(
+                sessionId = session.sessionId,
+                seq = session.nextSeq(),
+                tsNanos = System.nanoTime(),
+                semaphoreId = semaphoreId,
+                semaphoreLabel = label,
+                availablePermits = delegate.availablePermits,
+                totalPermits = totalPermits,
+                activeHolders = holders.map { it.coroutineId },
+                activeHolderLabels = holders.map { it.label },
+                waitingCoroutines = waiters.map { it.coroutineId },
+                waitingLabels = waiters.map { it.label },
+            ),
+        )
+    }
+}
+
+// ============================================================================
+// Extension function for creating VizSemaphore in VizScope
+// ============================================================================
+
+/**
+ * Create a new instrumented Semaphore within this VizScope
+ *
+ * Example:
+ * ```kotlin
+ * val connectionPool = vizSemaphore("db-connections", permits = 3)
+ * connectionPool.withPermit {
+ *     // Use connection
+ * }
+ * ```
+ */
+fun VizScope.vizSemaphore(
+    label: String? = null,
+    permits: Int,
+): VizSemaphore {
+    return VizSemaphore(session, permits, label)
+}

--- a/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/HierarchyValidatorTest.kt
+++ b/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/HierarchyValidatorTest.kt
@@ -1,0 +1,145 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class HierarchyValidatorTest {
+    private fun created(
+        coroutineId: String,
+        seq: Long,
+        parentCoroutineId: String? = null,
+        scopeId: String = "scope-1",
+    ): CoroutineCreated =
+        CoroutineCreated(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1000,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = parentCoroutineId,
+            scopeId = scopeId,
+            label = null,
+        )
+
+    private fun started(
+        coroutineId: String,
+        seq: Long,
+    ): CoroutineStarted =
+        CoroutineStarted(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1000,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun completed(
+        coroutineId: String,
+        seq: Long,
+    ): CoroutineCompleted =
+        CoroutineCompleted(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1000,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    @Test
+    fun `valid hierarchy passes`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("parent", 1),
+                started("parent", 2),
+                created("child", 3, parentCoroutineId = "parent"),
+                started("child", 4),
+                completed("child", 5),
+                completed("parent", 6),
+            )
+
+        val results = HierarchyValidator.validate(events)
+        assertTrue(
+            results.all { it is ValidationResult.Pass },
+            "Valid hierarchy should pass all checks. Failures: ${results.filterIsInstance<ValidationResult.Fail>()}",
+        )
+    }
+
+    @Test
+    fun `child outliving parent fails`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("parent", 1),
+                started("parent", 2),
+                created("child", 3, parentCoroutineId = "parent"),
+                started("child", 4),
+                // Parent completes before child
+                completed("parent", 5),
+                completed("child", 6),
+            )
+
+        val results = HierarchyValidator.validate(events)
+        val parentBeforeChild =
+            results.filter {
+                it.ruleName == "ParentNotCompletedBeforeChildren" && it is ValidationResult.Fail
+            }
+        assertTrue(
+            parentBeforeChild.isNotEmpty(),
+            "Should detect parent completing before child",
+        )
+    }
+
+    @Test
+    fun `deeply nested hierarchy validates`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("root", 1),
+                started("root", 2),
+                created("mid", 3, parentCoroutineId = "root"),
+                started("mid", 4),
+                created("leaf", 5, parentCoroutineId = "mid"),
+                started("leaf", 6),
+                completed("leaf", 7),
+                completed("mid", 8),
+                completed("root", 9),
+            )
+
+        val results = HierarchyValidator.validate(events)
+        assertTrue(
+            results.all { it is ValidationResult.Pass },
+            "Deeply nested hierarchy should pass. Failures: ${results.filterIsInstance<ValidationResult.Fail>()}",
+        )
+    }
+
+    @Test
+    fun `child created before parent fails`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("child", 1, parentCoroutineId = "parent"),
+                created("parent", 2),
+                started("parent", 3),
+                started("child", 4),
+                completed("child", 5),
+                completed("parent", 6),
+            )
+
+        val results = HierarchyValidator.validate(events)
+        val scopeCheck =
+            results.filter {
+                it.ruleName == "ChildCreatedWithinParentScope" && it is ValidationResult.Fail
+            }
+        assertTrue(
+            scopeCheck.isNotEmpty(),
+            "Should detect child created before parent",
+        )
+    }
+}

--- a/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/LifecycleValidatorTest.kt
+++ b/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/LifecycleValidatorTest.kt
@@ -1,0 +1,202 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class LifecycleValidatorTest {
+    private fun created(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long = seq * 1000,
+        parentCoroutineId: String? = null,
+    ): CoroutineCreated =
+        CoroutineCreated(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = parentCoroutineId,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun started(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long = seq * 1000,
+    ): CoroutineStarted =
+        CoroutineStarted(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun completed(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long = seq * 1000,
+    ): CoroutineCompleted =
+        CoroutineCompleted(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun cancelled(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long = seq * 1000,
+    ): CoroutineCancelled =
+        CoroutineCancelled(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+            cause = "test cancellation",
+        )
+
+    private fun suspended(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long = seq * 1000,
+    ): CoroutineSuspended =
+        CoroutineSuspended(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+            reason = "delay",
+        )
+
+    @Test
+    fun `valid lifecycle passes all checks`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1),
+                started("c1", 2),
+                completed("c1", 3),
+            )
+
+        val results = LifecycleValidator.validate(events)
+        assertTrue(results.all { it is ValidationResult.Pass }, "All checks should pass for valid lifecycle")
+    }
+
+    @Test
+    fun `missing Started after Created fails`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1),
+            )
+
+        val results = LifecycleValidator.validate(events)
+        val createdHasStarted = results.first { it.ruleName == "CreatedHasStarted" }
+        assertTrue(createdHasStarted is ValidationResult.Fail, "Should fail when Started is missing")
+        assertTrue(
+            (createdHasStarted as ValidationResult.Fail).message.contains("never started"),
+            "Failure message should mention 'never started'",
+        )
+    }
+
+    @Test
+    fun `events after terminal state detected`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1),
+                started("c1", 2),
+                completed("c1", 3),
+                // This event is after the terminal state
+                suspended("c1", 4),
+            )
+
+        val results = LifecycleValidator.validate(events)
+        val noEventsAfterTerminal = results.first { it.ruleName == "NoEventsAfterTerminal" }
+        assertTrue(
+            noEventsAfterTerminal is ValidationResult.Fail,
+            "Should fail when events appear after terminal state",
+        )
+        assertTrue(
+            (noEventsAfterTerminal as ValidationResult.Fail).details.contains("seq=4"),
+            "Failure should reference the offending event sequence number",
+        )
+    }
+
+    @Test
+    fun `cancellation lifecycle passes`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1),
+                started("c1", 2),
+                cancelled("c1", 3),
+            )
+
+        val results = LifecycleValidator.validate(events)
+        assertTrue(results.all { it is ValidationResult.Pass }, "Cancellation lifecycle should pass")
+    }
+
+    @Test
+    fun `multiple coroutines validated independently`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1),
+                started("c1", 2),
+                completed("c1", 3),
+                created("c2", 4),
+                // c2 is never started -- should fail
+            )
+
+        val results = LifecycleValidator.validate(events)
+
+        // c1 should have all passes
+        val c1Results = results.filter { it.message.contains("c1") }
+        assertTrue(c1Results.all { it is ValidationResult.Pass }, "c1 should pass all checks")
+
+        // c2 should have a failure for CreatedHasStarted
+        val c2Failure =
+            results.first {
+                it.ruleName == "CreatedHasStarted" && it.message.contains("c2")
+            }
+        assertTrue(c2Failure is ValidationResult.Fail, "c2 should fail CreatedHasStarted")
+    }
+
+    @Test
+    fun `started coroutine without terminal event fails`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1),
+                started("c1", 2),
+                suspended("c1", 3),
+            )
+
+        val results = LifecycleValidator.validate(events)
+        val startedHasTerminal = results.first { it.ruleName == "StartedHasTerminal" }
+        assertTrue(
+            startedHasTerminal is ValidationResult.Fail,
+            "Should fail when started coroutine has no terminal event",
+        )
+    }
+}

--- a/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/SequenceCheckerTest.kt
+++ b/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/SequenceCheckerTest.kt
@@ -1,0 +1,113 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class SequenceCheckerTest {
+    private fun created(seq: Long): CoroutineCreated =
+        CoroutineCreated(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1000,
+            coroutineId = "c1",
+            jobId = "job-c1",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun started(seq: Long): CoroutineStarted =
+        CoroutineStarted(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1000,
+            coroutineId = "c1",
+            jobId = "job-c1",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun completed(seq: Long): CoroutineCompleted =
+        CoroutineCompleted(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1000,
+            coroutineId = "c1",
+            jobId = "job-c1",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    @Test
+    fun `correct order passes`() {
+        val events: List<VizEvent> =
+            listOf(
+                created(1),
+                started(2),
+                completed(3),
+            )
+
+        val result =
+            SequenceChecker.checkOrdering(
+                events,
+                listOf("CoroutineCreated", "CoroutineStarted", "CoroutineCompleted"),
+            )
+        assertTrue(result is ValidationResult.Pass, "Correct ordering should pass")
+    }
+
+    @Test
+    fun `wrong order fails`() {
+        val events: List<VizEvent> =
+            listOf(
+                started(1),
+                created(2),
+                completed(3),
+            )
+
+        val result =
+            SequenceChecker.checkOrdering(
+                events,
+                listOf("CoroutineCreated", "CoroutineStarted", "CoroutineCompleted"),
+            )
+        // started(seq=1) comes first, so Created is matched at seq=2, but then Started
+        // has already been passed, so it won't match "CoroutineStarted" again.
+        assertTrue(result is ValidationResult.Fail, "Wrong ordering should fail")
+    }
+
+    @Test
+    fun `duplicate sequence numbers detected`() {
+        val events: List<VizEvent> =
+            listOf(
+                created(1),
+                // Duplicate seq=1
+                started(1),
+                completed(2),
+            )
+
+        val result = SequenceChecker.checkNoDuplicateSequenceNumbers(events)
+        assertTrue(result is ValidationResult.Fail, "Duplicate sequence numbers should be detected")
+        assertTrue(
+            (result as ValidationResult.Fail).details.contains("seq=1"),
+            "Details should mention the duplicate sequence number",
+        )
+    }
+
+    @Test
+    fun `unique sequence numbers pass`() {
+        val events: List<VizEvent> =
+            listOf(
+                created(1),
+                started(2),
+                completed(3),
+            )
+
+        val result = SequenceChecker.checkNoDuplicateSequenceNumbers(events)
+        assertTrue(result is ValidationResult.Pass, "Unique sequence numbers should pass")
+    }
+}

--- a/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/SyncValidatorsTest.kt
+++ b/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/SyncValidatorsTest.kt
@@ -1,0 +1,544 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.DeadlockDetected
+import com.jh.proj.coroutineviz.events.MutexLockAcquired
+import com.jh.proj.coroutineviz.events.MutexLockRequested
+import com.jh.proj.coroutineviz.events.MutexUnlocked
+import com.jh.proj.coroutineviz.events.SemaphorePermitAcquired
+import com.jh.proj.coroutineviz.events.SemaphorePermitReleased
+import com.jh.proj.coroutineviz.events.SemaphoreStateChanged
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class SyncValidatorsTest {
+    // ========================================================================
+    // Helper factories
+    // ========================================================================
+
+    private var seqCounter = 0L
+
+    private fun nextSeq(): Long = ++seqCounter
+
+    private fun deadlockDetected(
+        involvedCoroutines: List<String> = listOf("c-1", "c-2"),
+        involvedMutexes: List<String> = listOf("m-1", "m-2"),
+        cycleDescription: String = "c-1 -> m-1 -> c-2 -> m-2 -> c-1",
+    ): DeadlockDetected {
+        val seq = nextSeq()
+        return DeadlockDetected(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            involvedCoroutines = involvedCoroutines,
+            involvedCoroutineLabels = involvedCoroutines.map { null },
+            involvedMutexes = involvedMutexes,
+            involvedMutexLabels = involvedMutexes.map { null },
+            waitGraph = involvedCoroutines.zip(involvedMutexes).toMap(),
+            holdGraph = involvedMutexes.zip(involvedCoroutines).toMap(),
+            cycleDescription = cycleDescription,
+        )
+    }
+
+    private fun mutexLockRequested(
+        mutexId: String,
+        requesterId: String,
+        isLocked: Boolean = false,
+        queuePosition: Int = 0,
+    ): MutexLockRequested {
+        val seq = nextSeq()
+        return MutexLockRequested(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            mutexId = mutexId,
+            mutexLabel = null,
+            requesterId = requesterId,
+            requesterLabel = null,
+            isLocked = isLocked,
+            queuePosition = queuePosition,
+        )
+    }
+
+    private fun mutexLockAcquired(
+        mutexId: String,
+        acquirerId: String,
+        waitDurationNanos: Long = 0,
+    ): MutexLockAcquired {
+        val seq = nextSeq()
+        return MutexLockAcquired(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            mutexId = mutexId,
+            mutexLabel = null,
+            acquirerId = acquirerId,
+            acquirerLabel = null,
+            waitDurationNanos = waitDurationNanos,
+        )
+    }
+
+    private fun mutexUnlocked(
+        mutexId: String,
+        releaserId: String,
+        nextWaiterId: String? = null,
+        holdDurationNanos: Long = 1_000_000,
+    ): MutexUnlocked {
+        val seq = nextSeq()
+        return MutexUnlocked(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            mutexId = mutexId,
+            mutexLabel = null,
+            releaserId = releaserId,
+            releaserLabel = null,
+            nextWaiterId = nextWaiterId,
+            holdDurationNanos = holdDurationNanos,
+        )
+    }
+
+    private fun semaphorePermitAcquired(
+        semaphoreId: String,
+        acquirerId: String,
+        remainingPermits: Int = 0,
+        waitDurationNanos: Long = 0,
+    ): SemaphorePermitAcquired {
+        val seq = nextSeq()
+        return SemaphorePermitAcquired(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            semaphoreId = semaphoreId,
+            semaphoreLabel = null,
+            acquirerId = acquirerId,
+            acquirerLabel = null,
+            remainingPermits = remainingPermits,
+            waitDurationNanos = waitDurationNanos,
+        )
+    }
+
+    private fun semaphorePermitReleased(
+        semaphoreId: String,
+        releaserId: String,
+        newAvailablePermits: Int = 1,
+        holdDurationNanos: Long = 1_000_000,
+    ): SemaphorePermitReleased {
+        val seq = nextSeq()
+        return SemaphorePermitReleased(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            semaphoreId = semaphoreId,
+            semaphoreLabel = null,
+            releaserId = releaserId,
+            releaserLabel = null,
+            newAvailablePermits = newAvailablePermits,
+            holdDurationNanos = holdDurationNanos,
+        )
+    }
+
+    private fun semaphoreStateChanged(
+        semaphoreId: String,
+        availablePermits: Int,
+        totalPermits: Int,
+        activeHolders: List<String> = emptyList(),
+        waitingCoroutines: List<String> = emptyList(),
+    ): SemaphoreStateChanged {
+        val seq = nextSeq()
+        return SemaphoreStateChanged(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            semaphoreId = semaphoreId,
+            semaphoreLabel = null,
+            availablePermits = availablePermits,
+            totalPermits = totalPermits,
+            activeHolders = activeHolders,
+            activeHolderLabels = activeHolders.map { null },
+            waitingCoroutines = waitingCoroutines,
+            waitingLabels = waitingCoroutines.map { null },
+        )
+    }
+
+    // ========================================================================
+    // MutexValidator tests
+    // ========================================================================
+
+    @Test
+    fun `verifyNoDeadlock passes with no deadlock events`() {
+        val recorder = EventRecorder()
+        // Record some normal mutex events but no deadlocks
+        recorder.record(mutexLockAcquired("m-1", "c-1"))
+        recorder.record(mutexUnlocked("m-1", "c-1"))
+
+        val validator = MutexValidator(recorder)
+        validator.verifyNoDeadlock() // Should not throw
+    }
+
+    @Test
+    fun `verifyNoDeadlock fails when deadlock detected`() {
+        val recorder = EventRecorder()
+        recorder.record(
+            deadlockDetected(
+                involvedCoroutines = listOf("c-1", "c-2"),
+                involvedMutexes = listOf("m-1", "m-2"),
+                cycleDescription = "c-1 -> m-1 -> c-2 -> m-2 -> c-1",
+            ),
+        )
+
+        val validator = MutexValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyNoDeadlock()
+            }
+        assertTrue(error.message!!.contains("Deadlock detected"))
+        assertTrue(error.message!!.contains("c-1"))
+        assertTrue(error.message!!.contains("c-2"))
+    }
+
+    @Test
+    fun `verifyMutualExclusion passes with proper lock-unlock sequence`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // A acquires, A unlocks, B acquires, B unlocks
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexUnlocked(mutexId, "c-A"))
+        recorder.record(mutexLockAcquired(mutexId, "c-B"))
+        recorder.record(mutexUnlocked(mutexId, "c-B"))
+
+        val validator = MutexValidator(recorder)
+        validator.verifyMutualExclusion(mutexId) // Should not throw
+    }
+
+    @Test
+    fun `verifyMutualExclusion fails with double acquire`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // A acquires, then B acquires without A unlocking
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexLockAcquired(mutexId, "c-B"))
+
+        val validator = MutexValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyMutualExclusion(mutexId)
+            }
+        assertTrue(error.message!!.contains("c-A"))
+        assertTrue(error.message!!.contains("c-B"))
+    }
+
+    @Test
+    fun `verifyMutualExclusion fails with wrong releaser`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // A acquires, B unlocks (wrong releaser)
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexUnlocked(mutexId, "c-B"))
+
+        val validator = MutexValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyMutualExclusion(mutexId)
+            }
+        assertTrue(error.message!!.contains("c-B"))
+        assertTrue(error.message!!.contains("c-A"))
+    }
+
+    @Test
+    fun `verifyFairness passes with FIFO ordering`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // A and B queue (both contended), then A acquires first, then B
+        recorder.record(mutexLockRequested(mutexId, "c-A", isLocked = true, queuePosition = 1))
+        recorder.record(mutexLockRequested(mutexId, "c-B", isLocked = true, queuePosition = 2))
+        recorder.record(mutexLockAcquired(mutexId, "c-A", waitDurationNanos = 5_000))
+        recorder.record(mutexLockAcquired(mutexId, "c-B", waitDurationNanos = 10_000))
+
+        val validator = MutexValidator(recorder)
+        validator.verifyFairness(mutexId) // Should not throw
+    }
+
+    @Test
+    fun `verifyNoLockLeaks passes with balanced operations`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexUnlocked(mutexId, "c-A"))
+        recorder.record(mutexLockAcquired(mutexId, "c-B"))
+        recorder.record(mutexUnlocked(mutexId, "c-B"))
+
+        val validator = MutexValidator(recorder)
+        validator.verifyNoLockLeaks(mutexId) // Should not throw
+    }
+
+    @Test
+    fun `verifyNoLockLeaks fails with unbalanced operations`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // Two acquires but only one unlock
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexUnlocked(mutexId, "c-A"))
+        recorder.record(mutexLockAcquired(mutexId, "c-B"))
+        // c-B never unlocks
+
+        val validator = MutexValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyNoLockLeaks(mutexId)
+            }
+        assertTrue(error.message!!.contains("lock leak"))
+        assertTrue(error.message!!.contains("2 acquires"))
+        assertTrue(error.message!!.contains("1 releases"))
+    }
+
+    @Test
+    fun `getContentionStats returns correct statistics`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+
+        // Request 1: uncontended (isLocked = false)
+        recorder.record(mutexLockRequested(mutexId, "c-A", isLocked = false, queuePosition = 0))
+        recorder.record(mutexLockAcquired(mutexId, "c-A", waitDurationNanos = 0))
+        recorder.record(mutexUnlocked(mutexId, "c-A", holdDurationNanos = 5_000_000))
+
+        // Request 2: contended (isLocked = true)
+        recorder.record(mutexLockRequested(mutexId, "c-B", isLocked = true, queuePosition = 1))
+        recorder.record(mutexLockAcquired(mutexId, "c-B", waitDurationNanos = 2_000_000))
+        recorder.record(mutexUnlocked(mutexId, "c-B", holdDurationNanos = 3_000_000))
+
+        // Request 3: contended (isLocked = true)
+        recorder.record(mutexLockRequested(mutexId, "c-C", isLocked = true, queuePosition = 1))
+        recorder.record(mutexLockAcquired(mutexId, "c-C", waitDurationNanos = 4_000_000))
+        recorder.record(mutexUnlocked(mutexId, "c-C", holdDurationNanos = 1_000_000))
+
+        val validator = MutexValidator(recorder)
+        val stats = validator.getContentionStats(mutexId)
+
+        assertEquals(3, stats.totalRequests)
+        assertEquals(2, stats.contentionRequests)
+        assertEquals(2.0 / 3.0, stats.contentionRate, 0.001)
+        assertEquals(2_000_000.0, stats.avgWaitTimeNanos, 0.001)
+        assertEquals(4_000_000L, stats.maxWaitTimeNanos)
+        assertEquals(3_000_000.0, stats.avgHoldTimeNanos, 0.001)
+        assertEquals(5_000_000L, stats.maxHoldTimeNanos)
+    }
+
+    // ========================================================================
+    // SemaphoreValidator tests
+    // ========================================================================
+
+    @Test
+    fun `verifyPermitBounds passes with valid state`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val maxPermits = 3
+
+        // State with 2 active holders out of 3 permits -- valid
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 1,
+                totalPermits = maxPermits,
+                activeHolders = listOf("c-A", "c-B"),
+            ),
+        )
+        // State with 3 active holders out of 3 permits -- still valid
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 0,
+                totalPermits = maxPermits,
+                activeHolders = listOf("c-A", "c-B", "c-C"),
+            ),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        validator.verifyPermitBounds(semId, maxPermits) // Should not throw
+    }
+
+    @Test
+    fun `verifyPermitBounds fails with too many holders`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val maxPermits = 2
+
+        // 3 active holders but only 2 permits
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 0,
+                totalPermits = maxPermits,
+                activeHolders = listOf("c-A", "c-B", "c-C"),
+            ),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyPermitBounds(semId, maxPermits)
+            }
+        assertTrue(error.message!!.contains("permit limit exceeded"))
+        assertTrue(error.message!!.contains("3 holders"))
+        assertTrue(error.message!!.contains("2 permits"))
+    }
+
+    @Test
+    fun `verifyPermitBounds fails with negative permits`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = -1,
+                totalPermits = 3,
+                activeHolders = listOf("c-A", "c-B", "c-C"),
+            ),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyPermitBounds(semId, 3)
+            }
+        assertTrue(error.message!!.contains("negative permits"))
+    }
+
+    @Test
+    fun `verifyNoPermitLeaks passes when all permits returned`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val totalPermits = 3
+
+        // Some intermediate states then final state with all permits available
+        recorder.record(
+            semaphoreStateChanged(semId, availablePermits = 2, totalPermits = totalPermits, activeHolders = listOf("c-A")),
+        )
+        recorder.record(
+            semaphoreStateChanged(semId, availablePermits = 1, totalPermits = totalPermits, activeHolders = listOf("c-A", "c-B")),
+        )
+        recorder.record(
+            semaphoreStateChanged(semId, availablePermits = totalPermits, totalPermits = totalPermits, activeHolders = emptyList()),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        validator.verifyNoPermitLeaks(semId, totalPermits) // Should not throw
+    }
+
+    @Test
+    fun `verifyNoPermitLeaks fails when permits not returned`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val totalPermits = 3
+
+        // Final state still has a holder
+        recorder.record(
+            semaphoreStateChanged(semId, availablePermits = 2, totalPermits = totalPermits, activeHolders = listOf("c-A")),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyNoPermitLeaks(semId, totalPermits)
+            }
+        assertTrue(error.message!!.contains("permit leak"))
+        assertTrue(error.message!!.contains("2/$totalPermits"))
+    }
+
+    @Test
+    fun `verifyBalancedOperations passes with equal acquires and releases`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+
+        recorder.record(semaphorePermitAcquired(semId, "c-A"))
+        recorder.record(semaphorePermitAcquired(semId, "c-B"))
+        recorder.record(semaphorePermitReleased(semId, "c-A"))
+        recorder.record(semaphorePermitReleased(semId, "c-B"))
+
+        val validator = SemaphoreValidator(recorder)
+        validator.verifyBalancedOperations(semId) // Should not throw
+    }
+
+    @Test
+    fun `verifyBalancedOperations fails with unbalanced counts`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+
+        recorder.record(semaphorePermitAcquired(semId, "c-A"))
+        recorder.record(semaphorePermitAcquired(semId, "c-B"))
+        recorder.record(semaphorePermitReleased(semId, "c-A"))
+        // c-B never releases
+
+        val validator = SemaphoreValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyBalancedOperations(semId)
+            }
+        assertTrue(error.message!!.contains("unbalanced"))
+        assertTrue(error.message!!.contains("2 acquires"))
+        assertTrue(error.message!!.contains("1 releases"))
+    }
+
+    @Test
+    fun `getUtilizationStats returns correct statistics`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val totalPermits = 3
+
+        // State changes showing varying utilization
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 2,
+                totalPermits = totalPermits,
+                activeHolders = listOf("c-A"),
+                waitingCoroutines = emptyList(),
+            ),
+        )
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 0,
+                totalPermits = totalPermits,
+                activeHolders = listOf("c-A", "c-B", "c-C"),
+                waitingCoroutines = listOf("c-D"),
+            ),
+        )
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = totalPermits,
+                totalPermits = totalPermits,
+                activeHolders = emptyList(),
+                waitingCoroutines = emptyList(),
+            ),
+        )
+
+        // Acquire/release events
+        recorder.record(semaphorePermitAcquired(semId, "c-A", waitDurationNanos = 1_000_000))
+        recorder.record(semaphorePermitAcquired(semId, "c-B", waitDurationNanos = 3_000_000))
+        recorder.record(semaphorePermitReleased(semId, "c-A", holdDurationNanos = 5_000_000))
+        recorder.record(semaphorePermitReleased(semId, "c-B", holdDurationNanos = 7_000_000))
+
+        val validator = SemaphoreValidator(recorder)
+        val stats = validator.getUtilizationStats(semId)
+
+        assertEquals(2, stats.totalAcquires)
+        assertEquals(2, stats.totalReleases)
+
+        // Utilization samples: 1/3, 3/3, 0/3 => avg = (1/3 + 1.0 + 0.0) / 3
+        val expectedAvgUtil = (1.0 / 3.0 + 1.0 + 0.0) / 3.0
+        assertEquals(expectedAvgUtil, stats.avgUtilization, 0.001)
+        assertEquals(1.0, stats.maxUtilization, 0.001)
+
+        assertEquals(3, stats.maxConcurrentHolders)
+        assertEquals(1, stats.maxWaitingQueue)
+
+        assertEquals(2_000_000.0, stats.avgWaitTimeNanos, 0.001)
+        assertEquals(3_000_000L, stats.maxWaitTimeNanos)
+        assertEquals(6_000_000.0, stats.avgHoldTimeNanos, 0.001)
+        assertEquals(7_000_000L, stats.maxHoldTimeNanos)
+    }
+}

--- a/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/TimingAnalyzerTest.kt
+++ b/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/TimingAnalyzerTest.kt
@@ -1,0 +1,162 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.VizEvent
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineResumed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TimingAnalyzerTest {
+    private fun created(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long,
+    ): CoroutineCreated =
+        CoroutineCreated(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun started(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long,
+    ): CoroutineStarted =
+        CoroutineStarted(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun suspended(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long,
+    ): CoroutineSuspended =
+        CoroutineSuspended(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+            reason = "delay",
+        )
+
+    private fun resumed(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long,
+    ): CoroutineResumed =
+        CoroutineResumed(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    private fun completed(
+        coroutineId: String,
+        seq: Long,
+        tsNanos: Long,
+    ): CoroutineCompleted =
+        CoroutineCompleted(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = tsNanos,
+            coroutineId = coroutineId,
+            jobId = "job-$coroutineId",
+            parentCoroutineId = null,
+            scopeId = "scope-1",
+            label = null,
+        )
+
+    @Test
+    fun `duration calculation correct`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1, tsNanos = 1000),
+                started("c1", 2, tsNanos = 2000),
+                completed("c1", 3, tsNanos = 5000),
+            )
+
+        val report = TimingAnalyzer.analyze(events)
+
+        assertEquals(4000L, report.coroutineDurations["c1"], "Duration should be last - first tsNanos")
+        assertEquals(4000L, report.totalDuration, "Total duration should cover entire stream")
+    }
+
+    @Test
+    fun `suspension durations tracked`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1, tsNanos = 1000),
+                started("c1", 2, tsNanos = 2000),
+                suspended("c1", 3, tsNanos = 3000),
+                // 2000ns suspension
+                resumed("c1", 4, tsNanos = 5000),
+                suspended("c1", 5, tsNanos = 6000),
+                // 3000ns suspension
+                resumed("c1", 6, tsNanos = 9000),
+                completed("c1", 7, tsNanos = 10000),
+            )
+
+        val report = TimingAnalyzer.analyze(events)
+
+        val suspensions = report.suspensionDurations["c1"]!!
+        assertEquals(2, suspensions.size, "Should have 2 suspension periods")
+        assertEquals(2000L, suspensions[0], "First suspension should be 2000ns")
+        assertEquals(3000L, suspensions[1], "Second suspension should be 3000ns")
+    }
+
+    @Test
+    fun `report includes all coroutines`() {
+        val events: List<VizEvent> =
+            listOf(
+                created("c1", 1, tsNanos = 1000),
+                started("c1", 2, tsNanos = 2000),
+                created("c2", 3, tsNanos = 3000),
+                started("c2", 4, tsNanos = 4000),
+                completed("c1", 5, tsNanos = 5000),
+                completed("c2", 6, tsNanos = 8000),
+            )
+
+        val report = TimingAnalyzer.analyze(events)
+
+        assertTrue(report.coroutineDurations.containsKey("c1"), "Report should include c1")
+        assertTrue(report.coroutineDurations.containsKey("c2"), "Report should include c2")
+        assertEquals(4000L, report.coroutineDurations["c1"], "c1 duration: 5000 - 1000")
+        assertEquals(5000L, report.coroutineDurations["c2"], "c2 duration: 8000 - 3000")
+        assertEquals(7000L, report.totalDuration, "Total duration: 8000 - 1000")
+    }
+
+    @Test
+    fun `empty events produce empty report`() {
+        val report = TimingAnalyzer.analyze(emptyList())
+
+        assertTrue(report.coroutineDurations.isEmpty(), "No coroutines in empty report")
+        assertTrue(report.suspensionDurations.isEmpty(), "No suspensions in empty report")
+        assertEquals(0L, report.totalDuration, "Total duration should be 0 for empty events")
+    }
+}

--- a/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/events/EventSerializationTest.kt
+++ b/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/events/EventSerializationTest.kt
@@ -1,0 +1,2011 @@
+package com.jh.proj.coroutineviz.events
+
+import com.jh.proj.coroutineviz.events.channel.ChannelBufferStateChanged
+import com.jh.proj.coroutineviz.events.channel.ChannelClosed
+import com.jh.proj.coroutineviz.events.channel.ChannelCreated
+import com.jh.proj.coroutineviz.events.channel.ChannelReceiveCompleted
+import com.jh.proj.coroutineviz.events.channel.ChannelReceiveStarted
+import com.jh.proj.coroutineviz.events.channel.ChannelReceiveSuspended
+import com.jh.proj.coroutineviz.events.channel.ChannelSendCompleted
+import com.jh.proj.coroutineviz.events.channel.ChannelSendStarted
+import com.jh.proj.coroutineviz.events.channel.ChannelSendSuspended
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineBodyCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCancelled
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCompleted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineFailed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineResumed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineStarted
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import com.jh.proj.coroutineviz.events.deferred.DeferredAwaitCompleted
+import com.jh.proj.coroutineviz.events.deferred.DeferredAwaitStarted
+import com.jh.proj.coroutineviz.events.deferred.DeferredValueAvailable
+import com.jh.proj.coroutineviz.events.dispatcher.DispatcherSelected
+import com.jh.proj.coroutineviz.events.dispatcher.ThreadAssigned
+import com.jh.proj.coroutineviz.events.flow.FlowBackpressure
+import com.jh.proj.coroutineviz.events.flow.FlowBufferOverflow
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionCancelled
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionCompleted
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionStarted
+import com.jh.proj.coroutineviz.events.flow.FlowCreated
+import com.jh.proj.coroutineviz.events.flow.FlowOperatorApplied
+import com.jh.proj.coroutineviz.events.flow.FlowValueEmitted
+import com.jh.proj.coroutineviz.events.flow.FlowValueFiltered
+import com.jh.proj.coroutineviz.events.flow.FlowValueTransformed
+import com.jh.proj.coroutineviz.events.flow.SharedFlowEmission
+import com.jh.proj.coroutineviz.events.flow.SharedFlowSubscription
+import com.jh.proj.coroutineviz.events.flow.StateFlowValueChanged
+import com.jh.proj.coroutineviz.events.job.JobCancellationRequested
+import com.jh.proj.coroutineviz.events.job.JobJoinCompleted
+import com.jh.proj.coroutineviz.events.job.JobJoinRequested
+import com.jh.proj.coroutineviz.events.job.JobStateChanged
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class EventSerializationTest {
+    private val json =
+        Json {
+            prettyPrint = false
+            encodeDefaults = true
+        }
+
+    // ========================================================================
+    // Coroutine Events (existing)
+    // ========================================================================
+
+    @Test
+    fun `CoroutineCreated serialization round-trip`() {
+        val event =
+            CoroutineCreated(
+                sessionId = "test-session",
+                seq = 1L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "test-coroutine",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineCreated>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"sessionId\":\"test-session\""))
+        assertTrue(serialized.contains("\"coroutineId\":\"coroutine-1\""))
+        assertTrue(serialized.contains("\"label\":\"test-coroutine\""))
+    }
+
+    @Test
+    fun `CoroutineStarted serialization round-trip`() {
+        val event =
+            CoroutineStarted(
+                sessionId = "test-session",
+                seq = 2L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "test-coroutine",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineStarted>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `CoroutineCompleted serialization round-trip`() {
+        val event =
+            CoroutineCompleted(
+                sessionId = "test-session",
+                seq = 3L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = "coroutine-0",
+                scopeId = "scope-1",
+                label = "child-coroutine",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"parentCoroutineId\":\"coroutine-0\""))
+    }
+
+    @Test
+    fun `CoroutineFailed serialization round-trip`() {
+        val event =
+            CoroutineFailed(
+                sessionId = "test-session",
+                seq = 4L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "failing-coroutine",
+                exceptionType = "java.lang.RuntimeException",
+                message = "Test failure",
+                stackTrace = listOf("at com.example.Test.run(Test.kt:42)"),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineFailed>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"exceptionType\":\"java.lang.RuntimeException\""))
+        assertTrue(serialized.contains("\"message\":\"Test failure\""))
+        assertTrue(serialized.contains("\"stackTrace\""))
+    }
+
+    @Test
+    fun `CoroutineCancelled serialization round-trip`() {
+        val event =
+            CoroutineCancelled(
+                sessionId = "test-session",
+                seq = 5L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-2",
+                jobId = "job-2",
+                parentCoroutineId = "coroutine-1",
+                scopeId = "scope-1",
+                label = "cancelled-coroutine",
+                cause = "Parent was cancelled",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineCancelled>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"cause\":\"Parent was cancelled\""))
+    }
+
+    @Test
+    fun `CoroutineSuspended serialization round-trip`() {
+        val event =
+            CoroutineSuspended(
+                sessionId = "test-session",
+                seq = 6L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "suspended-coroutine",
+                reason = "delay",
+                durationMillis = 1000L,
+                suspensionPoint =
+                    SuspensionPoint(
+                        function = "doWork",
+                        fileName = "Worker.kt",
+                        lineNumber = 42,
+                        reason = "delay",
+                    ),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineSuspended>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"reason\":\"delay\""))
+        assertTrue(serialized.contains("\"durationMillis\":1000"))
+        assertTrue(serialized.contains("\"function\":\"doWork\""))
+    }
+
+    @Test
+    fun `CoroutineSuspended with null optional fields`() {
+        val event =
+            CoroutineSuspended(
+                sessionId = "test-session",
+                seq = 7L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = null,
+                reason = "await",
+                durationMillis = null,
+                suspensionPoint = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineSuspended>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `CoroutineResumed serialization round-trip`() {
+        val event =
+            CoroutineResumed(
+                sessionId = "test-session",
+                seq = 8L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "resumed-coroutine",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineResumed>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `CoroutineBodyCompleted serialization round-trip`() {
+        val event =
+            CoroutineBodyCompleted(
+                sessionId = "test-session",
+                seq = 9L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = "coroutine-0",
+                scopeId = "scope-1",
+                label = "body-completed-coroutine",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineBodyCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    // ========================================================================
+    // SuspensionPoint (existing)
+    // ========================================================================
+
+    @Test
+    fun `SuspensionPoint serialization round-trip`() {
+        val point =
+            SuspensionPoint(
+                function = "fetchData",
+                fileName = "DataService.kt",
+                lineNumber = 99,
+                reason = "withContext",
+            )
+
+        val serialized = json.encodeToString(point)
+        val deserialized = json.decodeFromString<SuspensionPoint>(serialized)
+
+        assertEquals(point, deserialized)
+        assertTrue(serialized.contains("\"function\":\"fetchData\""))
+        assertTrue(serialized.contains("\"fileName\":\"DataService.kt\""))
+        assertTrue(serialized.contains("\"lineNumber\":99"))
+        assertTrue(serialized.contains("\"reason\":\"withContext\""))
+    }
+
+    @Test
+    fun `SuspensionPoint with null optional fields`() {
+        val point =
+            SuspensionPoint(
+                function = "unknown",
+                fileName = null,
+                lineNumber = null,
+                reason = "delay",
+            )
+
+        val serialized = json.encodeToString(point)
+        val deserialized = json.decodeFromString<SuspensionPoint>(serialized)
+
+        assertEquals(point, deserialized)
+    }
+
+    @Test
+    fun `CoroutineCreated with null parentCoroutineId and label`() {
+        val event =
+            CoroutineCreated(
+                sessionId = "test-session",
+                seq = 10L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-root",
+                jobId = "job-root",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineCreated>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `serialized events contain kind field via SerialName`() {
+        val created =
+            CoroutineCreated(
+                sessionId = "s",
+                seq = 1,
+                tsNanos = 0,
+                coroutineId = "c",
+                jobId = "j",
+                parentCoroutineId = null,
+                scopeId = "sc",
+                label = null,
+            )
+        val serialized = json.encodeToString(created)
+        // The @SerialName annotation uses "type" discriminator by default,
+        // but since we're encoding the concrete type directly, the kind
+        // is a computed property and appears in the JSON output
+        assertNotNull(serialized, "Serialized output should not be null")
+        assertTrue(serialized.isNotEmpty(), "Serialized output should not be empty")
+    }
+
+    @Test
+    fun `CoroutineFailed with empty stack trace`() {
+        val event =
+            CoroutineFailed(
+                sessionId = "test-session",
+                seq = 11L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "failing",
+                exceptionType = null,
+                message = null,
+                stackTrace = emptyList(),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<CoroutineFailed>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"stackTrace\":[]"))
+    }
+
+    // ========================================================================
+    // Job Events
+    // ========================================================================
+
+    @Test
+    fun `JobStateChanged serialization round-trip`() {
+        val event =
+            JobStateChanged(
+                sessionId = "test-session",
+                seq = 20L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = "coroutine-0",
+                scopeId = "scope-1",
+                label = "worker-job",
+                isActive = true,
+                isCompleted = false,
+                isCancelled = false,
+                childrenCount = 3,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<JobStateChanged>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"isActive\":true"))
+        assertTrue(serialized.contains("\"childrenCount\":3"))
+    }
+
+    @Test
+    fun `JobJoinRequested serialization round-trip`() {
+        val event =
+            JobJoinRequested(
+                sessionId = "test-session",
+                seq = 21L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "joining-coroutine",
+                waitingCoroutineId = "coroutine-2",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<JobJoinRequested>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"waitingCoroutineId\":\"coroutine-2\""))
+    }
+
+    @Test
+    fun `JobJoinRequested with null waitingCoroutineId`() {
+        val event =
+            JobJoinRequested(
+                sessionId = "test-session",
+                seq = 22L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = null,
+                waitingCoroutineId = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<JobJoinRequested>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `JobJoinCompleted serialization round-trip`() {
+        val event =
+            JobJoinCompleted(
+                sessionId = "test-session",
+                seq = 23L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = "coroutine-0",
+                scopeId = "scope-1",
+                label = "join-completed",
+                waitingCoroutineId = "coroutine-3",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<JobJoinCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"waitingCoroutineId\":\"coroutine-3\""))
+    }
+
+    @Test
+    fun `JobCancellationRequested serialization round-trip`() {
+        val event =
+            JobCancellationRequested(
+                sessionId = "test-session",
+                seq = 24L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "cancelling-job",
+                requestedBy = "coroutine-parent",
+                cause = "Timeout exceeded",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<JobCancellationRequested>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"requestedBy\":\"coroutine-parent\""))
+        assertTrue(serialized.contains("\"cause\":\"Timeout exceeded\""))
+    }
+
+    @Test
+    fun `JobCancellationRequested with null optional fields`() {
+        val event =
+            JobCancellationRequested(
+                sessionId = "test-session",
+                seq = 25L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = null,
+                requestedBy = null,
+                cause = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<JobCancellationRequested>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    // ========================================================================
+    // Flow Events
+    // ========================================================================
+
+    @Test
+    fun `FlowCreated serialization round-trip`() {
+        val event =
+            FlowCreated(
+                sessionId = "test-session",
+                seq = 100L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-1",
+                flowType = "Cold",
+                label = "numbers-flow",
+                scopeId = "scope-1",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowCreated>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"flowType\":\"Cold\""))
+        assertTrue(serialized.contains("\"flowId\":\"flow-1\""))
+    }
+
+    @Test
+    fun `FlowCreated with null optional fields`() {
+        val event =
+            FlowCreated(
+                sessionId = "test-session",
+                seq = 101L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-2",
+                flowType = "SharedFlow",
+                label = null,
+                scopeId = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowCreated>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `FlowCollectionStarted serialization round-trip`() {
+        val event =
+            FlowCollectionStarted(
+                sessionId = "test-session",
+                seq = 102L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-1",
+                collectorId = "collector-1",
+                label = "main-collector",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowCollectionStarted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"collectorId\":\"collector-1\""))
+    }
+
+    @Test
+    fun `FlowCollectionCompleted serialization round-trip`() {
+        val event =
+            FlowCollectionCompleted(
+                sessionId = "test-session",
+                seq = 103L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-1",
+                collectorId = "collector-1",
+                totalEmissions = 42,
+                durationNanos = 1_500_000_000L,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowCollectionCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"totalEmissions\":42"))
+        assertTrue(serialized.contains("\"durationNanos\":1500000000"))
+    }
+
+    @Test
+    fun `FlowCollectionCancelled serialization round-trip`() {
+        val event =
+            FlowCollectionCancelled(
+                sessionId = "test-session",
+                seq = 104L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-1",
+                collectorId = "collector-1",
+                reason = "take(5) limit reached",
+                emittedCount = 5,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowCollectionCancelled>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"emittedCount\":5"))
+    }
+
+    @Test
+    fun `FlowCollectionCancelled with null reason`() {
+        val event =
+            FlowCollectionCancelled(
+                sessionId = "test-session",
+                seq = 105L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-1",
+                collectorId = "collector-1",
+                reason = null,
+                emittedCount = 0,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowCollectionCancelled>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `FlowValueEmitted serialization round-trip`() {
+        val event =
+            FlowValueEmitted(
+                sessionId = "test-session",
+                seq = 106L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-1",
+                collectorId = "collector-1",
+                sequenceNumber = 7,
+                valuePreview = "User(id=42, name=Alice)",
+                valueType = "com.example.User",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowValueEmitted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"sequenceNumber\":7"))
+        assertTrue(serialized.contains("\"valueType\":\"com.example.User\""))
+    }
+
+    @Test
+    fun `FlowValueFiltered serialization round-trip`() {
+        val event =
+            FlowValueFiltered(
+                sessionId = "test-session",
+                seq = 107L,
+                tsNanos = System.nanoTime(),
+                flowId = "flow-1",
+                operatorName = "filter",
+                valuePreview = "42",
+                valueType = "kotlin.Int",
+                passed = true,
+                sequenceNumber = 3,
+                coroutineId = "coroutine-1",
+                collectorId = "collector-1",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowValueFiltered>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"passed\":true"))
+        assertTrue(serialized.contains("\"operatorName\":\"filter\""))
+    }
+
+    @Test
+    fun `FlowValueFiltered with null optional fields`() {
+        val event =
+            FlowValueFiltered(
+                sessionId = "test-session",
+                seq = 108L,
+                tsNanos = System.nanoTime(),
+                flowId = "flow-2",
+                operatorName = "distinctUntilChanged",
+                valuePreview = "hello",
+                valueType = "kotlin.String",
+                passed = false,
+                sequenceNumber = 0,
+                coroutineId = null,
+                collectorId = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowValueFiltered>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `FlowValueTransformed serialization round-trip`() {
+        val event =
+            FlowValueTransformed(
+                sessionId = "test-session",
+                seq = 109L,
+                tsNanos = System.nanoTime(),
+                flowId = "flow-1",
+                operatorName = "map",
+                inputValuePreview = "42",
+                outputValuePreview = "84",
+                inputType = "kotlin.Int",
+                outputType = "kotlin.Int",
+                sequenceNumber = 5,
+                coroutineId = "coroutine-1",
+                collectorId = "collector-1",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowValueTransformed>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"inputValuePreview\":\"42\""))
+        assertTrue(serialized.contains("\"outputValuePreview\":\"84\""))
+    }
+
+    @Test
+    fun `FlowValueTransformed with null optional fields`() {
+        val event =
+            FlowValueTransformed(
+                sessionId = "test-session",
+                seq = 110L,
+                tsNanos = System.nanoTime(),
+                flowId = "flow-1",
+                operatorName = "transform",
+                inputValuePreview = "abc",
+                outputValuePreview = "ABC",
+                inputType = "kotlin.String",
+                outputType = "kotlin.String",
+                sequenceNumber = 0,
+                coroutineId = null,
+                collectorId = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowValueTransformed>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `FlowOperatorApplied serialization round-trip`() {
+        val event =
+            FlowOperatorApplied(
+                sessionId = "test-session",
+                seq = 111L,
+                tsNanos = System.nanoTime(),
+                flowId = "flow-derived-1",
+                sourceFlowId = "flow-1",
+                operatorName = "map",
+                operatorIndex = 0,
+                label = "double-values",
+                coroutineId = "coroutine-1",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowOperatorApplied>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"sourceFlowId\":\"flow-1\""))
+        assertTrue(serialized.contains("\"operatorIndex\":0"))
+    }
+
+    @Test
+    fun `FlowOperatorApplied with null optional fields`() {
+        val event =
+            FlowOperatorApplied(
+                sessionId = "test-session",
+                seq = 112L,
+                tsNanos = System.nanoTime(),
+                flowId = "flow-derived-2",
+                sourceFlowId = "flow-derived-1",
+                operatorName = "filter",
+                operatorIndex = 1,
+                label = null,
+                coroutineId = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowOperatorApplied>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `FlowBackpressure serialization round-trip`() {
+        val event =
+            FlowBackpressure(
+                sessionId = "test-session",
+                seq = 113L,
+                tsNanos = System.nanoTime(),
+                flowId = "flow-1",
+                collectorId = "collector-1",
+                reason = "slow_collector",
+                pendingEmissions = 15,
+                bufferCapacity = 64,
+                durationNanos = 250_000_000L,
+                coroutineId = "coroutine-1",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowBackpressure>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"reason\":\"slow_collector\""))
+        assertTrue(serialized.contains("\"pendingEmissions\":15"))
+    }
+
+    @Test
+    fun `FlowBackpressure with null optional fields`() {
+        val event =
+            FlowBackpressure(
+                sessionId = "test-session",
+                seq = 114L,
+                tsNanos = System.nanoTime(),
+                flowId = "flow-1",
+                collectorId = "collector-2",
+                reason = "buffer_full",
+                pendingEmissions = 0,
+                bufferCapacity = null,
+                durationNanos = null,
+                coroutineId = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowBackpressure>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `FlowBufferOverflow serialization round-trip`() {
+        val event =
+            FlowBufferOverflow(
+                sessionId = "test-session",
+                seq = 115L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-1",
+                droppedValue = "Event(id=99)",
+                bufferSize = 64,
+                overflowStrategy = "DROP_OLDEST",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowBufferOverflow>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"overflowStrategy\":\"DROP_OLDEST\""))
+        assertTrue(serialized.contains("\"bufferSize\":64"))
+    }
+
+    @Test
+    fun `FlowBufferOverflow with null droppedValue`() {
+        val event =
+            FlowBufferOverflow(
+                sessionId = "test-session",
+                seq = 116L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                flowId = "flow-1",
+                droppedValue = null,
+                bufferSize = 128,
+                overflowStrategy = "SUSPEND",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<FlowBufferOverflow>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `SharedFlowEmission serialization round-trip`() {
+        val event =
+            SharedFlowEmission(
+                sessionId = "test-session",
+                seq = 117L,
+                tsNanos = System.nanoTime(),
+                flowId = "shared-flow-1",
+                valuePreview = "ChatMessage(from=Alice, text=Hello)",
+                valueType = "com.example.ChatMessage",
+                subscriberCount = 3,
+                replayCache = 1,
+                extraBufferCapacity = 10,
+                coroutineId = "coroutine-1",
+                label = "chat-messages",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SharedFlowEmission>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"subscriberCount\":3"))
+        assertTrue(serialized.contains("\"replayCache\":1"))
+        assertTrue(serialized.contains("\"extraBufferCapacity\":10"))
+    }
+
+    @Test
+    fun `SharedFlowEmission with null optional fields`() {
+        val event =
+            SharedFlowEmission(
+                sessionId = "test-session",
+                seq = 118L,
+                tsNanos = System.nanoTime(),
+                flowId = "shared-flow-2",
+                valuePreview = "42",
+                valueType = "kotlin.Int",
+                subscriberCount = 0,
+                replayCache = 0,
+                extraBufferCapacity = 0,
+                coroutineId = null,
+                label = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SharedFlowEmission>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `SharedFlowSubscription serialization round-trip`() {
+        val event =
+            SharedFlowSubscription(
+                sessionId = "test-session",
+                seq = 119L,
+                tsNanos = System.nanoTime(),
+                flowId = "shared-flow-1",
+                collectorId = "collector-5",
+                action = "subscribed",
+                subscriberCount = 4,
+                coroutineId = "coroutine-3",
+                label = "ui-subscriber",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SharedFlowSubscription>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"action\":\"subscribed\""))
+        assertTrue(serialized.contains("\"subscriberCount\":4"))
+    }
+
+    @Test
+    fun `SharedFlowSubscription unsubscribed round-trip`() {
+        val event =
+            SharedFlowSubscription(
+                sessionId = "test-session",
+                seq = 120L,
+                tsNanos = System.nanoTime(),
+                flowId = "shared-flow-1",
+                collectorId = "collector-5",
+                action = "unsubscribed",
+                subscriberCount = 3,
+                coroutineId = null,
+                label = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SharedFlowSubscription>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `StateFlowValueChanged serialization round-trip`() {
+        val event =
+            StateFlowValueChanged(
+                sessionId = "test-session",
+                seq = 121L,
+                tsNanos = System.nanoTime(),
+                flowId = "state-flow-1",
+                oldValuePreview = "UiState(loading=true)",
+                newValuePreview = "UiState(loading=false, data=[1, 2, 3])",
+                valueType = "com.example.UiState",
+                subscriberCount = 2,
+                coroutineId = "coroutine-1",
+                label = "ui-state",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<StateFlowValueChanged>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"oldValuePreview\":\"UiState(loading=true)\""))
+        assertTrue(serialized.contains("\"subscriberCount\":2"))
+    }
+
+    @Test
+    fun `StateFlowValueChanged with null optional fields`() {
+        val event =
+            StateFlowValueChanged(
+                sessionId = "test-session",
+                seq = 122L,
+                tsNanos = System.nanoTime(),
+                flowId = "state-flow-2",
+                oldValuePreview = "0",
+                newValuePreview = "1",
+                valueType = "kotlin.Int",
+                subscriberCount = 0,
+                coroutineId = null,
+                label = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<StateFlowValueChanged>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    // ========================================================================
+    // Channel Events
+    // ========================================================================
+
+    @Test
+    fun `ChannelCreated serialization round-trip`() {
+        val event =
+            ChannelCreated(
+                sessionId = "test-session",
+                seq = 200L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                name = "task-queue",
+                capacity = 64,
+                channelType = "BUFFERED",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelCreated>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"channelType\":\"BUFFERED\""))
+        assertTrue(serialized.contains("\"capacity\":64"))
+    }
+
+    @Test
+    fun `ChannelCreated with null name`() {
+        val event =
+            ChannelCreated(
+                sessionId = "test-session",
+                seq = 201L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-2",
+                name = null,
+                capacity = 0,
+                channelType = "RENDEZVOUS",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelCreated>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `ChannelSendStarted serialization round-trip`() {
+        val event =
+            ChannelSendStarted(
+                sessionId = "test-session",
+                seq = 202L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                coroutineId = "coroutine-producer",
+                valueDescription = "Task(id=42, priority=HIGH)",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelSendStarted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"valueDescription\":\"Task(id=42, priority=HIGH)\""))
+    }
+
+    @Test
+    fun `ChannelSendSuspended serialization round-trip`() {
+        val event =
+            ChannelSendSuspended(
+                sessionId = "test-session",
+                seq = 203L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                coroutineId = "coroutine-producer",
+                bufferSize = 64,
+                capacity = 64,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelSendSuspended>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"bufferSize\":64"))
+        assertTrue(serialized.contains("\"capacity\":64"))
+    }
+
+    @Test
+    fun `ChannelSendCompleted serialization round-trip`() {
+        val event =
+            ChannelSendCompleted(
+                sessionId = "test-session",
+                seq = 204L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                coroutineId = "coroutine-producer",
+                valueDescription = "Task(id=42, priority=HIGH)",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelSendCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `ChannelReceiveStarted serialization round-trip`() {
+        val event =
+            ChannelReceiveStarted(
+                sessionId = "test-session",
+                seq = 205L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                coroutineId = "coroutine-consumer",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelReceiveStarted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"channelId\":\"channel-1\""))
+    }
+
+    @Test
+    fun `ChannelReceiveSuspended serialization round-trip`() {
+        val event =
+            ChannelReceiveSuspended(
+                sessionId = "test-session",
+                seq = 206L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                coroutineId = "coroutine-consumer",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelReceiveSuspended>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `ChannelReceiveCompleted serialization round-trip`() {
+        val event =
+            ChannelReceiveCompleted(
+                sessionId = "test-session",
+                seq = 207L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                coroutineId = "coroutine-consumer",
+                valueDescription = "Task(id=42, priority=HIGH)",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelReceiveCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"valueDescription\":\"Task(id=42, priority=HIGH)\""))
+    }
+
+    @Test
+    fun `ChannelBufferStateChanged serialization round-trip`() {
+        val event =
+            ChannelBufferStateChanged(
+                sessionId = "test-session",
+                seq = 208L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                currentSize = 32,
+                capacity = 64,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelBufferStateChanged>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"currentSize\":32"))
+    }
+
+    @Test
+    fun `ChannelClosed serialization round-trip`() {
+        val event =
+            ChannelClosed(
+                sessionId = "test-session",
+                seq = 209L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-1",
+                cause = "Producer finished",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelClosed>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"cause\":\"Producer finished\""))
+    }
+
+    @Test
+    fun `ChannelClosed with null cause`() {
+        val event =
+            ChannelClosed(
+                sessionId = "test-session",
+                seq = 210L,
+                tsNanos = System.nanoTime(),
+                channelId = "channel-2",
+                cause = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ChannelClosed>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    // ========================================================================
+    // Deferred Events
+    // ========================================================================
+
+    @Test
+    fun `DeferredAwaitStarted serialization round-trip`() {
+        val event =
+            DeferredAwaitStarted(
+                sessionId = "test-session",
+                seq = 300L,
+                tsNanos = System.nanoTime(),
+                deferredId = "deferred-1",
+                coroutineId = "coroutine-async",
+                awaiterId = "coroutine-main",
+                scopeId = "scope-1",
+                label = "fetch-user-data",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<DeferredAwaitStarted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"deferredId\":\"deferred-1\""))
+        assertTrue(serialized.contains("\"awaiterId\":\"coroutine-main\""))
+    }
+
+    @Test
+    fun `DeferredAwaitStarted with null optional fields`() {
+        val event =
+            DeferredAwaitStarted(
+                sessionId = "test-session",
+                seq = 301L,
+                tsNanos = System.nanoTime(),
+                deferredId = "deferred-2",
+                coroutineId = "coroutine-async",
+                awaiterId = null,
+                scopeId = "scope-1",
+                label = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<DeferredAwaitStarted>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `DeferredAwaitCompleted serialization round-trip`() {
+        val event =
+            DeferredAwaitCompleted(
+                sessionId = "test-session",
+                seq = 302L,
+                tsNanos = System.nanoTime(),
+                deferredId = "deferred-1",
+                coroutineId = "coroutine-async",
+                awaiterId = "coroutine-main",
+                scopeId = "scope-1",
+                label = "fetch-user-data",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<DeferredAwaitCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"deferredId\":\"deferred-1\""))
+    }
+
+    @Test
+    fun `DeferredAwaitCompleted with null optional fields`() {
+        val event =
+            DeferredAwaitCompleted(
+                sessionId = "test-session",
+                seq = 303L,
+                tsNanos = System.nanoTime(),
+                deferredId = "deferred-2",
+                coroutineId = "coroutine-async",
+                awaiterId = null,
+                scopeId = "scope-1",
+                label = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<DeferredAwaitCompleted>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `DeferredValueAvailable serialization round-trip`() {
+        val event =
+            DeferredValueAvailable(
+                sessionId = "test-session",
+                seq = 304L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-async",
+                jobId = "job-async",
+                parentCoroutineId = "coroutine-main",
+                scopeId = "scope-1",
+                label = "compute-result",
+                deferredId = "deferred-1",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<DeferredValueAvailable>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"deferredId\":\"deferred-1\""))
+        assertTrue(serialized.contains("\"coroutineId\":\"coroutine-async\""))
+    }
+
+    // ========================================================================
+    // Dispatcher Events
+    // ========================================================================
+
+    @Test
+    fun `DispatcherSelected serialization round-trip`() {
+        val event =
+            DispatcherSelected(
+                sessionId = "test-session",
+                seq = 400L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "io-task",
+                dispatcherId = "dispatcher-io",
+                dispatcherName = "Dispatchers.IO",
+                queueDepth = 5,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<DispatcherSelected>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"dispatcherName\":\"Dispatchers.IO\""))
+        assertTrue(serialized.contains("\"queueDepth\":5"))
+    }
+
+    @Test
+    fun `DispatcherSelected with null queueDepth`() {
+        val event =
+            DispatcherSelected(
+                sessionId = "test-session",
+                seq = 401L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-2",
+                jobId = "job-2",
+                parentCoroutineId = "coroutine-1",
+                scopeId = "scope-1",
+                label = null,
+                dispatcherId = "dispatcher-default",
+                dispatcherName = "Dispatchers.Default",
+                queueDepth = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<DispatcherSelected>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `ThreadAssigned serialization round-trip`() {
+        val event =
+            ThreadAssigned(
+                sessionId = "test-session",
+                seq = 402L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-1",
+                jobId = "job-1",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "io-task",
+                threadId = 42L,
+                threadName = "DefaultDispatcher-worker-3",
+                dispatcherName = "Dispatchers.Default",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ThreadAssigned>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"threadId\":42"))
+        assertTrue(serialized.contains("\"threadName\":\"DefaultDispatcher-worker-3\""))
+    }
+
+    @Test
+    fun `ThreadAssigned with null dispatcherName`() {
+        val event =
+            ThreadAssigned(
+                sessionId = "test-session",
+                seq = 403L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-2",
+                jobId = "job-2",
+                parentCoroutineId = "coroutine-1",
+                scopeId = "scope-1",
+                label = null,
+                threadId = 99L,
+                threadName = "main",
+                dispatcherName = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<ThreadAssigned>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    // ========================================================================
+    // Mutex Events
+    // ========================================================================
+
+    @Test
+    fun `MutexCreated serialization round-trip`() {
+        val event =
+            MutexCreated(
+                sessionId = "test-session",
+                seq = 500L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = "db-lock",
+                ownerCoroutineId = "coroutine-1",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexCreated>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"mutexId\":\"mutex-1\""))
+        assertTrue(serialized.contains("\"mutexLabel\":\"db-lock\""))
+    }
+
+    @Test
+    fun `MutexCreated with null optional fields`() {
+        val event =
+            MutexCreated(
+                sessionId = "test-session",
+                seq = 501L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-2",
+                mutexLabel = null,
+                ownerCoroutineId = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexCreated>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `MutexLockRequested serialization round-trip`() {
+        val event =
+            MutexLockRequested(
+                sessionId = "test-session",
+                seq = 502L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = "db-lock",
+                requesterId = "coroutine-2",
+                requesterLabel = "writer-coroutine",
+                isLocked = true,
+                queuePosition = 2,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexLockRequested>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"isLocked\":true"))
+        assertTrue(serialized.contains("\"queuePosition\":2"))
+    }
+
+    @Test
+    fun `MutexLockRequested with null requesterLabel`() {
+        val event =
+            MutexLockRequested(
+                sessionId = "test-session",
+                seq = 503L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = null,
+                requesterId = "coroutine-3",
+                requesterLabel = null,
+                isLocked = false,
+                queuePosition = 0,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexLockRequested>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `MutexLockAcquired serialization round-trip`() {
+        val event =
+            MutexLockAcquired(
+                sessionId = "test-session",
+                seq = 504L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = "db-lock",
+                acquirerId = "coroutine-2",
+                acquirerLabel = "writer-coroutine",
+                waitDurationNanos = 500_000_000L,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexLockAcquired>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"waitDurationNanos\":500000000"))
+    }
+
+    @Test
+    fun `MutexUnlocked serialization round-trip`() {
+        val event =
+            MutexUnlocked(
+                sessionId = "test-session",
+                seq = 505L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = "db-lock",
+                releaserId = "coroutine-2",
+                releaserLabel = "writer-coroutine",
+                nextWaiterId = "coroutine-3",
+                holdDurationNanos = 1_200_000_000L,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexUnlocked>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"nextWaiterId\":\"coroutine-3\""))
+        assertTrue(serialized.contains("\"holdDurationNanos\":1200000000"))
+    }
+
+    @Test
+    fun `MutexUnlocked with null optional fields`() {
+        val event =
+            MutexUnlocked(
+                sessionId = "test-session",
+                seq = 506L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = null,
+                releaserId = "coroutine-2",
+                releaserLabel = null,
+                nextWaiterId = null,
+                holdDurationNanos = 100_000L,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexUnlocked>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `MutexTryLockFailed serialization round-trip`() {
+        val event =
+            MutexTryLockFailed(
+                sessionId = "test-session",
+                seq = 507L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = "db-lock",
+                requesterId = "coroutine-4",
+                requesterLabel = "reader-coroutine",
+                currentOwnerId = "coroutine-2",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexTryLockFailed>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"currentOwnerId\":\"coroutine-2\""))
+    }
+
+    @Test
+    fun `MutexTryLockFailed with null optional fields`() {
+        val event =
+            MutexTryLockFailed(
+                sessionId = "test-session",
+                seq = 508L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-2",
+                mutexLabel = null,
+                requesterId = "coroutine-5",
+                requesterLabel = null,
+                currentOwnerId = null,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexTryLockFailed>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `MutexQueueChanged serialization round-trip`() {
+        val event =
+            MutexQueueChanged(
+                sessionId = "test-session",
+                seq = 509L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = "db-lock",
+                waitingCoroutineIds = listOf("coroutine-3", "coroutine-4", "coroutine-5"),
+                waitingLabels = listOf("reader-1", null, "reader-3"),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexQueueChanged>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"waitingCoroutineIds\":[\"coroutine-3\",\"coroutine-4\",\"coroutine-5\"]"))
+    }
+
+    @Test
+    fun `MutexQueueChanged with empty lists`() {
+        val event =
+            MutexQueueChanged(
+                sessionId = "test-session",
+                seq = 510L,
+                tsNanos = System.nanoTime(),
+                mutexId = "mutex-1",
+                mutexLabel = null,
+                waitingCoroutineIds = emptyList(),
+                waitingLabels = emptyList(),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<MutexQueueChanged>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    // ========================================================================
+    // Semaphore Events
+    // ========================================================================
+
+    @Test
+    fun `SemaphoreCreated serialization round-trip`() {
+        val event =
+            SemaphoreCreated(
+                sessionId = "test-session",
+                seq = 600L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-1",
+                semaphoreLabel = "connection-pool",
+                totalPermits = 10,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphoreCreated>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"totalPermits\":10"))
+    }
+
+    @Test
+    fun `SemaphoreCreated with null label`() {
+        val event =
+            SemaphoreCreated(
+                sessionId = "test-session",
+                seq = 601L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-2",
+                semaphoreLabel = null,
+                totalPermits = 3,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphoreCreated>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `SemaphoreAcquireRequested serialization round-trip`() {
+        val event =
+            SemaphoreAcquireRequested(
+                sessionId = "test-session",
+                seq = 602L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-1",
+                semaphoreLabel = "connection-pool",
+                requesterId = "coroutine-1",
+                requesterLabel = "http-handler",
+                availablePermits = 2,
+                permitsRequested = 1,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphoreAcquireRequested>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"availablePermits\":2"))
+        assertTrue(serialized.contains("\"permitsRequested\":1"))
+    }
+
+    @Test
+    fun `SemaphorePermitAcquired serialization round-trip`() {
+        val event =
+            SemaphorePermitAcquired(
+                sessionId = "test-session",
+                seq = 603L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-1",
+                semaphoreLabel = "connection-pool",
+                acquirerId = "coroutine-1",
+                acquirerLabel = "http-handler",
+                remainingPermits = 1,
+                waitDurationNanos = 0L,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphorePermitAcquired>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"remainingPermits\":1"))
+    }
+
+    @Test
+    fun `SemaphorePermitReleased serialization round-trip`() {
+        val event =
+            SemaphorePermitReleased(
+                sessionId = "test-session",
+                seq = 604L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-1",
+                semaphoreLabel = "connection-pool",
+                releaserId = "coroutine-1",
+                releaserLabel = "http-handler",
+                newAvailablePermits = 2,
+                holdDurationNanos = 350_000_000L,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphorePermitReleased>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"newAvailablePermits\":2"))
+        assertTrue(serialized.contains("\"holdDurationNanos\":350000000"))
+    }
+
+    @Test
+    fun `SemaphoreTryAcquireFailed serialization round-trip`() {
+        val event =
+            SemaphoreTryAcquireFailed(
+                sessionId = "test-session",
+                seq = 605L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-1",
+                semaphoreLabel = "connection-pool",
+                requesterId = "coroutine-5",
+                requesterLabel = "overflow-handler",
+                availablePermits = 0,
+                permitsRequested = 1,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphoreTryAcquireFailed>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"availablePermits\":0"))
+    }
+
+    @Test
+    fun `SemaphoreTryAcquireFailed with null labels`() {
+        val event =
+            SemaphoreTryAcquireFailed(
+                sessionId = "test-session",
+                seq = 606L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-2",
+                semaphoreLabel = null,
+                requesterId = "coroutine-6",
+                requesterLabel = null,
+                availablePermits = 0,
+                permitsRequested = 2,
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphoreTryAcquireFailed>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    @Test
+    fun `SemaphoreStateChanged serialization round-trip`() {
+        val event =
+            SemaphoreStateChanged(
+                sessionId = "test-session",
+                seq = 607L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-1",
+                semaphoreLabel = "connection-pool",
+                availablePermits = 3,
+                totalPermits = 10,
+                activeHolders = listOf("coroutine-1", "coroutine-2", "coroutine-3"),
+                activeHolderLabels = listOf("handler-1", "handler-2", null),
+                waitingCoroutines = listOf("coroutine-4", "coroutine-5"),
+                waitingLabels = listOf("handler-4", null),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphoreStateChanged>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"totalPermits\":10"))
+        assertTrue(serialized.contains("\"activeHolders\":[\"coroutine-1\",\"coroutine-2\",\"coroutine-3\"]"))
+    }
+
+    @Test
+    fun `SemaphoreStateChanged with empty lists`() {
+        val event =
+            SemaphoreStateChanged(
+                sessionId = "test-session",
+                seq = 608L,
+                tsNanos = System.nanoTime(),
+                semaphoreId = "semaphore-2",
+                semaphoreLabel = null,
+                availablePermits = 5,
+                totalPermits = 5,
+                activeHolders = emptyList(),
+                activeHolderLabels = emptyList(),
+                waitingCoroutines = emptyList(),
+                waitingLabels = emptyList(),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<SemaphoreStateChanged>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    // ========================================================================
+    // Deadlock Events
+    // ========================================================================
+
+    @Test
+    fun `DeadlockDetected serialization round-trip`() {
+        val event =
+            DeadlockDetected(
+                sessionId = "test-session",
+                seq = 700L,
+                tsNanos = System.nanoTime(),
+                involvedCoroutines = listOf("coroutine-A", "coroutine-B"),
+                involvedCoroutineLabels = listOf("worker-A", "worker-B"),
+                involvedMutexes = listOf("mutex-1", "mutex-2"),
+                involvedMutexLabels = listOf("lock-alpha", "lock-beta"),
+                waitGraph = mapOf("coroutine-A" to "mutex-2", "coroutine-B" to "mutex-1"),
+                holdGraph = mapOf("mutex-1" to "coroutine-A", "mutex-2" to "coroutine-B"),
+                cycleDescription = "coroutine-A holds mutex-1, waits for mutex-2; coroutine-B holds mutex-2, waits for mutex-1",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<DeadlockDetected>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"cycleDescription\""))
+        assertTrue(serialized.contains("\"waitGraph\""))
+        assertTrue(serialized.contains("\"holdGraph\""))
+    }
+
+    @Test
+    fun `PotentialDeadlockWarning serialization round-trip`() {
+        val event =
+            PotentialDeadlockWarning(
+                sessionId = "test-session",
+                seq = 701L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-A",
+                coroutineLabel = "worker-A",
+                holdingMutex = "mutex-1",
+                holdingMutexLabel = "lock-alpha",
+                requestingMutex = "mutex-2",
+                requestingMutexLabel = "lock-beta",
+                recommendation = "Consider acquiring mutexes in a consistent order to avoid deadlocks",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<PotentialDeadlockWarning>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"recommendation\""))
+        assertTrue(serialized.contains("\"holdingMutex\":\"mutex-1\""))
+        assertTrue(serialized.contains("\"requestingMutex\":\"mutex-2\""))
+    }
+
+    @Test
+    fun `PotentialDeadlockWarning with null labels`() {
+        val event =
+            PotentialDeadlockWarning(
+                sessionId = "test-session",
+                seq = 702L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-X",
+                coroutineLabel = null,
+                holdingMutex = "mutex-10",
+                holdingMutexLabel = null,
+                requestingMutex = "mutex-20",
+                requestingMutexLabel = null,
+                recommendation = "Avoid nested lock acquisition",
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<PotentialDeadlockWarning>(serialized)
+
+        assertEquals(event, deserialized)
+    }
+
+    // ========================================================================
+    // WaitingForChildren Event
+    // ========================================================================
+
+    @Test
+    fun `WaitingForChildren serialization round-trip`() {
+        val event =
+            WaitingForChildren(
+                sessionId = "test-session",
+                seq = 800L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-parent",
+                jobId = "job-parent",
+                parentCoroutineId = null,
+                scopeId = "scope-1",
+                label = "supervisor-scope",
+                activeChildrenCount = 3,
+                activeChildrenIds = listOf("coroutine-child-1", "coroutine-child-2", "coroutine-child-3"),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<WaitingForChildren>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"activeChildrenCount\":3"))
+        assertTrue(serialized.contains("\"activeChildrenIds\""))
+    }
+
+    @Test
+    fun `WaitingForChildren with empty children list`() {
+        val event =
+            WaitingForChildren(
+                sessionId = "test-session",
+                seq = 801L,
+                tsNanos = System.nanoTime(),
+                coroutineId = "coroutine-parent",
+                jobId = "job-parent",
+                parentCoroutineId = "coroutine-grandparent",
+                scopeId = "scope-1",
+                label = null,
+                activeChildrenCount = 0,
+                activeChildrenIds = emptyList(),
+            )
+
+        val serialized = json.encodeToString(event)
+        val deserialized = json.decodeFromString<WaitingForChildren>(serialized)
+
+        assertEquals(event, deserialized)
+        assertTrue(serialized.contains("\"activeChildrenIds\":[]"))
+    }
+}

--- a/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/session/EventStoreTest.kt
+++ b/backend/coroutine-viz-core/src/test/kotlin/com/jh/proj/coroutineviz/session/EventStoreTest.kt
@@ -1,0 +1,133 @@
+package com.jh.proj.coroutineviz.session
+
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EventStoreTest {
+    private fun event(seq: Long) =
+        CoroutineCreated(
+            sessionId = "test",
+            seq = seq,
+            tsNanos = System.nanoTime(),
+            coroutineId = "c-$seq",
+            jobId = "j-$seq",
+            parentCoroutineId = null,
+            scopeId = "scope",
+            label = "label-$seq",
+        )
+
+    @Test
+    fun `append and retrieve events in order`() {
+        val store = EventStore()
+        store.append(event(1))
+        store.append(event(2))
+        store.append(event(3))
+
+        val all = store.all()
+        assertEquals(3, all.size)
+        assertEquals(1L, all[0].seq)
+        assertEquals(3L, all[2].seq)
+    }
+
+    @Test
+    fun `size returns correct count`() {
+        val store = EventStore()
+        assertEquals(0, store.size())
+
+        store.append(event(1))
+        assertEquals(1, store.size())
+
+        store.append(event(2))
+        assertEquals(2, store.size())
+    }
+
+    @Test
+    fun `evicts oldest events when maxEvents exceeded`() {
+        val store = EventStore(maxEvents = 5)
+
+        for (i in 1L..10L) {
+            store.append(event(i))
+        }
+
+        assertEquals(5, store.size())
+        val all = store.all()
+        // Should retain events 6-10 (oldest 1-5 evicted)
+        assertEquals(6L, all.first().seq)
+        assertEquals(10L, all.last().seq)
+    }
+
+    @Test
+    fun `eviction at exact boundary`() {
+        val store = EventStore(maxEvents = 3)
+
+        store.append(event(1))
+        store.append(event(2))
+        store.append(event(3))
+        assertEquals(3, store.size())
+
+        // One more triggers eviction
+        store.append(event(4))
+        assertEquals(3, store.size())
+        assertEquals(2L, store.all().first().seq)
+    }
+
+    @Test
+    fun `onEvict callback is called for each eviction`() {
+        val evictCount = AtomicInteger(0)
+        val store = EventStore(maxEvents = 3)
+        store.onEvict = { evictCount.incrementAndGet() }
+
+        for (i in 1L..6L) {
+            store.append(event(i))
+        }
+
+        // 6 appended, max 3, so 3 evictions
+        assertEquals(3, evictCount.get())
+    }
+
+    @Test
+    fun `all returns defensive copy`() {
+        val store = EventStore()
+        store.append(event(1))
+
+        val copy1 = store.all()
+        store.append(event(2))
+        val copy2 = store.all()
+
+        assertEquals(1, copy1.size, "First copy should not be affected by later appends")
+        assertEquals(2, copy2.size)
+    }
+
+    @Test
+    fun `thread safety under concurrent writes`() {
+        val store = EventStore(maxEvents = 500)
+        val threads = 8
+        val eventsPerThread = 200
+        val executor = Executors.newFixedThreadPool(threads)
+        val latch = CountDownLatch(threads)
+
+        for (t in 0 until threads) {
+            executor.submit {
+                try {
+                    for (i in 0 until eventsPerThread) {
+                        store.append(event((t * eventsPerThread + i).toLong()))
+                    }
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        latch.await()
+        executor.shutdown()
+
+        // Should have at most maxEvents
+        assertTrue(store.size() <= 500, "Size should not exceed maxEvents")
+        assertEquals(store.size(), store.all().size, "size() and all().size should agree")
+    }
+}

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "backend"
 
+include("coroutine-viz-core")
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/docs/adr/013-core-library-extraction.md
+++ b/docs/adr/013-core-library-extraction.md
@@ -1,0 +1,75 @@
+# ADR-013: Core Library Extraction
+
+## Status
+Accepted
+
+## Date
+2026-03-17
+
+## Context
+The backend is a monolithic Ktor application containing both the core visualization logic (events, wrappers, session management, validation) and the HTTP/SSE web layer. To support the IntelliJ plugin (Phase 4), the core logic must be available as a standalone library without Ktor dependencies.
+
+## Decision
+Convert the backend to a multi-module Gradle project with two modules:
+
+### Module: `coroutine-viz-core`
+**102 source files** extracted to a standalone library with zero Ktor dependencies.
+
+```
+coroutine-viz-core/
+├── events/          — 45+ event types (VizEvent, CoroutineEvent, Flow/Channel/Mutex/etc.)
+├── wrappers/        — VizScope, InstrumentedFlow, VizMutex, VizSemaphore, VizSelect, VizActor
+├── session/         — VizSession, EventBus, EventStore, RuntimeSnapshot, ProjectionService
+├── models/          — CoroutineNode, CoroutineState, CoroutineTimeline
+├── checksystem/     — Validators, EventRecorder, AntiPatternDetector, TimingAnalyzer
+├── validation/      — ValidationRule, ValidationRuleRegistry, 20 rules across 6 categories
+└── sync/            — DeadlockDetector
+```
+
+**Dependencies:** kotlinx-coroutines-core, kotlinx-serialization-json, slf4j-api
+
+### Module: `backend` (root)
+Thin HTTP layer depending on `coroutine-viz-core`:
+```
+backend/
+├── routes/          — HTTP endpoints, SSE streaming
+├── scenarios/       — Scenario runners (PatternScenarios, SyncScenarios)
+├── Application.kt   — Ktor server setup
+└── HTTP/Monitoring/Serialization/Routing
+```
+
+**Dependencies:** coroutine-viz-core + Ktor + Micrometer
+
+### Build Configuration
+```kotlin
+// settings.gradle.kts
+include("coroutine-viz-core")
+
+// build.gradle.kts (root/backend)
+dependencies {
+    implementation(project(":coroutine-viz-core"))
+}
+```
+
+### Publishing
+Core library is published via Maven:
+- Group: `com.jh.coroutine-visualizer`
+- Artifact: `coroutine-viz-core`
+- Version: `0.1.0`
+
+## Rationale
+- **Zero Ktor dependency** verified — no file in the core packages imports `io.ktor`
+- **Identical package names** — no import changes needed in either module
+- **Sources duplicated temporarily** — both modules contain the core source files during transition; the backend's copies will be removed once all tests are migrated
+- **Core library tests pass independently** — validated with `./gradlew :coroutine-viz-core:test`
+
+## Consequences
+### Positive
+- IntelliJ plugin can depend on `coroutine-viz-core` JAR directly
+- Core library can be used in CLI tools, test frameworks, or other integrations
+- Clear separation of concerns (visualization logic vs HTTP transport)
+
+### Negative
+- Source duplication during transition period
+- Two test suites to maintain until migration completes
+- Gradle multi-module adds build complexity


### PR DESCRIPTION
## Summary

- Extract shared core library into `backend/coroutine-viz-core/` Gradle sub-module with **zero Ktor dependencies**
- Enables IntelliJ plugin and future consumers to depend on events, wrappers, and session management without web framework coupling
- 109 source files: 32 event types, 11 wrappers, 10 session/model types, validation engine with 8 rule categories
- New capabilities: actor events, select events, anti-pattern detection
- CI workflow for core module testing, coverage, and JAR artifact upload

## Module structure

```
coroutine-viz-core/
  src/main/kotlin/com/jh/proj/coroutineviz/
    events/       -- 32 event types (coroutine, job, flow, channel, deferred, dispatcher, actor, select)
    wrappers/     -- VizScope, InstrumentedFlow/Channel/Deferred, VizMutex/Semaphore, VizActor, VizSelect
    session/      -- VizSession, EventBus, EventStore, ProjectionService, SessionManager
    models/       -- CoroutineNode, RuntimeSnapshot, HierarchyNode, etc.
    checksystem/  -- Validators, AntiPatternDetector, EventRecorder
    validation/   -- Rule engine with 8 rule categories + real-time analysis
    sync/         -- DeadlockDetector
  src/test/kotlin/ -- 7 test files
```

## Dependencies

Core module depends only on:
- `kotlinx-coroutines-core` 1.10.2
- `kotlinx-serialization-json` 1.8.1
- `slf4j-api` 2.0.9

No Ktor, no web framework, no HTTP.

## What changed

| File | Change |
|------|--------|
| `backend/coroutine-viz-core/` | New module (109 files) |
| `backend/settings.gradle.kts` | Added `include("coroutine-viz-core")` |
| `backend/build.gradle.kts` | Added `implementation(project(":coroutine-viz-core"))` |
| `.github/workflows/ci-core.yml` | New CI workflow |
| `docs/adr/013-core-library-extraction.md` | Architecture decision record |

Backend source copies are retained during transition (per ADR-013). Package names are identical so backend imports resolve from the core JAR.

## Test plan

- [x] `./gradlew :coroutine-viz-core:test` passes (7 tests)
- [x] `./gradlew test` passes (backend, 112 tests)
- [ ] CI passes on this PR
- [ ] Core JAR has zero Ktor transitive dependencies

Closes #71