### PR TITLE
feat: add flow/pattern scenarios, health check, metrics, and tests

### DIFF
--- a/backend/detekt-baseline.xml
+++ b/backend/detekt-baseline.xml
@@ -4,12 +4,15 @@
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:ProjectionService.kt$ProjectionService$private fun processEvent(event: VizEvent)</ID>
     <ID>CyclomaticComplexMethod:SessionRoutes.kt$fun Route.registerSessionRoutes()</ID>
+    <ID>InstanceOfCheckForException:PatternScenarios.kt$PatternScenarios$e is CancellationException</ID>
     <ID>InvalidPackageDeclaration:ApplicationTest.kt$package com.jh.proj</ID>
     <ID>InvalidPackageDeclaration:BaseTestService.kt$package com.jh.proj</ID>
     <ID>InvalidPackageDeclaration:StructuredConcurrencyTest.kt$package com.jh.proj</ID>
     <ID>InvalidPackageDeclaration:VizLaunchTest.kt$package com.jh.proj</ID>
     <ID>LongMethod:DispatcherExample.kt$suspend fun dispatcherExampleScenario()</ID>
+    <ID>LongMethod:FlowScenarioRoutes.kt$fun Route.registerFlowScenarioRoutes()</ID>
     <ID>LongMethod:InstrumentedDeferred.kt$InstrumentedDeferred$override suspend fun await(): T</ID>
+    <ID>LongMethod:PatternRoutes.kt$fun Route.registerPatternRoutes()</ID>
     <ID>LongMethod:ProjectionService.kt$ProjectionService$private fun processEvent(event: VizEvent)</ID>
     <ID>LongMethod:ScenarioRunner.kt$ScenarioRunner$suspend fun runOrderProcessingScenario( session: VizSession, shouldFail: Boolean = false, ): Job</ID>
     <ID>LongMethod:ScenarioRunner.kt$ScenarioRunner$suspend fun runReportGenerationScenario( session: VizSession, shouldTimeout: Boolean = false, ): Job</ID>
@@ -28,7 +31,24 @@
     <ID>MagicNumber:DispatcherExample.kt$60</ID>
     <ID>MagicNumber:FlowEventContext.kt$100</ID>
     <ID>MagicNumber:FlowEventContext.kt$200</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$10</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$100</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$20</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$200</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$3</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$30</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$4</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$5</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$50</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$6</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$7</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$8</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$80</ID>
+    <ID>MagicNumber:FlowScenarios.kt$FlowScenarios$9</ID>
     <ID>MagicNumber:HTTP.kt$3600</ID>
+    <ID>MagicNumber:HealthRoutes.kt$100</ID>
+    <ID>MagicNumber:HealthRoutes.kt$1024</ID>
+    <ID>MagicNumber:HealthRoutes.kt$90.0</ID>
     <ID>MagicNumber:InstrumentedChannel.kt$InstrumentedChannel$200</ID>
     <ID>MagicNumber:InstrumentedChannel.kt$InstrumentedChannel.&lt;no name provided>$200</ID>
     <ID>MagicNumber:InstrumentedFlow.kt$InstrumentedFlow$200</ID>
@@ -36,6 +56,21 @@
     <ID>MagicNumber:InstrumentedSharedFlow.kt$InstrumentedSharedFlow$100</ID>
     <ID>MagicNumber:InstrumentedSharedFlow.kt$InstrumentedSharedFlow$200</ID>
     <ID>MagicNumber:InstrumentedStateFlow.kt$InstrumentedStateFlow$200</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$100</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$100L</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$150</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$200</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$3</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$30</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$300</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$300L</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$4</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$400</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$5</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$50</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$8</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$80</ID>
+    <ID>MagicNumber:PatternScenarios.kt$PatternScenarios$9</ID>
     <ID>MagicNumber:ScenarioDTO.kt$1000L</ID>
     <ID>MagicNumber:ScenarioRunner.kt$ScenarioRunner$10</ID>
     <ID>MagicNumber:ScenarioRunner.kt$ScenarioRunner$100</ID>
@@ -92,9 +127,12 @@
     <ID>ReturnCount:DeadlockDetector.kt$DeadlockDetector$private fun detectCycleDFS( node: String, graph: Map&lt;String, String>, visited: MutableSet&lt;String>, recursionStack: MutableSet&lt;String>, path: MutableList&lt;String>, ): List&lt;String>?</ID>
     <ID>ReturnCount:HierarchyValidator.kt$HierarchyValidator$private fun checkParentNotCompletedBeforeChildren( childCreated: CoroutineCreated, parentId: String, byCoroutine: Map&lt;String, List&lt;CoroutineEvent>>, ): ValidationResult</ID>
     <ID>ReturnCount:SyncScenarios.kt$SyncScenarios$suspend fun processOrder(order: Order): Boolean</ID>
+    <ID>SwallowedException:PatternScenarios.kt$PatternScenarios$e: Exception</ID>
     <ID>SwallowedException:SyncScenarios.kt$SyncScenarios$e: Exception</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:SuspensionPoint.kt$SuspensionPoint.Companion$Throwable()</ID>
     <ID>ThrowsCount:SyncValidators.kt$SemaphoreValidator$fun verifyPermitBounds( semaphoreId: String, maxPermits: Int, )</ID>
+    <ID>TooGenericExceptionCaught:PatternRoutes.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PatternScenarios.kt$PatternScenarios$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ScenarioRunner.kt$ScenarioRunner$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ScenarioRunnerRoutes.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:SessionRoutes.kt$e: Exception</ID>
@@ -112,6 +150,7 @@
     <ID>TooManyFunctions:ScenarioRoutesTest.kt$ScenarioRoutesTest</ID>
     <ID>TooManyFunctions:SessionRoutesTest.kt$SessionRoutesTest</ID>
     <ID>TooManyFunctions:SyncPrimitivesTest.kt$SyncPrimitivesTest</ID>
