### PR TITLE
fix: handle scheme in CORS allowHost configuration

### DIFF
--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/HTTP.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/HTTP.kt
@@ -24,15 +24,17 @@ fun Application.configureHTTP() {
 
     // CORS Configuration — origins and methods come from application.yaml / env vars
     install(CORS) {
-        val origins =
+        val originsRaw =
             config.propertyOrNull("cors.allowedOrigins")?.getString()
                 ?: "http://localhost:3000,http://127.0.0.1:3000"
+        val origins = originsRaw.trim('"')
         origins.split(",").map { it.trim() }.filter { it.isNotEmpty() }.forEach { origin ->
-            val host = origin.removePrefix("https://").removePrefix("http://")
-            if (origin.startsWith("https://")) {
+            val cleaned = origin.trim('"')
+            val host = cleaned.removePrefix("https://").removePrefix("http://")
+            if (cleaned.startsWith("https://")) {
                 allowHost(host, schemes = listOf("https"))
             } else {
-                allowHost(host)
+                allowHost(host, schemes = listOf("http"))
             }
         }
         logger.info("CORS origins: $origins")


### PR DESCRIPTION
## Summary

Fix runtime crash when starting the backend — Ktor's `allowHost` requires host without scheme prefix and explicit `schemes` parameter.

- Strip quotes from YAML config default values
- Always pass `schemes = listOf("http")` or `listOf("https")` explicitly

Without this fix, the backend throws `IllegalArgumentException: scheme should be specified as a separate parameter` on startup.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>