### PR TITLE
fix: remove auth wrapper breaking route registration

### DIFF
--- a/backend/src/main/kotlin/com/jh/proj/coroutineviz/Routing.kt
+++ b/backend/src/main/kotlin/com/jh/proj/coroutineviz/Routing.kt
@@ -22,17 +22,15 @@ fun Application.configureRouting() {
         registerRootRoutes()
         registerHealthRoutes()
 
-        // Protected routes — require API key when configured
-        authenticatedApi {
-            registerVizScenarioRoutes()
-            registerSyncScenarioRoutes()
-            registerTestRoutes()
-            registerSessionRoutes()
-            registerValidationRoutes()
-            registerScenarioRunnerRoutes()
-            registerFlowScenarioRoutes()
-            registerPatternRoutes()
-            registerComparisonRoutes()
-        }
+        // API routes
+        registerVizScenarioRoutes()
+        registerSyncScenarioRoutes()
+        registerTestRoutes()
+        registerSessionRoutes()
+        registerValidationRoutes()
+        registerScenarioRunnerRoutes()
+        registerFlowScenarioRoutes()
+        registerPatternRoutes()
+        registerComparisonRoutes()
     }
 }


### PR DESCRIPTION
## Summary

The `authenticatedApi()` wrapper from PR #119 used Ktor's deprecated Authentication provider API, which silently prevented all `/api/*` routes from registering — every endpoint returned 404.

This removes the auth wrapping until ktor-server-auth is upgraded to the current API. All routes are public again (auth was disabled by default anyway since no API_KEY was set).

## Impact
- Before: 0 scenarios, all /api/* routes return 404
- After: 12 + 4 + 5 scenarios, all endpoints working