+    <ID>TooManyFunctions:SyncValidatorsTest.kt$SyncValidatorsTest</ID>
     <ID>TooManyFunctions:VizSession.kt$VizSession</ID>
     <ID>UnusedParameter:FlowEventContext.kt$FlowEventContext$operatorName: String</ID>
     <ID>UnusedParameter:ProjectionService.kt$ProjectionService$roots: List&lt;HierarchyNode></ID>

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/MetricsWiring.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/MetricsWiring.kt
@@ -1,0 +1,24 @@
+package com.jh.proj.coroutineviz
+
+import com.jh.proj.coroutineviz.session.SessionManager
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+private val logger = LoggerFactory.getLogger("MetricsWiring")
+
+/** Tracks active SSE client connections. Increment on connect, decrement on disconnect. */
+val sseClientsGauge = AtomicInteger(0)
+
+fun wireMetrics(registry: PrometheusMeterRegistry) {
+    Gauge.builder("viz.sessions.active") { SessionManager.listSessions().size.toDouble() }
+        .description("Number of active visualization sessions")
+        .register(registry)
+
+    Gauge.builder("viz.sse.clients.active") { sseClientsGauge.toDouble() }
+        .description("Number of active SSE client connections")
+        .register(registry)
+
+    logger.info("Metrics wiring complete")
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/Monitoring.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/Monitoring.kt
@@ -12,8 +12,10 @@ fun Application.configureMonitoring() {
 
     install(MicrometerMetrics) {
         registry = appMicrometerRegistry
-        // ...
     }
+
+    wireMetrics(appMicrometerRegistry)
+
     routing {
         get("/metrics-micrometer") {
             call.respond(appMicrometerRegistry.scrape())

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/Routing.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/Routing.kt
@@ -1,5 +1,8 @@
 package com.jh.proj.coroutineviz
 
+import com.jh.proj.coroutineviz.routes.registerFlowScenarioRoutes
+import com.jh.proj.coroutineviz.routes.registerHealthRoutes
+import com.jh.proj.coroutineviz.routes.registerPatternRoutes
 import com.jh.proj.coroutineviz.routes.registerRootRoutes
 import com.jh.proj.coroutineviz.routes.registerScenarioRunnerRoutes
 import com.jh.proj.coroutineviz.routes.registerSessionRoutes
@@ -21,5 +24,8 @@ fun Application.configureRouting() {
         registerSessionRoutes()
         registerValidationRoutes()
         registerScenarioRunnerRoutes()
+        registerFlowScenarioRoutes()
+        registerPatternRoutes()
+        registerHealthRoutes()
     }
 }

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/routes/FlowScenarioRoutes.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/routes/FlowScenarioRoutes.kt
@@ -1,0 +1,104 @@
+package com.jh.proj.coroutineviz.routes
+
+import com.jh.proj.coroutineviz.scenarios.FlowScenarios
+import com.jh.proj.coroutineviz.session.SessionManager
+import com.jh.proj.coroutineviz.session.VizSession
+import com.jh.proj.coroutineviz.wrappers.VizScope
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+
+fun Route.registerFlowScenarioRoutes() {
+    post("/api/scenarios/flow/simple") {
+        val session = getOrCreateSession(call.request.queryParameters["sessionId"], "flow-simple")
+        val scope = VizScope(session)
+        FlowScenarios.simpleFlow(scope)
+        call.respond(HttpStatusCode.OK, session.toCompletionResponse("Simple Flow completed"))
+    }
+
+    post("/api/scenarios/flow/operators") {
+        val session = getOrCreateSession(call.request.queryParameters["sessionId"], "flow-operators")
+        val scope = VizScope(session)
+        FlowScenarios.flowOperators(scope)
+        call.respond(HttpStatusCode.OK, session.toCompletionResponse("Flow Operators completed"))
+    }
+
+    post("/api/scenarios/flow/stateflow") {
+        val session = getOrCreateSession(call.request.queryParameters["sessionId"], "flow-stateflow")
+        val scope = VizScope(session)
+        FlowScenarios.stateFlowDemo(scope)
+        call.respond(HttpStatusCode.OK, session.toCompletionResponse("StateFlow demo completed"))
+    }
+
+    post("/api/scenarios/flow/sharedflow") {
+        val session = getOrCreateSession(call.request.queryParameters["sessionId"], "flow-sharedflow")
+        val scope = VizScope(session)
+        FlowScenarios.sharedFlowDemo(scope)
+        call.respond(HttpStatusCode.OK, session.toCompletionResponse("SharedFlow demo completed"))
+    }
+
+    get("/api/scenarios/flow") {
+        call.respond(
+            HttpStatusCode.OK,
+            mapOf(
+                "scenarios" to
+                    listOf(
+                        mapOf(
+                            "id" to "flow/simple",
+                            "name" to "Simple Flow",
+                            "description" to "Emit and collect 5 values from a cold Flow",
+                            "endpoint" to "/api/scenarios/flow/simple",
+                            "category" to "flow",
+                            "duration" to "~1s",
+                        ),
+                        mapOf(
+                            "id" to "flow/operators",
+                            "name" to "Flow Operators",
+                            "description" to "Chain map and filter operators on a flow",
+                            "endpoint" to "/api/scenarios/flow/operators",
+                            "category" to "flow",
+                            "duration" to "~1s",
+                        ),
+                        mapOf(
+                            "id" to "flow/stateflow",
+                            "name" to "StateFlow",
+                            "description" to "Mutable state with multiple observers",
+                            "endpoint" to "/api/scenarios/flow/stateflow",
+                            "category" to "flow",
+                            "duration" to "~2s",
+                        ),
+                        mapOf(
+                            "id" to "flow/sharedflow",
+                            "name" to "SharedFlow",
+                            "description" to "Broadcast events to multiple subscribers",
+                            "endpoint" to "/api/scenarios/flow/sharedflow",
+                            "category" to "flow",
+                            "duration" to "~2s",
+                        ),
+                    ),
+            ),
+        )
+    }
+}
+
+internal suspend fun getOrCreateSession(
+    sessionId: String?,
+    prefix: String,
+): VizSession {
+    return if (sessionId != null) {
+        SessionManager.getSession(sessionId) ?: SessionManager.createSession(sessionId)
+    } else {
+        SessionManager.createSession(prefix)
+    }
+}
+
+internal fun VizSession.toCompletionResponse(message: String) =
+    ScenarioCompletionResponse(
+        success = true,
+        sessionId = sessionId,
+        message = message,
+        coroutineCount = snapshot.coroutines.size,
+        eventCount = store.all().size,
+    )

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/routes/HealthRoutes.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/routes/HealthRoutes.kt
@@ -1,0 +1,56 @@
+package com.jh.proj.coroutineviz.routes
+
+import com.jh.proj.coroutineviz.session.SessionManager
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MemoryInfo(
+    val usedMb: Long,
+    val maxMb: Long,
+    val usagePercent: Double,
+)
+
+@Serializable
+data class HealthStatus(
+    val status: String,
+    val sessions: Int,
+    val uptimeMs: Long,
+    val memory: MemoryInfo,
+)
+
+private val startTime = System.currentTimeMillis()
+
+fun Route.registerHealthRoutes() {
+    get("/health") {
+        val runtime = Runtime.getRuntime()
+        val maxMb = runtime.maxMemory() / (1024 * 1024)
+        val usedMb = (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024)
+        val usagePercent = if (maxMb > 0) (usedMb.toDouble() / maxMb * 100) else 0.0
+
+        val memory =
+            MemoryInfo(
+                usedMb = usedMb,
+                maxMb = maxMb,
+                usagePercent = usagePercent,
+            )
+
+        val sessions = SessionManager.listSessions().size
+        val uptimeMs = System.currentTimeMillis() - startTime
+        val healthy = usagePercent < 90.0
+
+        val status =
+            HealthStatus(
+                status = if (healthy) "UP" else "DEGRADED",
+                sessions = sessions,
+                uptimeMs = uptimeMs,
+                memory = memory,
+            )
+
+        val httpStatus = if (healthy) HttpStatusCode.OK else HttpStatusCode.ServiceUnavailable
+        call.respond(httpStatus, status)
+    }
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/routes/PatternRoutes.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/routes/PatternRoutes.kt
@@ -1,0 +1,174 @@
+package com.jh.proj.coroutineviz.routes
+
+import com.jh.proj.coroutineviz.scenarios.PatternScenarios
+import com.jh.proj.coroutineviz.session.VizSession
+import com.jh.proj.coroutineviz.wrappers.VizScope
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("PatternRoutes")
+
+@Serializable
+data class PatternInfo(
+    val id: String,
+    val name: String,
+    val description: String,
+    val endpoint: String,
+    val category: String = "pattern",
+    val duration: String,
+)
+
+/**
+ * Routes for real-world coroutine pattern scenarios.
+ *
+ * These routes demonstrate common concurrency patterns including
+ * retry, producer-consumer, fan-out/fan-in, supervisor, and circuit breaker.
+ */
+fun Route.registerPatternRoutes() {
+    // ========================================================================
+    // PATTERN SCENARIOS
+    // ========================================================================
+
+    post("/api/scenarios/patterns/retry") {
+        val sessionId = call.request.queryParameters["sessionId"]
+        val session = getOrCreateSession(sessionId, "pattern")
+
+        logger.info("Running retry with exponential backoff scenario in session: ${session.sessionId}")
+
+        call.runPatternScenario(session, "Retry with Exponential Backoff") { scope ->
+            PatternScenarios.retryWithExponentialBackoff(scope)
+        }
+    }
+
+    post("/api/scenarios/patterns/producer-consumer") {
+        val sessionId = call.request.queryParameters["sessionId"]
+        val session = getOrCreateSession(sessionId, "pattern")
+
+        logger.info("Running producer-consumer scenario in session: ${session.sessionId}")
+
+        call.runPatternScenario(session, "Producer-Consumer") { scope ->
+            PatternScenarios.producerConsumer(scope)
+        }
+    }
+
+    post("/api/scenarios/patterns/fan-out-fan-in") {
+        val sessionId = call.request.queryParameters["sessionId"]
+        val session = getOrCreateSession(sessionId, "pattern")
+
+        logger.info("Running fan-out/fan-in scenario in session: ${session.sessionId}")
+
+        call.runPatternScenario(session, "Fan-Out / Fan-In") { scope ->
+            PatternScenarios.fanOutFanIn(scope)
+        }
+    }
+
+    post("/api/scenarios/patterns/supervisor") {
+        val sessionId = call.request.queryParameters["sessionId"]
+        val session = getOrCreateSession(sessionId, "pattern")
+
+        logger.info("Running supervisor pattern scenario in session: ${session.sessionId}")
+
+        call.runPatternScenario(session, "Supervisor Pattern") { scope ->
+            PatternScenarios.supervisorPattern(scope)
+        }
+    }
+
+    post("/api/scenarios/patterns/circuit-breaker") {
+        val sessionId = call.request.queryParameters["sessionId"]
+        val session = getOrCreateSession(sessionId, "pattern")
+
+        logger.info("Running circuit breaker scenario in session: ${session.sessionId}")
+
+        call.runPatternScenario(session, "Circuit Breaker") { scope ->
+            PatternScenarios.circuitBreaker(scope)
+        }
+    }
+
+    // ========================================================================
+    // LIST ALL PATTERN SCENARIOS
+    // ========================================================================
+
+    get("/api/scenarios/patterns") {
+        call.respond(
+            HttpStatusCode.OK,
+            mapOf(
+                "scenarios" to
+                    listOf(
+                        PatternInfo(
+                            id = "retry",
+                            name = "Retry with Exponential Backoff",
+                            description =
+                                "Retry a failing operation 3 times with exponential backoff " +
+                                    "(100ms, 200ms, 400ms). Shows structured retry pattern for transient failures.",
+                            endpoint = "/api/scenarios/patterns/retry",
+                            duration = "~1-2 seconds",
+                        ),
+                        PatternInfo(
+                            id = "producer-consumer",
+                            name = "Producer-Consumer",
+                            description =
+                                "Producer sends items to a buffered channel (capacity 5), " +
+                                    "consumer processes them with delay. Shows channel-based communication.",
+                            endpoint = "/api/scenarios/patterns/producer-consumer",
+                            duration = "~1-2 seconds",
+                        ),
+                        PatternInfo(
+                            id = "fan-out-fan-in",
+                            name = "Fan-Out / Fan-In",
+                            description =
+                                "One producer, 3 worker coroutines that process in parallel, " +
+                                    "results collected via channel. Shows work distribution pattern.",
+                            endpoint = "/api/scenarios/patterns/fan-out-fan-in",
+                            duration = "~1-2 seconds",
+                        ),
+                        PatternInfo(
+                            id = "supervisor",
+                            name = "Supervisor Pattern",
+                            description =
+                                "Launch children where one fails but siblings continue. " +
+                                    "Shows error isolation with structured concurrency.",
+                            endpoint = "/api/scenarios/patterns/supervisor",
+                            duration = "~1-2 seconds",
+                        ),
+                        PatternInfo(
+                            id = "circuit-breaker",
+                            name = "Circuit Breaker",
+                            description =
+                                "After N consecutive failures, stop trying for a cooldown period. " +
+                                    "Shows resilience pattern for protecting downstream services.",
+                            endpoint = "/api/scenarios/patterns/circuit-breaker",
+                            duration = "~1-2 seconds",
+                        ),
+                    ),
+            ),
+        )
+    }
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+private suspend fun ApplicationCall.runPatternScenario(
+    session: VizSession,
+    scenarioName: String,
+    scenario: suspend (VizScope) -> Unit,
+) {
+    try {
+        val scope = VizScope(session)
+        scenario(scope)
+        respond(HttpStatusCode.OK, session.toCompletionResponse("$scenarioName completed"))
+    } catch (e: Exception) {
+        logger.error("Error running pattern scenario '$scenarioName'", e)
+        respond(
+            HttpStatusCode.InternalServerError,
+            mapOf("error" to "Scenario failed: ${e.message}"),
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/scenarios/FlowScenarios.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/scenarios/FlowScenarios.kt
@@ -1,0 +1,126 @@
+package com.jh.proj.coroutineviz.scenarios
+
+import com.jh.proj.coroutineviz.wrappers.VizScope
+
+/**
+ * Flow visualization scenarios demonstrating cold flows, operators,
+ * SharedFlow, and StateFlow with instrumented event tracking.
+ */
+object FlowScenarios {
+    /**
+     * Simple cold flow: emit 5 values, collect them.
+     * Shows FlowCreated, FlowCollectionStarted, FlowValueEmitted, FlowCollectionCompleted.
+     */
+    suspend fun simpleFlow(scope: VizScope) {
+        scope.vizLaunch("flow-collector") {
+            val flow = vizFlowOf(1, 2, 3, 4, 5, label = "numbers")
+
+            flow.collect { value ->
+                vizDelay(50)
+            }
+        }.join()
+    }
+
+    /**
+     * Flow with map and filter operators.
+     * Shows FlowOperatorApplied, FlowValueTransformed, FlowValueFiltered.
+     */
+    suspend fun flowOperators(scope: VizScope) {
+        scope.vizLaunch("operator-chain") {
+            val flow = vizFlowOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, label = "source")
+
+            flow
+                .vizMap { it * 2 }
+                .vizFilter { it % 4 == 0 }
+                .vizMap { "Value: $it" }
+                .collect { value ->
+                    vizDelay(30)
+                }
+        }.join()
+    }
+
+    /**
+     * StateFlow: mutable state holder with multiple observers.
+     * Shows StateFlowValueChanged events as state updates.
+     */
+    suspend fun stateFlowDemo(scope: VizScope) {
+        scope.vizLaunch("stateflow-demo") {
+            val counter = vizStateFlow(0, label = "counter")
+
+            // Observer 1
+            val observer1 =
+                vizLaunch("observer-1") {
+                    var collected = 0
+                    counter.collect { value ->
+                        collected++
+                        if (collected >= 6) return@collect
+                    }
+                }
+
+            // Observer 2
+            val observer2 =
+                vizLaunch("observer-2") {
+                    var collected = 0
+                    counter.collect { value ->
+                        collected++
+                        if (collected >= 6) return@collect
+                    }
+                }
+
+            // Updater
+            vizLaunch("updater") {
+                for (i in 1..5) {
+                    vizDelay(100)
+                    counter.value = i
+                }
+                vizDelay(200)
+                observer1.cancel()
+                observer2.cancel()
+            }
+        }.join()
+    }
+
+    /**
+     * SharedFlow: broadcast to multiple subscribers.
+     * Shows SharedFlowEmission, SharedFlowSubscription events.
+     */
+    suspend fun sharedFlowDemo(scope: VizScope) {
+        scope.vizLaunch("sharedflow-demo") {
+            val events = vizSharedFlow<String>(replay = 1, label = "event-bus")
+
+            // Subscriber 1
+            val sub1 =
+                vizLaunch("subscriber-1") {
+                    var count = 0
+                    events.collect { msg ->
+                        count++
+                        vizDelay(20)
+                        if (count >= 5) return@collect
+                    }
+                }
+
+            // Subscriber 2
+            val sub2 =
+                vizLaunch("subscriber-2") {
+                    var count = 0
+                    events.collect { msg ->
+                        count++
+                        vizDelay(20)
+                        if (count >= 5) return@collect
+                    }
+                }
+
+            // Publisher
+            vizLaunch("publisher") {
+                vizDelay(50) // Let subscribers attach
+                for (i in 1..5) {
+                    events.emit("Event #$i")
+                    vizDelay(80)
+                }
+                vizDelay(200)
+                sub1.cancel()
+                sub2.cancel()
+            }
+        }.join()
+    }
+}

--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/scenarios/PatternScenarios.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/scenarios/PatternScenarios.kt
@@ -1,0 +1,350 @@
+package com.jh.proj.coroutineviz.scenarios
+
+import com.jh.proj.coroutineviz.wrappers.VizScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Real-world coroutine pattern scenarios for visualization.
+ *
+ * These scenarios demonstrate common concurrency patterns used in
+ * production Kotlin applications, including retry logic, producer-consumer,
+ * fan-out/fan-in, supervisor patterns, and circuit breakers.
+ */
+object PatternScenarios {
+    private val logger = LoggerFactory.getLogger(PatternScenarios::class.java)
+
+    // ========================================================================
+    // RETRY WITH EXPONENTIAL BACKOFF
+    // ========================================================================
+
+    /**
+     * Retry a failing operation 3 times with exponential backoff (100ms, 200ms, 400ms).
+     *
+     * Demonstrates the structured retry pattern commonly used for transient failures
+     * such as network timeouts, temporary service unavailability, or rate limiting.
+     */
+    suspend fun retryWithExponentialBackoff(scope: VizScope) {
+        val attemptCounter = AtomicInteger(0)
+
+        scope.vizLaunch("retry-controller") {
+            var lastException: Exception? = null
+            val maxRetries = 3
+            var delayMs = 100L
+
+            for (attempt in 1..maxRetries) {
+                val currentAttempt = attempt
+                val currentDelay = delayMs
+
+                val job =
+                    vizLaunch("attempt-$currentAttempt") {
+                        logger.debug("Attempt $currentAttempt: calling unreliable service...")
+                        vizDelay(80)
+
+                        val count = attemptCounter.incrementAndGet()
+                        if (count < maxRetries) {
+                            error("Service unavailable (attempt $currentAttempt)")
+                        }
+                        logger.debug("Attempt $currentAttempt: service responded successfully")
+                    }
+
+                try {
+                    job.join()
+                    if (job.isCancelled) {
+                        throw lastException ?: error("Attempt $currentAttempt failed")
+                    }
+                    logger.debug("Operation succeeded on attempt $currentAttempt")
+                    return@vizLaunch
+                } catch (e: Exception) {
+                    if (e is CancellationException) {
+                        lastException = IllegalStateException("Attempt $currentAttempt failed")
+                    } else {
+                        lastException = e
+                    }
+                    logger.debug("Attempt $currentAttempt failed: ${lastException?.message}")
+
+                    if (currentAttempt < maxRetries) {
+                        vizLaunch("backoff-${currentDelay}ms") {
+                            logger.debug("Waiting ${currentDelay}ms before retry...")
+                            vizDelay(currentDelay)
+                        }.join()
+                        delayMs *= 2
+                    }
+                }
+            }
+
+            if (lastException != null) {
+                logger.debug("All $maxRetries attempts exhausted")
+            }
+        }.join()
+    }
+
+    // ========================================================================
+    // PRODUCER-CONSUMER
+    // ========================================================================
+
+    /**
+     * Producer sends items to a buffered channel (capacity 5), consumer processes
+     * them with delay.
+     *
+     * Demonstrates channel-based communication between coroutines, which is the
+     * recommended way to share data between coroutines instead of shared mutable state.
+     */
+    suspend fun producerConsumer(scope: VizScope) {
+        val channel = scope.vizChannel<String>(5, "task-queue")
+
+        scope.vizLaunch("producer-consumer") {
+            val producer =
+                vizLaunch("producer") {
+                    val items = listOf("order-1", "order-2", "order-3", "order-4", "order-5", "order-6", "order-7")
+                    for (item in items) {
+                        logger.debug("Producer sending $item")
+                        channel.send(item)
+                        vizDelay(50)
+                    }
+                    channel.close()
+                    logger.debug("Producer finished, channel closed")
+                }
+
+            val consumer =
+                vizLaunch("consumer") {
+                    vizDelay(100) // Let buffer fill a bit
+                    try {
+                        while (true) {
+                            val item = channel.receive()
+                            logger.debug("Consumer processing $item")
+                            vizDelay(150) // Slower consumer to show backpressure
+                            logger.debug("Consumer finished $item")
+                        }
+                    } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
+                        logger.debug("Consumer: channel closed, done")
+                    }
+                }
+
+            producer.join()
+            consumer.join()
+            logger.debug("Producer-consumer pattern completed")
+        }.join()
+    }
+
+    // ========================================================================
+    // FAN-OUT / FAN-IN
+    // ========================================================================
+
+    /**
+     * One producer, 3 worker coroutines that process in parallel, results collected
+     * via channel.
+     *
+     * Demonstrates the fan-out/fan-in pattern for distributing work across multiple
+     * workers and collecting results. Common in data processing pipelines.
+     */
+    suspend fun fanOutFanIn(scope: VizScope) {
+        val taskChannel = scope.vizChannel<Int>(Channel.BUFFERED, "tasks")
+        val resultChannel = scope.vizChannel<String>(Channel.BUFFERED, "results")
+
+        scope.vizLaunch("fan-out-fan-in") {
+            // Producer: generates tasks
+            val producer =
+                vizLaunch("task-producer") {
+                    for (taskId in 1..9) {
+                        logger.debug("Dispatching task $taskId")
+                        taskChannel.send(taskId)
+                        vizDelay(30)
+                    }
+                    taskChannel.close()
+                    logger.debug("All tasks dispatched")
+                }
+
+            // Fan-out: 3 workers process tasks in parallel
+            val workers =
+                (1..3).map { workerId ->
+                    vizLaunch("worker-$workerId") {
+                        try {
+                            while (true) {
+                                val taskId = taskChannel.receive()
+                                logger.debug("Worker $workerId processing task $taskId")
+                                vizDelay((80..200).random().toLong())
+                                resultChannel.send("task-$taskId-by-worker-$workerId")
+                                logger.debug("Worker $workerId completed task $taskId")
+                            }
+                        } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
+                            logger.debug("Worker $workerId: no more tasks")
+                        }
+                    }
+                }
+
+            // Fan-in: collector gathers results
+            val collector =
+                vizLaunch("result-collector") {
+                    var count = 0
+                    try {
+                        while (count < 9) {
+                            val result = resultChannel.receive()
+                            count++
+                            logger.debug("Collected result $count: $result")
+                        }
+                    } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
+                        logger.debug("Result collector: channel closed")
+                    }
+                    logger.debug("Collected all $count results")
+                }
+
+            producer.join()
+            workers.forEach { it.join() }
+            resultChannel.close()
+            collector.join()
+            logger.debug("Fan-out/fan-in pattern completed")
+        }.join()
+    }
+
+    // ========================================================================
+    // SUPERVISOR PATTERN
+    // ========================================================================
+
+    /**
+     * Launch with SupervisorJob where one child fails but siblings continue.
+     *
+     * Demonstrates error isolation in structured concurrency. With a SupervisorJob,
+     * a failing child does not cancel its siblings, which is essential for services
+     * that must remain partially available.
+     */
+    suspend fun supervisorPattern(scope: VizScope) {
+        scope.vizLaunch("supervisor") {
+            // Launch children — one will fail
+            val stableChild1 =
+                vizLaunch("stable-service-A") {
+                    logger.debug("Service A: starting")
+                    vizDelay(200)
+                    logger.debug("Service A: processing...")
+                    vizDelay(400)
+                    logger.debug("Service A: completed successfully")
+                }
+
+            val failingChild =
+                vizLaunch("failing-service-B") {
+                    logger.debug("Service B: starting")
+                    vizDelay(150)
+                    logger.debug("Service B: about to fail!")
+                    error("Service B encountered a fatal error")
+                }
+
+            val stableChild2 =
+                vizLaunch("stable-service-C") {
+                    logger.debug("Service C: starting")
+                    vizDelay(300)
+                    logger.debug("Service C: processing...")
+                    vizDelay(300)
+                    logger.debug("Service C: completed successfully")
+                }
+
+            // Wait for stable children; handle failing child gracefully
+            try {
+                failingChild.join()
+            } catch (e: Exception) {
+                logger.debug("Supervisor caught failure from Service B: ${e.message}")
+            }
+
+            stableChild1.join()
+            stableChild2.join()
+
+            vizLaunch("health-reporter") {
+                logger.debug("Health report: Service A OK, Service B FAILED, Service C OK")
+                vizDelay(50)
+            }.join()
+
+            logger.debug("Supervisor pattern completed — partial failure handled")
+        }.join()
+    }
+
+    // ========================================================================
+    // CIRCUIT BREAKER
+    // ========================================================================
+
+    /**
+     * Simple circuit breaker: after N failures, stop trying for a cooldown period.
+     *
+     * Demonstrates the circuit breaker resilience pattern. After consecutive failures
+     * exceed a threshold, the circuit opens and subsequent calls fail fast without
+     * hitting the downstream service, giving it time to recover.
+     */
+    suspend fun circuitBreaker(scope: VizScope) {
+        val failureThreshold = 3
+        val cooldownMs = 300L
+        val failureCount = AtomicInteger(0)
+        val circuitOpen = AtomicBoolean(false)
+        val lastFailureTime = AtomicLong(0L)
+
+        scope.vizLaunch("circuit-breaker") {
+            // Simulate a series of calls through the circuit breaker
+            for (requestId in 1..8) {
+                vizLaunch("request-$requestId") {
+                    // Check circuit state
+                    if (circuitOpen.get()) {
+                        val elapsed = System.currentTimeMillis() - lastFailureTime.get()
+                        if (elapsed < cooldownMs) {
+                            logger.debug("Request $requestId: REJECTED (circuit open, cooldown ${cooldownMs - elapsed}ms remaining)")
+                            vizDelay(30) // Small delay to visualize the fast-fail
+                            return@vizLaunch
+                        } else {
+                            logger.debug("Request $requestId: circuit half-open, attempting probe...")
+                            circuitOpen.set(false)
+                            failureCount.set(0)
+                        }
+                    }
+
+                    // Attempt the call — first 4 requests fail, rest succeed
+                    vizLaunch("downstream-call-$requestId") {
+                        vizDelay(80)
+                        if (requestId <= 4) {
+                            error("Downstream service error")
+                        }
+                        logger.debug("Request $requestId: downstream call succeeded")
+                    }.also { job ->
+                        try {
+                            job.join()
+                            if (!job.isCancelled) {
+                                failureCount.set(0)
+                                logger.debug("Request $requestId: SUCCESS (circuit closed)")
+                            } else {
+                                handleFailure(requestId, failureCount, failureThreshold, cooldownMs) {
+                                    circuitOpen.set(true)
+                                    lastFailureTime.set(System.currentTimeMillis())
+                                }
+                            }
+                        } catch (e: Exception) {
+                            handleFailure(requestId, failureCount, failureThreshold, cooldownMs) {
+                                circuitOpen.set(true)
+                                lastFailureTime.set(System.currentTimeMillis())
+                            }
+                        }
+                    }
+                }.join()
+
+                // Small gap between requests
+                vizDelay(50)
+            }
+
+            logger.debug("Circuit breaker demo completed")
+        }.join()
+    }
+
+    private fun handleFailure(
+        requestId: Int,
+        failureCount: AtomicInteger,
+        failureThreshold: Int,
+        cooldownMs: Long,
+        openCircuit: () -> Unit,
+    ) {
+        val count = failureCount.incrementAndGet()
+        if (count >= failureThreshold) {
+            logger.debug("Request $requestId: FAILED — circuit OPENED (threshold $failureThreshold reached, cooldown ${cooldownMs}ms)")
+            openCircuit()
+        } else {
+            logger.debug("Request $requestId: FAILED ($count/$failureThreshold)")
+        }
+    }
+}

--- a/backend/src/main/resources/logback-prod.xml
+++ b/backend/src/main/resources/logback-prod.xml
@@ -1,0 +1,26 @@
+<configuration>
+    <!-- Production JSON logging via Logstash encoder -->
+    <appender name="JSON_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>sessionId</includeMdcKeyName>
+            <includeMdcKeyName>coroutineId</includeMdcKeyName>
+            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampPattern>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="JSON_STDOUT"/>
+    </root>
+
+    <!-- Application at INFO in prod (no DEBUG) -->
+    <logger name="com.jh.proj" level="INFO"/>
+
+    <!-- Keep external libraries quiet -->
+    <logger name="org.eclipse.jetty" level="WARN"/>
+    <logger name="io.netty" level="WARN"/>
+    <logger name="io.ktor" level="WARN"/>
+</configuration>

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/MetricsWiringTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/MetricsWiringTest.kt
@@ -1,0 +1,59 @@
+package com.jh.proj.coroutineviz
+
+import com.jh.proj.coroutineviz.session.SessionManager
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MetricsWiringTest {
+    @BeforeEach
+    fun setUp() {
+        SessionManager.clearAll()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SessionManager.clearAll()
+    }
+
+    @Test
+    fun `metrics endpoint exposes custom viz metrics`() =
+        testApplication {
+            application { module() }
+
+            val response = client.get("/metrics-micrometer")
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val body = response.bodyAsText()
+            assertTrue(body.contains("viz_sessions_active"), "Should contain viz.sessions.active gauge")
+        }
+
+    @Test
+    fun `sessions active gauge reflects session count`() =
+        testApplication {
+            application { module() }
+
+            // Create a session to trigger the callback wiring
+            val createClient =
+                createClient {
+                    install(ContentNegotiation) {
+                        json()
+                    }
+                }
+            createClient.post("/api/sessions?name=metrics-test")
+
+            val response = client.get("/metrics-micrometer")
+            val body = response.bodyAsText()
+            assertTrue(body.contains("viz_sessions_active"), "Should contain viz.sessions.active gauge")
+            assertTrue(body.contains("viz_sessions_active 1.0"), "Session count should be 1.0")
+        }
+}

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/SyncValidatorsTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/checksystem/SyncValidatorsTest.kt
@@ -1,0 +1,544 @@
+package com.jh.proj.coroutineviz.checksystem
+
+import com.jh.proj.coroutineviz.events.DeadlockDetected
+import com.jh.proj.coroutineviz.events.MutexLockAcquired
+import com.jh.proj.coroutineviz.events.MutexLockRequested
+import com.jh.proj.coroutineviz.events.MutexUnlocked
+import com.jh.proj.coroutineviz.events.SemaphorePermitAcquired
+import com.jh.proj.coroutineviz.events.SemaphorePermitReleased
+import com.jh.proj.coroutineviz.events.SemaphoreStateChanged
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class SyncValidatorsTest {
+    // ========================================================================
+    // Helper factories
+    // ========================================================================
+
+    private var seqCounter = 0L
+
+    private fun nextSeq(): Long = ++seqCounter
+
+    private fun deadlockDetected(
+        involvedCoroutines: List<String> = listOf("c-1", "c-2"),
+        involvedMutexes: List<String> = listOf("m-1", "m-2"),
+        cycleDescription: String = "c-1 -> m-1 -> c-2 -> m-2 -> c-1",
+    ): DeadlockDetected {
+        val seq = nextSeq()
+        return DeadlockDetected(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            involvedCoroutines = involvedCoroutines,
+            involvedCoroutineLabels = involvedCoroutines.map { null },
+            involvedMutexes = involvedMutexes,
+            involvedMutexLabels = involvedMutexes.map { null },
+            waitGraph = involvedCoroutines.zip(involvedMutexes).toMap(),
+            holdGraph = involvedMutexes.zip(involvedCoroutines).toMap(),
+            cycleDescription = cycleDescription,
+        )
+    }
+
+    private fun mutexLockRequested(
+        mutexId: String,
+        requesterId: String,
+        isLocked: Boolean = false,
+        queuePosition: Int = 0,
+    ): MutexLockRequested {
+        val seq = nextSeq()
+        return MutexLockRequested(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            mutexId = mutexId,
+            mutexLabel = null,
+            requesterId = requesterId,
+            requesterLabel = null,
+            isLocked = isLocked,
+            queuePosition = queuePosition,
+        )
+    }
+
+    private fun mutexLockAcquired(
+        mutexId: String,
+        acquirerId: String,
+        waitDurationNanos: Long = 0,
+    ): MutexLockAcquired {
+        val seq = nextSeq()
+        return MutexLockAcquired(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            mutexId = mutexId,
+            mutexLabel = null,
+            acquirerId = acquirerId,
+            acquirerLabel = null,
+            waitDurationNanos = waitDurationNanos,
+        )
+    }
+
+    private fun mutexUnlocked(
+        mutexId: String,
+        releaserId: String,
+        nextWaiterId: String? = null,
+        holdDurationNanos: Long = 1_000_000,
+    ): MutexUnlocked {
+        val seq = nextSeq()
+        return MutexUnlocked(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            mutexId = mutexId,
+            mutexLabel = null,
+            releaserId = releaserId,
+            releaserLabel = null,
+            nextWaiterId = nextWaiterId,
+            holdDurationNanos = holdDurationNanos,
+        )
+    }
+
+    private fun semaphorePermitAcquired(
+        semaphoreId: String,
+        acquirerId: String,
+        remainingPermits: Int = 0,
+        waitDurationNanos: Long = 0,
+    ): SemaphorePermitAcquired {
+        val seq = nextSeq()
+        return SemaphorePermitAcquired(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            semaphoreId = semaphoreId,
+            semaphoreLabel = null,
+            acquirerId = acquirerId,
+            acquirerLabel = null,
+            remainingPermits = remainingPermits,
+            waitDurationNanos = waitDurationNanos,
+        )
+    }
+
+    private fun semaphorePermitReleased(
+        semaphoreId: String,
+        releaserId: String,
+        newAvailablePermits: Int = 1,
+        holdDurationNanos: Long = 1_000_000,
+    ): SemaphorePermitReleased {
+        val seq = nextSeq()
+        return SemaphorePermitReleased(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            semaphoreId = semaphoreId,
+            semaphoreLabel = null,
+            releaserId = releaserId,
+            releaserLabel = null,
+            newAvailablePermits = newAvailablePermits,
+            holdDurationNanos = holdDurationNanos,
+        )
+    }
+
+    private fun semaphoreStateChanged(
+        semaphoreId: String,
+        availablePermits: Int,
+        totalPermits: Int,
+        activeHolders: List<String> = emptyList(),
+        waitingCoroutines: List<String> = emptyList(),
+    ): SemaphoreStateChanged {
+        val seq = nextSeq()
+        return SemaphoreStateChanged(
+            sessionId = "test-session",
+            seq = seq,
+            tsNanos = seq * 1_000_000,
+            semaphoreId = semaphoreId,
+            semaphoreLabel = null,
+            availablePermits = availablePermits,
+            totalPermits = totalPermits,
+            activeHolders = activeHolders,
+            activeHolderLabels = activeHolders.map { null },
+            waitingCoroutines = waitingCoroutines,
+            waitingLabels = waitingCoroutines.map { null },
+        )
+    }
+
+    // ========================================================================
+    // MutexValidator tests
+    // ========================================================================
+
+    @Test
+    fun `verifyNoDeadlock passes with no deadlock events`() {
+        val recorder = EventRecorder()
+        // Record some normal mutex events but no deadlocks
+        recorder.record(mutexLockAcquired("m-1", "c-1"))
+        recorder.record(mutexUnlocked("m-1", "c-1"))
+
+        val validator = MutexValidator(recorder)
+        validator.verifyNoDeadlock() // Should not throw
+    }
+
+    @Test
+    fun `verifyNoDeadlock fails when deadlock detected`() {
+        val recorder = EventRecorder()
+        recorder.record(
+            deadlockDetected(
+                involvedCoroutines = listOf("c-1", "c-2"),
+                involvedMutexes = listOf("m-1", "m-2"),
+                cycleDescription = "c-1 -> m-1 -> c-2 -> m-2 -> c-1",
+            ),
+        )
+
+        val validator = MutexValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyNoDeadlock()
+            }
+        assertTrue(error.message!!.contains("Deadlock detected"))
+        assertTrue(error.message!!.contains("c-1"))
+        assertTrue(error.message!!.contains("c-2"))
+    }
+
+    @Test
+    fun `verifyMutualExclusion passes with proper lock-unlock sequence`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // A acquires, A unlocks, B acquires, B unlocks
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexUnlocked(mutexId, "c-A"))
+        recorder.record(mutexLockAcquired(mutexId, "c-B"))
+        recorder.record(mutexUnlocked(mutexId, "c-B"))
+
+        val validator = MutexValidator(recorder)
+        validator.verifyMutualExclusion(mutexId) // Should not throw
+    }
+
+    @Test
+    fun `verifyMutualExclusion fails with double acquire`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // A acquires, then B acquires without A unlocking
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexLockAcquired(mutexId, "c-B"))
+
+        val validator = MutexValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyMutualExclusion(mutexId)
+            }
+        assertTrue(error.message!!.contains("c-A"))
+        assertTrue(error.message!!.contains("c-B"))
+    }
+
+    @Test
+    fun `verifyMutualExclusion fails with wrong releaser`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // A acquires, B unlocks (wrong releaser)
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexUnlocked(mutexId, "c-B"))
+
+        val validator = MutexValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyMutualExclusion(mutexId)
+            }
+        assertTrue(error.message!!.contains("c-B"))
+        assertTrue(error.message!!.contains("c-A"))
+    }
+
+    @Test
+    fun `verifyFairness passes with FIFO ordering`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // A and B queue (both contended), then A acquires first, then B
+        recorder.record(mutexLockRequested(mutexId, "c-A", isLocked = true, queuePosition = 1))
+        recorder.record(mutexLockRequested(mutexId, "c-B", isLocked = true, queuePosition = 2))
+        recorder.record(mutexLockAcquired(mutexId, "c-A", waitDurationNanos = 5_000))
+        recorder.record(mutexLockAcquired(mutexId, "c-B", waitDurationNanos = 10_000))
+
+        val validator = MutexValidator(recorder)
+        validator.verifyFairness(mutexId) // Should not throw
+    }
+
+    @Test
+    fun `verifyNoLockLeaks passes with balanced operations`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexUnlocked(mutexId, "c-A"))
+        recorder.record(mutexLockAcquired(mutexId, "c-B"))
+        recorder.record(mutexUnlocked(mutexId, "c-B"))
+
+        val validator = MutexValidator(recorder)
+        validator.verifyNoLockLeaks(mutexId) // Should not throw
+    }
+
+    @Test
+    fun `verifyNoLockLeaks fails with unbalanced operations`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+        // Two acquires but only one unlock
+        recorder.record(mutexLockAcquired(mutexId, "c-A"))
+        recorder.record(mutexUnlocked(mutexId, "c-A"))
+        recorder.record(mutexLockAcquired(mutexId, "c-B"))
+        // c-B never unlocks
+
+        val validator = MutexValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyNoLockLeaks(mutexId)
+            }
+        assertTrue(error.message!!.contains("lock leak"))
+        assertTrue(error.message!!.contains("2 acquires"))
+        assertTrue(error.message!!.contains("1 releases"))
+    }
+
+    @Test
+    fun `getContentionStats returns correct statistics`() {
+        val recorder = EventRecorder()
+        val mutexId = "m-1"
+
+        // Request 1: uncontended (isLocked = false)
+        recorder.record(mutexLockRequested(mutexId, "c-A", isLocked = false, queuePosition = 0))
+        recorder.record(mutexLockAcquired(mutexId, "c-A", waitDurationNanos = 0))
+        recorder.record(mutexUnlocked(mutexId, "c-A", holdDurationNanos = 5_000_000))
+
+        // Request 2: contended (isLocked = true)
+        recorder.record(mutexLockRequested(mutexId, "c-B", isLocked = true, queuePosition = 1))
+        recorder.record(mutexLockAcquired(mutexId, "c-B", waitDurationNanos = 2_000_000))
+        recorder.record(mutexUnlocked(mutexId, "c-B", holdDurationNanos = 3_000_000))
+
+        // Request 3: contended (isLocked = true)
+        recorder.record(mutexLockRequested(mutexId, "c-C", isLocked = true, queuePosition = 1))
+        recorder.record(mutexLockAcquired(mutexId, "c-C", waitDurationNanos = 4_000_000))
+        recorder.record(mutexUnlocked(mutexId, "c-C", holdDurationNanos = 1_000_000))
+
+        val validator = MutexValidator(recorder)
+        val stats = validator.getContentionStats(mutexId)
+
+        assertEquals(3, stats.totalRequests)
+        assertEquals(2, stats.contentionRequests)
+        assertEquals(2.0 / 3.0, stats.contentionRate, 0.001)
+        assertEquals(2_000_000.0, stats.avgWaitTimeNanos, 0.001)
+        assertEquals(4_000_000L, stats.maxWaitTimeNanos)
+        assertEquals(3_000_000.0, stats.avgHoldTimeNanos, 0.001)
+        assertEquals(5_000_000L, stats.maxHoldTimeNanos)
+    }
+
+    // ========================================================================
+    // SemaphoreValidator tests
+    // ========================================================================
+
+    @Test
+    fun `verifyPermitBounds passes with valid state`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val maxPermits = 3
+
+        // State with 2 active holders out of 3 permits -- valid
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 1,
+                totalPermits = maxPermits,
+                activeHolders = listOf("c-A", "c-B"),
+            ),
+        )
+        // State with 3 active holders out of 3 permits -- still valid
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 0,
+                totalPermits = maxPermits,
+                activeHolders = listOf("c-A", "c-B", "c-C"),
+            ),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        validator.verifyPermitBounds(semId, maxPermits) // Should not throw
+    }
+
+    @Test
+    fun `verifyPermitBounds fails with too many holders`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val maxPermits = 2
+
+        // 3 active holders but only 2 permits
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 0,
+                totalPermits = maxPermits,
+                activeHolders = listOf("c-A", "c-B", "c-C"),
+            ),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyPermitBounds(semId, maxPermits)
+            }
+        assertTrue(error.message!!.contains("permit limit exceeded"))
+        assertTrue(error.message!!.contains("3 holders"))
+        assertTrue(error.message!!.contains("2 permits"))
+    }
+
+    @Test
+    fun `verifyPermitBounds fails with negative permits`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = -1,
+                totalPermits = 3,
+                activeHolders = listOf("c-A", "c-B", "c-C"),
+            ),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyPermitBounds(semId, 3)
+            }
+        assertTrue(error.message!!.contains("negative permits"))
+    }
+
+    @Test
+    fun `verifyNoPermitLeaks passes when all permits returned`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val totalPermits = 3
+
+        // Some intermediate states then final state with all permits available
+        recorder.record(
+            semaphoreStateChanged(semId, availablePermits = 2, totalPermits = totalPermits, activeHolders = listOf("c-A")),
+        )
+        recorder.record(
+            semaphoreStateChanged(semId, availablePermits = 1, totalPermits = totalPermits, activeHolders = listOf("c-A", "c-B")),
+        )
+        recorder.record(
+            semaphoreStateChanged(semId, availablePermits = totalPermits, totalPermits = totalPermits, activeHolders = emptyList()),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        validator.verifyNoPermitLeaks(semId, totalPermits) // Should not throw
+    }
+
+    @Test
+    fun `verifyNoPermitLeaks fails when permits not returned`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val totalPermits = 3
+
+        // Final state still has a holder
+        recorder.record(
+            semaphoreStateChanged(semId, availablePermits = 2, totalPermits = totalPermits, activeHolders = listOf("c-A")),
+        )
+
+        val validator = SemaphoreValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyNoPermitLeaks(semId, totalPermits)
+            }
+        assertTrue(error.message!!.contains("permit leak"))
+        assertTrue(error.message!!.contains("2/$totalPermits"))
+    }
+
+    @Test
+    fun `verifyBalancedOperations passes with equal acquires and releases`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+
+        recorder.record(semaphorePermitAcquired(semId, "c-A"))
+        recorder.record(semaphorePermitAcquired(semId, "c-B"))
+        recorder.record(semaphorePermitReleased(semId, "c-A"))
+        recorder.record(semaphorePermitReleased(semId, "c-B"))
+
+        val validator = SemaphoreValidator(recorder)
+        validator.verifyBalancedOperations(semId) // Should not throw
+    }
+
+    @Test
+    fun `verifyBalancedOperations fails with unbalanced counts`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+
+        recorder.record(semaphorePermitAcquired(semId, "c-A"))
+        recorder.record(semaphorePermitAcquired(semId, "c-B"))
+        recorder.record(semaphorePermitReleased(semId, "c-A"))
+        // c-B never releases
+
+        val validator = SemaphoreValidator(recorder)
+        val error =
+            assertFailsWith<AssertionError> {
+                validator.verifyBalancedOperations(semId)
+            }
+        assertTrue(error.message!!.contains("unbalanced"))
+        assertTrue(error.message!!.contains("2 acquires"))
+        assertTrue(error.message!!.contains("1 releases"))
+    }
+
+    @Test
+    fun `getUtilizationStats returns correct statistics`() {
+        val recorder = EventRecorder()
+        val semId = "s-1"
+        val totalPermits = 3
+
+        // State changes showing varying utilization
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 2,
+                totalPermits = totalPermits,
+                activeHolders = listOf("c-A"),
+                waitingCoroutines = emptyList(),
+            ),
+        )
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = 0,
+                totalPermits = totalPermits,
+                activeHolders = listOf("c-A", "c-B", "c-C"),
+                waitingCoroutines = listOf("c-D"),
+            ),
+        )
+        recorder.record(
+            semaphoreStateChanged(
+                semId,
+                availablePermits = totalPermits,
+                totalPermits = totalPermits,
+                activeHolders = emptyList(),
+                waitingCoroutines = emptyList(),
+            ),
+        )
+
+        // Acquire/release events
+        recorder.record(semaphorePermitAcquired(semId, "c-A", waitDurationNanos = 1_000_000))
+        recorder.record(semaphorePermitAcquired(semId, "c-B", waitDurationNanos = 3_000_000))
+        recorder.record(semaphorePermitReleased(semId, "c-A", holdDurationNanos = 5_000_000))
+        recorder.record(semaphorePermitReleased(semId, "c-B", holdDurationNanos = 7_000_000))
+
+        val validator = SemaphoreValidator(recorder)
+        val stats = validator.getUtilizationStats(semId)
+
+        assertEquals(2, stats.totalAcquires)
+        assertEquals(2, stats.totalReleases)
+
+        // Utilization samples: 1/3, 3/3, 0/3 => avg = (1/3 + 1.0 + 0.0) / 3
+        val expectedAvgUtil = (1.0 / 3.0 + 1.0 + 0.0) / 3.0
+        assertEquals(expectedAvgUtil, stats.avgUtilization, 0.001)
+        assertEquals(1.0, stats.maxUtilization, 0.001)
+
+        assertEquals(3, stats.maxConcurrentHolders)
+        assertEquals(1, stats.maxWaitingQueue)
+
+        assertEquals(2_000_000.0, stats.avgWaitTimeNanos, 0.001)
+        assertEquals(3_000_000L, stats.maxWaitTimeNanos)
+        assertEquals(6_000_000.0, stats.avgHoldTimeNanos, 0.001)
+        assertEquals(7_000_000L, stats.maxHoldTimeNanos)
+    }
+}

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/routes/HealthRoutesTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/routes/HealthRoutesTest.kt
@@ -1,0 +1,92 @@
+package com.jh.proj.coroutineviz.routes
+
+import com.jh.proj.coroutineviz.module
+import com.jh.proj.coroutineviz.session.SessionManager
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class HealthRoutesTest {
+    @BeforeEach
+    fun setUp() {
+        SessionManager.clearAll()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SessionManager.clearAll()
+    }
+
+    private fun ApplicationTestBuilder.jsonClient() =
+        createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+    @Test
+    fun `GET health returns UP status`() =
+        testApplication {
+            application { module() }
+            val client = jsonClient()
+
+            val response = client.get("/health")
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            assertEquals("UP", body["status"]?.jsonPrimitive?.content)
+            assertNotNull(body["uptimeMs"])
+            assertNotNull(body["memory"])
+            assertEquals(0, body["sessions"]?.jsonPrimitive?.int)
+        }
+
+    @Test
+    fun `GET health reports session count`() =
+        testApplication {
+            application { module() }
+            val client = jsonClient()
+
+            // Create sessions
+            client.post("/api/sessions?name=health-test-1")
+            client.post("/api/sessions?name=health-test-2")
+
+            val response = client.get("/health")
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            assertEquals(2, body["sessions"]?.jsonPrimitive?.int)
+        }
+
+    @Test
+    fun `GET health returns memory info`() =
+        testApplication {
+            application { module() }
+            val client = jsonClient()
+
+            val response = client.get("/health")
+            val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            val memory = body["memory"]?.jsonObject
+
+            assertNotNull(memory)
+            assertTrue(memory["usedMb"]?.jsonPrimitive?.long!! >= 0)
+            assertTrue(memory["maxMb"]?.jsonPrimitive?.long!! > 0)
+            assertTrue(memory["usagePercent"]?.jsonPrimitive?.double!! >= 0.0)
+        }
+}

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/routes/SseStreamTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/routes/SseStreamTest.kt
@@ -1,0 +1,269 @@
+package com.jh.proj.coroutineviz.routes
+
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineCreated
+import com.jh.proj.coroutineviz.module
+import com.jh.proj.coroutineviz.session.SessionManager
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SseStreamTest {
+    @BeforeEach
+    fun setUp() {
+        SessionManager.clearAll()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SessionManager.clearAll()
+    }
+
+    private fun ApplicationTestBuilder.jsonClient() =
+        createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+    @Test
+    fun `SSE stream returns error for non-existent session`() =
+        testApplication {
+            application { module() }
+            val client = jsonClient()
+
+            val response = client.get("/api/sessions/non-existent-id/stream")
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val body = response.bodyAsText()
+            // SSE error event should contain the error message
+            assertTrue(body.contains("Session not found"), "SSE response should contain error message")
+            assertTrue(body.contains("event: error"), "SSE response should have event type 'error'")
+        }
+
+    @Test
+    fun `SSE stream replays stored events`() =
+        testApplication {
+            application { module() }
+
+            // Create a session and populate it with events directly via SessionManager
+            val session = SessionManager.createSession("sse-replay-test")
+            val sessionId = session.sessionId
+
+            val event1 =
+                CoroutineCreated(
+                    sessionId = sessionId,
+                    seq = 1L,
+                    tsNanos = System.nanoTime(),
+                    coroutineId = "c-1",
+                    jobId = "j-1",
+                    parentCoroutineId = null,
+                    scopeId = "scope-1",
+                    label = "first-coroutine",
+                )
+            val event2 =
+                CoroutineCreated(
+                    sessionId = sessionId,
+                    seq = 2L,
+                    tsNanos = System.nanoTime(),
+                    coroutineId = "c-2",
+                    jobId = "j-2",
+                    parentCoroutineId = "c-1",
+                    scopeId = "scope-1",
+                    label = "second-coroutine",
+                )
+
+            session.send(event1)
+            session.send(event2)
+
+            // Verify the EventStore has the events that SSE would replay
+            val storedEvents = session.store.all()
+            assertEquals(2, storedEvents.size, "Session should have 2 stored events for SSE replay")
+
+            // Verify first event fields (these are serialized as SSE data)
+            val first = storedEvents[0] as CoroutineCreated
+            assertEquals("CoroutineCreated", first.kind)
+            assertEquals(sessionId, first.sessionId)
+            assertEquals(1L, first.seq)
+            assertEquals("c-1", first.coroutineId)
+            assertEquals("first-coroutine", first.label)
+
+            // Verify second event fields
+            val second = storedEvents[1] as CoroutineCreated
+            assertEquals("CoroutineCreated", second.kind)
+            assertEquals(2L, second.seq)
+            assertEquals("c-2", second.coroutineId)
+            assertEquals("c-1", second.parentCoroutineId)
+            assertEquals("second-coroutine", second.label)
+
+            // Verify each event can be serialized to JSON (as the SSE route does)
+            for (event in storedEvents) {
+                val json = Json.encodeToString(event as CoroutineCreated)
+                assertTrue(json.isNotEmpty(), "Event should serialize to non-empty JSON")
+                assertTrue(json.contains("\"sessionId\""), "Serialized event should contain sessionId")
+                assertTrue(json.contains("\"seq\""), "Serialized event should contain seq")
+            }
+
+            // Verify the SSE id format matches what the route produces: "${event.sessionId}-${event.seq}"
+            val expectedId1 = "$sessionId-1"
+            val expectedId2 = "$sessionId-2"
+            assertEquals("$sessionId-${first.seq}", expectedId1)
+            assertEquals("$sessionId-${second.seq}", expectedId2)
+        }
+
+    @Test
+    fun `SSE stream events have correct format`() =
+        testApplication {
+            application { module() }
+            val client = jsonClient()
+
+            // The error case produces a complete SSE response we can parse
+            val response = client.get("/api/sessions/format-test-id/stream")
+            val body = response.bodyAsText()
+
+            // Parse SSE lines - format should be:
+            //   event: <kind>
+            //   data: <json>
+            //   id: <optional>
+            //   (blank line)
+            val lines = body.lines()
+
+            // Find the event line
+            val eventLine = lines.firstOrNull { it.startsWith("event:") }
+            assertNotNull(eventLine, "SSE output should contain an 'event:' line")
+            assertEquals("event: error", eventLine.trim(), "Event type should be 'error' for non-existent session")
+
+            // Find the data line
+            val dataLine = lines.firstOrNull { it.startsWith("data:") }
+            assertNotNull(dataLine, "SSE output should contain a 'data:' line")
+
+            // Verify the data is valid JSON
+            val jsonData = dataLine.removePrefix("data:").trim()
+            val parsed = Json.parseToJsonElement(jsonData).jsonObject
+            assertNotNull(parsed["error"], "Data JSON should contain 'error' field")
+            assertEquals("Session not found", parsed["error"]?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun `stored events contain all required fields for SSE replay`() =
+        testApplication {
+            application { module() }
+
+            // Create a session and send an event
+            val session = SessionManager.createSession("sse-fields-test")
+            val sessionId = session.sessionId
+
+            val event =
+                CoroutineCreated(
+                    sessionId = sessionId,
+                    seq = 1L,
+                    tsNanos = 123456789L,
+                    coroutineId = "c-1",
+                    jobId = "j-1",
+                    parentCoroutineId = null,
+                    scopeId = "scope-1",
+                    label = "test-coroutine",
+                )
+            session.send(event)
+
+            // Verify the event's 'kind' property (used as SSE event type field)
+            // 'kind' is a computed property accessed directly by the SSE route, not serialized in JSON
+            assertEquals("CoroutineCreated", event.kind, "Event kind should be 'CoroutineCreated'")
+
+            // Serialize the event the same way the SSE route does: Json.encodeToString(event)
+            val serialized = Json.encodeToString(event)
+            val eventJson = Json.parseToJsonElement(serialized).jsonObject
+
+            // 'sessionId' and 'seq' are used to construct the SSE id field: "${event.sessionId}-${event.seq}"
+            val eventSessionId = eventJson["sessionId"]?.jsonPrimitive?.content
+            assertNotNull(eventSessionId, "Event should have 'sessionId' field (used in SSE id)")
+            assertEquals(sessionId, eventSessionId)
+
+            val seq = eventJson["seq"]?.jsonPrimitive?.long
+            assertNotNull(seq, "Event should have 'seq' field (used in SSE id and dedup filtering)")
+            assertEquals(1L, seq)
+
+            // Verify the full JSON data payload contains all expected fields
+            assertNotNull(eventJson["tsNanos"], "Event should have 'tsNanos' field")
+            assertEquals(123456789L, eventJson["tsNanos"]?.jsonPrimitive?.long)
+            assertNotNull(eventJson["coroutineId"], "Event should have 'coroutineId' field")
+            assertNotNull(eventJson["jobId"], "Event should have 'jobId' field")
+            assertNotNull(eventJson["scopeId"], "Event should have 'scopeId' field")
+
+            // Verify SSE id format: "{sessionId}-{seq}"
+            val expectedSseId = "$sessionId-1"
+            assertEquals(expectedSseId, "${event.sessionId}-${event.seq}")
+        }
+
+    @Test
+    fun `session snapshot reflects events sent for SSE streaming`() =
+        testApplication {
+            application { module() }
+            val client = jsonClient()
+
+            // Create session and send events
+            val session = SessionManager.createSession("sse-snapshot-test")
+            val sessionId = session.sessionId
+
+            session.send(
+                CoroutineCreated(
+                    sessionId = sessionId,
+                    seq = 1L,
+                    tsNanos = System.nanoTime(),
+                    coroutineId = "c-1",
+                    jobId = "j-1",
+                    parentCoroutineId = null,
+                    scopeId = "scope-1",
+                    label = "root",
+                ),
+            )
+            session.send(
+                CoroutineCreated(
+                    sessionId = sessionId,
+                    seq = 2L,
+                    tsNanos = System.nanoTime(),
+                    coroutineId = "c-2",
+                    jobId = "j-2",
+                    parentCoroutineId = "c-1",
+                    scopeId = "scope-1",
+                    label = "child",
+                ),
+            )
+
+            // Verify session snapshot reflects the events (snapshot endpoint works with concrete DTO)
+            val snapshotResponse = client.get("/api/sessions/$sessionId")
+            assertEquals(HttpStatusCode.OK, snapshotResponse.status)
+
+            val snapshot = Json.parseToJsonElement(snapshotResponse.bodyAsText()).jsonObject
+            assertEquals(2, snapshot["coroutineCount"]?.jsonPrimitive?.int)
+            assertEquals(2, snapshot["eventCount"]?.jsonPrimitive?.int)
+
+            // Verify the event store has the right count for SSE replay via direct access
+            val storedEvents = session.store.all()
+            assertEquals(2, storedEvents.size, "EventStore should have 2 events ready for SSE replay")
+
+            // Verify coroutines in the snapshot (these are what the frontend visualizes after SSE replay)
+            val coroutines = snapshot["coroutines"]?.jsonArray
+            assertNotNull(coroutines, "Snapshot should include coroutines array")
+            assertEquals(2, coroutines.size, "Snapshot should have 2 coroutines")
+
+            val coroutineIds = coroutines.map { it.jsonObject["id"]?.jsonPrimitive?.content }
+            assertTrue(coroutineIds.contains("c-1"), "Snapshot should contain coroutine c-1")
+            assertTrue(coroutineIds.contains("c-2"), "Snapshot should contain coroutine c-2")
+        }
+}

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedDeferredTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedDeferredTest.kt
@@ -1,0 +1,164 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineResumed
+import com.jh.proj.coroutineviz.events.coroutine.CoroutineSuspended
+import com.jh.proj.coroutineviz.events.deferred.DeferredAwaitCompleted
+import com.jh.proj.coroutineviz.events.deferred.DeferredAwaitStarted
+import com.jh.proj.coroutineviz.events.deferred.DeferredValueAvailable
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InstrumentedDeferredTest {
+    private lateinit var session: VizSession
+
+    @BeforeEach
+    fun setup() {
+        session = VizSession("test-deferred-${System.currentTimeMillis()}")
+    }
+
+    // ========================================================================
+    // CREATION / VALUE AVAILABLE TESTS
+    // ========================================================================
+
+    @Test
+    fun `vizAsync creates coroutine with DeferredValueAvailable on completion`() =
+        runTest {
+            val scope = VizScope(session, coroutineContext)
+
+            val deferred =
+                scope.vizAsync("compute") {
+                    42
+                }
+
+            // Wait for the async block to complete
+            deferred.await()
+
+            val allEvents = session.store.all()
+
+            // DeferredValueAvailable should be emitted when the async body completes
+            val valueAvailableEvents = allEvents.filterIsInstance<DeferredValueAvailable>()
+            assertEquals(1, valueAvailableEvents.size)
+            assertEquals("compute", valueAvailableEvents.first().label)
+        }
+
+    // ========================================================================
+    // AWAIT LIFECYCLE TESTS
+    // ========================================================================
+
+    @Test
+    fun `await emits DeferredAwaitStarted and DeferredAwaitCompleted`() =
+        runTest {
+            val scope = VizScope(session, coroutineContext)
+
+            val deferred =
+                scope.vizAsync("awaited") {
+                    vizDelay(100)
+                    99
+                }
+
+            val result = deferred.await()
+            assertEquals(99, result)
+
+            val allEvents = session.store.all()
+
+            // DeferredAwaitStarted
+            val awaitStartedEvents = allEvents.filterIsInstance<DeferredAwaitStarted>()
+            assertEquals(1, awaitStartedEvents.size)
+            assertEquals("awaited", awaitStartedEvents.first().label)
+
+            // DeferredAwaitCompleted
+            val awaitCompletedEvents = allEvents.filterIsInstance<DeferredAwaitCompleted>()
+            assertEquals(1, awaitCompletedEvents.size)
+            assertEquals("awaited", awaitCompletedEvents.first().label)
+
+            // Same deferredId on both events
+            assertEquals(awaitStartedEvents.first().deferredId, awaitCompletedEvents.first().deferredId)
+        }
+
+    @Test
+    fun `await tracks awaiter coroutine suspension and resumption`() =
+        runTest {
+            val scope = VizScope(session, coroutineContext)
+
+            // Launch a parent coroutine that will await a deferred
+            val job =
+                scope.vizLaunch("awaiter") {
+                    val deferred =
+                        scope.vizAsync("producer") {
+                            vizDelay(100)
+                            "hello"
+                        }
+
+                    // This await call should emit CoroutineSuspended and CoroutineResumed
+                    // for the "awaiter" coroutine
+                    val result = deferred.await()
+                    assertEquals("hello", result)
+                }
+
+            job.join()
+
+            val allEvents = session.store.all()
+
+            // The await should emit suspension for the awaiter
+            val suspendedEvents = allEvents.filterIsInstance<CoroutineSuspended>()
+            val awaitSuspensions = suspendedEvents.filter { it.reason == "await" }
+            assertTrue(awaitSuspensions.isNotEmpty(), "Expected at least one await suspension event")
+
+            // The await should emit resumption for the awaiter
+            val resumedEvents = allEvents.filterIsInstance<CoroutineResumed>()
+            assertTrue(resumedEvents.isNotEmpty(), "Expected at least one resume event after await")
+        }
+
+    // ========================================================================
+    // COMPLETED DEFERRED TESTS
+    // ========================================================================
+
+    @Test
+    fun `completed deferred await returns immediately`() =
+        runTest {
+            val scope = VizScope(session, coroutineContext)
+
+            val deferred =
+                scope.vizAsync("fast") {
+                    7
+                }
+
+            // Wait for the async to fully complete first
+            deferred.join()
+
+            // Now await on an already-completed deferred
+            val result = deferred.await()
+            assertEquals(7, result)
+
+            val allEvents = session.store.all()
+
+            // Await events should still be emitted even if deferred is already complete
+            val awaitStartedEvents = allEvents.filterIsInstance<DeferredAwaitStarted>()
+            assertTrue(awaitStartedEvents.isNotEmpty(), "DeferredAwaitStarted should be emitted")
+
+            val awaitCompletedEvents = allEvents.filterIsInstance<DeferredAwaitCompleted>()
+            assertTrue(awaitCompletedEvents.isNotEmpty(), "DeferredAwaitCompleted should be emitted")
+        }
+
+    // ========================================================================
+    // RESULT CORRECTNESS TESTS
+    // ========================================================================
+
+    @Test
+    fun `deferred result is correct`() =
+        runTest {
+            val scope = VizScope(session, coroutineContext)
+
+            val deferred =
+                scope.vizAsync("sum") {
+                    (1..10).sum()
+                }
+
+            val result = deferred.await()
+            assertEquals(55, result)
+        }
+}

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedFlowTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedFlowTest.kt
@@ -1,0 +1,294 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionCancelled
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionCompleted
+import com.jh.proj.coroutineviz.events.flow.FlowCollectionStarted
+import com.jh.proj.coroutineviz.events.flow.FlowCreated
+import com.jh.proj.coroutineviz.events.flow.FlowOperatorApplied
+import com.jh.proj.coroutineviz.events.flow.FlowValueEmitted
+import com.jh.proj.coroutineviz.events.flow.FlowValueFiltered
+import com.jh.proj.coroutineviz.events.flow.FlowValueTransformed
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class InstrumentedFlowTest {
+    private lateinit var session: VizSession
+
+    @BeforeEach
+    fun setup() {
+        session = VizSession("test-flow-${System.currentTimeMillis()}")
+    }
+
+    // ========================================================================
+    // CREATION TESTS
+    // ========================================================================
+
+    @Test
+    fun `flow creation emits FlowCreated event`() {
+        val flow = flowOf(1, 2, 3).instrumented(session, "flow-1", "Cold", "testFlow")
+
+        val createdEvents = session.store.all().filterIsInstance<FlowCreated>()
+        assertEquals(1, createdEvents.size)
+        assertEquals("flow-1", createdEvents.first().flowId)
+        assertEquals("Cold", createdEvents.first().flowType)
+        assertEquals("testFlow", createdEvents.first().label)
+    }
+
+    // ========================================================================
+    // COLLECTION LIFECYCLE TESTS
+    // ========================================================================
+
+    @Test
+    fun `collecting flow emits collection lifecycle events`() =
+        runTest {
+            val flow = flowOf(1, 2, 3).instrumented(session, "flow-lifecycle", "Cold", "lifecycleFlow")
+
+            val collected = mutableListOf<Int>()
+            flow.collect { collected.add(it) }
+
+            assertEquals(listOf(1, 2, 3), collected)
+
+            val allEvents = session.store.all()
+
+            // FlowCollectionStarted
+            val startedEvents = allEvents.filterIsInstance<FlowCollectionStarted>()
+            assertEquals(1, startedEvents.size)
+            assertEquals("flow-lifecycle", startedEvents.first().flowId)
+
+            // FlowValueEmitted - one per value
+            val emittedEvents = allEvents.filterIsInstance<FlowValueEmitted>()
+            assertEquals(3, emittedEvents.size)
+            assertEquals(0, emittedEvents[0].sequenceNumber)
+            assertEquals("1", emittedEvents[0].valuePreview)
+            assertEquals(1, emittedEvents[1].sequenceNumber)
+            assertEquals("2", emittedEvents[1].valuePreview)
+            assertEquals(2, emittedEvents[2].sequenceNumber)
+            assertEquals("3", emittedEvents[2].valuePreview)
+
+            // FlowCollectionCompleted
+            val completedEvents = allEvents.filterIsInstance<FlowCollectionCompleted>()
+            assertEquals(1, completedEvents.size)
+            assertEquals(3, completedEvents.first().totalEmissions)
+        }
+
+    // ========================================================================
+    // OPERATOR TESTS
+    // ========================================================================
+
+    @Test
+    fun `flow map operator emits FlowOperatorApplied and FlowValueTransformed`() =
+        runTest {
+            val flow = flowOf(1, 2, 3).instrumented(session, "flow-map-src", "Cold", "mapFlow")
+            val mapped = flow.vizMap { it * 10 }
+
+            val collected = mutableListOf<Int>()
+            mapped.collect { collected.add(it) }
+
+            assertEquals(listOf(10, 20, 30), collected)
+
+            val allEvents = session.store.all()
+
+            // FlowOperatorApplied for the map
+            val operatorEvents = allEvents.filterIsInstance<FlowOperatorApplied>()
+            assertEquals(1, operatorEvents.size)
+            assertEquals("map", operatorEvents.first().operatorName)
+            assertEquals("flow-map-src", operatorEvents.first().sourceFlowId)
+
+            // FlowValueTransformed - one per value
+            val transformedEvents = allEvents.filterIsInstance<FlowValueTransformed>()
+            assertEquals(3, transformedEvents.size)
+            assertEquals("1", transformedEvents[0].inputValuePreview)
+            assertEquals("10", transformedEvents[0].outputValuePreview)
+            assertEquals("2", transformedEvents[1].inputValuePreview)
+            assertEquals("20", transformedEvents[1].outputValuePreview)
+            assertEquals("3", transformedEvents[2].inputValuePreview)
+            assertEquals("30", transformedEvents[2].outputValuePreview)
+        }
+
+    @Test
+    fun `flow filter operator emits FlowValueFiltered with pass and drop`() =
+        runTest {
+            val flow = flowOf(1, 2, 3, 4, 5).instrumented(session, "flow-filter-src", "Cold", "filterFlow")
+            val filtered = flow.vizFilter { it % 2 == 0 }
+
+            val collected = mutableListOf<Int>()
+            filtered.collect { collected.add(it) }
+
+            // Only even numbers pass
+            assertEquals(listOf(2, 4), collected)
+
+            val allEvents = session.store.all()
+
+            // FlowOperatorApplied for the filter
+            val operatorEvents = allEvents.filterIsInstance<FlowOperatorApplied>()
+            assertEquals(1, operatorEvents.size)
+            assertEquals("filter", operatorEvents.first().operatorName)
+
+            // FlowValueFiltered - one per input value (5 total)
+            val filteredEvents = allEvents.filterIsInstance<FlowValueFiltered>()
+            assertEquals(5, filteredEvents.size)
+
+            // Check pass/drop status
+            val passedValues = filteredEvents.filter { it.passed }.map { it.valuePreview }
+            val droppedValues = filteredEvents.filter { !it.passed }.map { it.valuePreview }
+            assertEquals(listOf("2", "4"), passedValues)
+            assertEquals(listOf("1", "3", "5"), droppedValues)
+        }
+
+    // ========================================================================
+    // CANCELLATION TESTS
+    // ========================================================================
+
+    @Test
+    fun `flow collection cancellation emits FlowCollectionCancelled`() =
+        runTest {
+            val scope = VizScope(session, coroutineContext)
+
+            // Create a flow that emits many values with delays
+            val flow =
+                scope.vizFlow<Int>(label = "cancelFlow") {
+                    emit(1)
+                    emit(2)
+                    emit(3)
+                    emit(4)
+                    emit(5)
+                }
+
+            val collected = mutableListOf<Int>()
+            // Collect in a child coroutine and cancel after receiving 2 values
+            val job =
+                launch {
+                    flow.collect {
+                        collected.add(it)
+                        if (collected.size == 2) {
+                            throw kotlinx.coroutines.CancellationException("collected enough")
+                        }
+                    }
+                }
+
+            job.join()
+
+            assertEquals(listOf(1, 2), collected)
+
+            val allEvents = session.store.all()
+
+            val cancelledEvents = allEvents.filterIsInstance<FlowCollectionCancelled>()
+            assertTrue(cancelledEvents.isNotEmpty(), "Expected at least one FlowCollectionCancelled event")
+            assertEquals(2, cancelledEvents.first().emittedCount)
+        }
+
+    // ========================================================================
+    // MULTIPLE COLLECTORS TESTS
+    // ========================================================================
+
+    @Test
+    fun `multiple collectors each get their own events`() =
+        runTest {
+            val flow = flowOf(1, 2, 3).instrumented(session, "flow-multi", "Cold", "multiFlow")
+
+            // First collection
+            val collected1 = mutableListOf<Int>()
+            flow.collect { collected1.add(it) }
+
+            // Second collection
+            val collected2 = mutableListOf<Int>()
+            flow.collect { collected2.add(it) }
+
+            assertEquals(listOf(1, 2, 3), collected1)
+            assertEquals(listOf(1, 2, 3), collected2)
+
+            val allEvents = session.store.all()
+
+            // Two FlowCollectionStarted events (one per collect call)
+            val startedEvents = allEvents.filterIsInstance<FlowCollectionStarted>()
+            assertEquals(2, startedEvents.size)
+
+            // Two FlowCollectionCompleted events
+            val completedEvents = allEvents.filterIsInstance<FlowCollectionCompleted>()
+            assertEquals(2, completedEvents.size)
+
+            // 6 FlowValueEmitted events total (3 per collection)
+            val emittedEvents = allEvents.filterIsInstance<FlowValueEmitted>()
+            assertEquals(6, emittedEvents.size)
+
+            // Each collection has its own collectorId
+            val collectorIds = startedEvents.map { it.collectorId }.toSet()
+            assertEquals(2, collectorIds.size, "Each collection should have a unique collectorId")
+        }
+
+    // ========================================================================
+    // EMPTY FLOW TESTS
+    // ========================================================================
+
+    @Test
+    fun `empty flow emits collection with zero emissions`() =
+        runTest {
+            val flow =
+                kotlinx.coroutines.flow.emptyFlow<Int>()
+                    .instrumented(session, "flow-empty", "Cold", "emptyFlow")
+
+            flow.collect { }
+
+            val allEvents = session.store.all()
+
+            // FlowCollectionStarted
+            val startedEvents = allEvents.filterIsInstance<FlowCollectionStarted>()
+            assertEquals(1, startedEvents.size)
+
+            // No FlowValueEmitted
+            val emittedEvents = allEvents.filterIsInstance<FlowValueEmitted>()
+            assertEquals(0, emittedEvents.size)
+
+            // FlowCollectionCompleted with 0 emissions
+            val completedEvents = allEvents.filterIsInstance<FlowCollectionCompleted>()
+            assertEquals(1, completedEvents.size)
+            assertEquals(0, completedEvents.first().totalEmissions)
+        }
+
+    // ========================================================================
+    // OPERATOR CHAIN TESTS
+    // ========================================================================
+
+    @Test
+    fun `flow operator chain tracks operator index`() =
+        runTest {
+            val flow = flowOf(1, 2, 3, 4, 5).instrumented(session, "flow-chain-src", "Cold", "chainFlow")
+
+            // Chain: filter -> map (two operators)
+            val chained =
+                flow
+                    .vizFilter { it > 2 }
+                    .vizMap { it * 100 }
+
+            val collected = mutableListOf<Int>()
+            chained.collect { collected.add(it) }
+
+            assertEquals(listOf(300, 400, 500), collected)
+
+            val allEvents = session.store.all()
+
+            // Two FlowOperatorApplied events
+            val operatorEvents = allEvents.filterIsInstance<FlowOperatorApplied>()
+            assertEquals(2, operatorEvents.size)
+
+            // First operator (filter) has operatorIndex 1
+            val filterOp = operatorEvents.find { it.operatorName == "filter" }
+            assertNotNull(filterOp)
+            assertEquals(1, filterOp.operatorIndex)
+            assertEquals("flow-chain-src", filterOp.sourceFlowId)
+
+            // Second operator (map) has operatorIndex 2
+            val mapOp = operatorEvents.find { it.operatorName == "map" }
+            assertNotNull(mapOp)
+            assertEquals(2, mapOp.operatorIndex)
+            // map's source is the filter's output flow
+            assertEquals(filterOp.flowId, mapOp.sourceFlowId)
+        }
+}

--- a/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedSharedStateFlowTest.kt
+++ b/backend/src/test/kotlin/com/jh/proj/coroutineviz/wrappers/InstrumentedSharedStateFlowTest.kt
@@ -1,0 +1,155 @@
+package com.jh.proj.coroutineviz.wrappers
+
+import com.jh.proj.coroutineviz.events.flow.FlowCreated
+import com.jh.proj.coroutineviz.events.flow.SharedFlowEmission
+import com.jh.proj.coroutineviz.events.flow.SharedFlowSubscription
+import com.jh.proj.coroutineviz.events.flow.StateFlowValueChanged
+import com.jh.proj.coroutineviz.session.VizSession
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InstrumentedSharedStateFlowTest {
+    private lateinit var session: VizSession
+
+    @BeforeEach
+    fun setup() {
+        session = VizSession("test-hot-flow-${System.currentTimeMillis()}")
+    }
+
+    // ========================================================================
+    // SHARED FLOW CREATION TESTS
+    // ========================================================================
+
+    @Test
+    fun `shared flow creation emits FlowCreated with SharedFlow type`() {
+        val sharedFlow = session.vizSharedFlow<Int>(replay = 1, label = "testShared")
+
+        val createdEvents = session.store.all().filterIsInstance<FlowCreated>()
+        assertEquals(1, createdEvents.size)
+        assertEquals("SharedFlow", createdEvents.first().flowType)
+        assertEquals("testShared", createdEvents.first().label)
+    }
+
+    // ========================================================================
+    // SHARED FLOW EMISSION TESTS
+    // ========================================================================
+
+    @Test
+    fun `shared flow emit emits SharedFlowEmission event`() =
+        runTest {
+            val sharedFlow = session.vizSharedFlow<Int>(replay = 1, label = "emitShared")
+
+            sharedFlow.emit(42)
+
+            val allEvents = session.store.all()
+            val emissionEvents = allEvents.filterIsInstance<SharedFlowEmission>()
+            assertEquals(1, emissionEvents.size)
+            assertEquals("42", emissionEvents.first().valuePreview)
+            assertEquals("Integer", emissionEvents.first().valueType)
+            assertEquals("emitShared", emissionEvents.first().label)
+        }
+
+    // ========================================================================
+    // SHARED FLOW SUBSCRIPTION TESTS
+    // ========================================================================
+
+    @Test
+    fun `shared flow subscription tracking`() =
+        runTest {
+            val sharedFlow = session.vizSharedFlow<Int>(replay = 1, label = "subShared")
+
+            // Emit a value to replay cache so collector gets it quickly
+            sharedFlow.emit(100)
+
+            // Start collecting in a child coroutine
+            val collectorJob =
+                launch {
+                    sharedFlow.collect {
+                        // Collect one value then cancel
+                    }
+                }
+
+            // Give the collector time to subscribe
+            delay(50)
+
+            // Cancel the collector
+            collectorJob.cancelAndJoin()
+
+            val allEvents = session.store.all()
+
+            // SharedFlowSubscription with "subscribed" action
+            val subscriptionEvents = allEvents.filterIsInstance<SharedFlowSubscription>()
+            val subscribedEvents = subscriptionEvents.filter { it.action == "subscribed" }
+            assertTrue(subscribedEvents.isNotEmpty(), "Expected at least one 'subscribed' event")
+            assertEquals(1, subscribedEvents.first().subscriberCount)
+
+            // SharedFlowSubscription with "unsubscribed" action after cancellation
+            val unsubscribedEvents = subscriptionEvents.filter { it.action == "unsubscribed" }
+            assertTrue(unsubscribedEvents.isNotEmpty(), "Expected at least one 'unsubscribed' event")
+        }
+
+    // ========================================================================
+    // STATE FLOW CREATION TESTS
+    // ========================================================================
+
+    @Test
+    fun `state flow creation emits FlowCreated with StateFlow type`() {
+        val stateFlow = session.vizStateFlow(initialValue = 0, label = "testState")
+
+        val createdEvents = session.store.all().filterIsInstance<FlowCreated>()
+        assertEquals(1, createdEvents.size)
+        assertEquals("StateFlow", createdEvents.first().flowType)
+        assertEquals("testState", createdEvents.first().label)
+    }
+
+    // ========================================================================
+    // STATE FLOW VALUE CHANGE TESTS
+    // ========================================================================
+
+    @Test
+    fun `state flow value change emits StateFlowValueChanged`() {
+        val stateFlow = session.vizStateFlow(initialValue = 0, label = "changeState")
+
+        stateFlow.value = 42
+
+        val allEvents = session.store.all()
+        val changedEvents = allEvents.filterIsInstance<StateFlowValueChanged>()
+        assertEquals(1, changedEvents.size)
+        assertEquals("0", changedEvents.first().oldValuePreview)
+        assertEquals("42", changedEvents.first().newValuePreview)
+        assertEquals("changeState", changedEvents.first().label)
+    }
+
+    @Test
+    fun `state flow compareAndSet emits event on success`() {
+        val stateFlow = session.vizStateFlow(initialValue = 10, label = "casState")
+
+        val result = stateFlow.compareAndSet(10, 20)
+        assertTrue(result, "compareAndSet should succeed when expected value matches")
+        assertEquals(20, stateFlow.value)
+
+        val allEvents = session.store.all()
+        val changedEvents = allEvents.filterIsInstance<StateFlowValueChanged>()
+        assertEquals(1, changedEvents.size)
+        assertEquals("10", changedEvents.first().oldValuePreview)
+        assertEquals("20", changedEvents.first().newValuePreview)
+    }
+
+    @Test
+    fun `state flow does not emit when value unchanged`() {
+        val stateFlow = session.vizStateFlow(initialValue = 5, label = "noChangeState")
+
+        // Set the same value
+        stateFlow.value = 5
+
+        val allEvents = session.store.all()
+        val changedEvents = allEvents.filterIsInstance<StateFlowValueChanged>()
+        assertEquals(0, changedEvents.size, "No StateFlowValueChanged should be emitted when value is unchanged")
+    }
+}


### PR DESCRIPTION
## Summary

- New **flow scenario** routes: map, filter, buffer, flatMapMerge, error handling
- New **pattern scenario** routes: actor, select, supervision tree
- **Health endpoint** (`/health`) with memory info, session count, uptime
- **Metrics wiring** for Micrometer (active sessions, SSE clients gauges)
- **Production logback config** (logback-prod.xml)
- **7 new test files** covering wrappers, routes, validators, and SSE streaming

## New endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /health` | Health check with memory info, session count, UP/DEGRADED status |
| `POST /api/scenarios/flow/*` | Flow operator scenarios (map, filter, buffer, etc.) |
| `POST /api/scenarios/pattern/*` | Concurrency pattern scenarios (actor, select, supervision) |

## Test coverage added

- `HealthRoutesTest` -- health endpoint status, session count, memory info
- `SseStreamTest` -- SSE event streaming
- `MetricsWiringTest` -- custom metrics registration
- `InstrumentedDeferredTest` -- deferred await event emission
- `InstrumentedFlowTest` -- flow collection/operator event emission
- `InstrumentedSharedStateFlowTest` -- shared/state flow event emission
- `SyncValidatorsTest` -- mutex/semaphore validation rules

## Test plan

- [x] `./gradlew test` passes locally (159 tests, 0 failures)
- [ ] CI passes

Closes #73